### PR TITLE
perf(ci): optimize ci-rust with sccache and merged jobs

### DIFF
--- a/.github/workflows/ci-rust.yml
+++ b/.github/workflows/ci-rust.yml
@@ -14,7 +14,18 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  test:
+  fmt:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          components: rustfmt
+      - run: cargo fmt --all --check
+        working-directory: engine
+
+  check:
     runs-on: macos-14
     timeout-minutes: 45
     defaults:
@@ -22,27 +33,27 @@ jobs:
         working-directory: engine
     steps:
       - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@stable
-      - uses: Swatinem/rust-cache@v2
-        with:
-          workspaces: "engine -> target"
-          shared-key: macos-stable-engine
-      - run: cargo test --workspace --locked
 
-  lint:
-    runs-on: macos-14
-    timeout-minutes: 30
-    defaults:
-      run:
-        working-directory: engine
-    steps:
-      - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
         with:
-          components: clippy, rustfmt
+          components: clippy
+
       - uses: Swatinem/rust-cache@v2
         with:
           workspaces: "engine -> target"
           shared-key: macos-stable-engine
-      - run: cargo fmt --all --check
+          save-if: ${{ github.ref == 'refs/heads/main' }}
+
+      - name: Setup sccache
+        uses: mozilla-actions/sccache-action@v0.0.9
+        with:
+          version: "v0.10.0"
+
+      - name: Configure sccache
+        run: |
+          echo "SCCACHE_GHA_ENABLED=true" >> $GITHUB_ENV
+          echo "RUSTC_WRAPPER=sccache" >> $GITHUB_ENV
+          echo "CARGO_INCREMENTAL=0" >> $GITHUB_ENV
+
       - run: cargo clippy --workspace -- -Dwarnings
+      - run: cargo test --workspace --locked


### PR DESCRIPTION
## Summary
- **Move `cargo fmt` to `ubuntu-latest`**: Format checking doesn't need macOS — runs faster and costs less on Linux
- **Merge `test` + `lint` into single `check` job**: Eliminates duplicate checkout/toolchain/cache setup; clippy + test run sequentially in one job
- **Add sccache via `mozilla-actions/sccache-action`**: Caches compiled artifacts across CI runs for faster incremental builds
- **Set `CARGO_INCREMENTAL=0`**: Recommended when using sccache to avoid redundant incremental compilation artifacts
- **Add `save-if` guard on `rust-cache`**: Only writes cache on `main` branch pushes, preventing PR branch cache thrashing

## Test plan
- [x] Verify `fmt` job passes on `ubuntu-latest`
- [ ] Verify `check` job runs both `cargo clippy` and `cargo test` successfully
- [ ] Confirm sccache is initialized and caching artifacts
- [ ] Verify cache is only saved on `main` branch pushes (not on PR branches)

🤖 Generated with [Claude Code](https://claude.com/claude-code)