### PR TITLE
fix: correct Docusaurus baseUrl to match GitHub Pages URL

### DIFF
--- a/docs/website/docusaurus.config.ts
+++ b/docs/website/docusaurus.config.ts
@@ -7,7 +7,7 @@ const config: Config = {
   favicon: "img/favicon.ico",
 
   url: "https://not-elm.github.io",
-  baseUrl: "/desktop-homunculus/",
+  baseUrl: "/desktop_homunculus/",
 
   organizationName: "not-elm",
   projectName: "desktop-homunculus",


### PR DESCRIPTION
## Summary

- The Docusaurus `baseUrl` was set to `/desktop-homunculus/` (hyphen), but the GitHub Pages deployment URL uses `/desktop_homunculus/` (underscore).
- This mismatch caused the site to fail loading assets and navigation correctly.
- One-line fix in `docs/website/docusaurus.config.ts`: changed `baseUrl` from `/desktop-homunculus/` to `/desktop_homunculus/`.

## Test plan

- [ ] Confirm the deploy workflow re-runs after merge
- [ ] Verify the GitHub Pages site loads correctly at the underscore URL

🤖 Generated with [Claude Code](https://claude.com/claude-code)