### PR TITLE
fix(deps): override minimatch 10.2.1 to 10.2.4 for ReDoS vulnerability

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,8 @@
   },
   "pnpm": {
     "overrides": {
-      "serialize-javascript@<7.0.3": "7.0.3"
+      "serialize-javascript@<7.0.3": "7.0.3",
+      "minimatch@>=10.0.0 <10.2.3": "10.2.4"
     }
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,6 +6,7 @@ settings:
 
 overrides:
   serialize-javascript@<7.0.3: 7.0.3
+  minimatch@>=10.0.0 <10.2.3: 10.2.4
 
 importers:
 
@@ -7097,10 +7098,6 @@ packages:
   minimalistic-assert@1.0.1:
     resolution: {integrity: sha512-UtJcAD4yEaGtjPezWuO9wC4nwUnVH/8/Im3yEHQP4b67cXlD/Qr9hdITCU1xDbSEXg2XKNaP8jsReV7vQd00/A==}
 
-  minimatch@10.2.1:
-    resolution: {integrity: sha512-MClCe8IL5nRRmawL6ib/eT4oLyeKMGCghibcDWK+J0hh0Q8kqSdia6BvbRMVk6mPa6WqUa5uR2oxt6C5jd533A==}
-    engines: {node: 20 || >=22}
-
   minimatch@10.2.4:
     resolution: {integrity: sha512-oRjTw/97aTBN0RHbYCdtF1MQfvusSIBQM0IZEgzl6426+8jSC0nF1a/GmnVLpfB9yyr6g6FTqWqiZVbxrtaCIg==}
     engines: {node: 18 || 20 || >=22}
@@ -12170,7 +12167,7 @@ snapshots:
       '@rushstack/ts-command-line': 5.3.3(@types/node@24.11.0)
       diff: 8.0.3
       lodash: 4.17.23
-      minimatch: 10.2.1
+      minimatch: 10.2.4
       resolve: 1.22.11
       semver: 7.5.4
       source-map: 0.6.1
@@ -17678,10 +17675,6 @@ snapshots:
       webpack: 5.105.4
 
   minimalistic-assert@1.0.1: {}
-
-  minimatch@10.2.1:
-    dependencies:
-      brace-expansion: 5.0.4
 
   minimatch@10.2.4:
     dependencies:


### PR DESCRIPTION
## Summary

- Resolves [Dependabot alert #132](https://github.com/not-elm/desktop_homunculus/security/dependabot/132) (high severity ReDoS in `minimatch`)
- `@microsoft/api-extractor@7.57.6` (transitive dep of `vite-plugin-dts`) pins `minimatch@10.2.1`, which is vulnerable to combinatorial backtracking in `matchOne()`
- Added `pnpm.overrides` entry to force `minimatch@>=10.0.0 <10.2.3` → `10.2.4`

## Test plan

- [x] `minimatch@10.2.1` removed from `pnpm-lock.yaml`
- [x] `pnpm install` succeeds
- [x] `pnpm build` succeeds (all packages)
- [x] `pnpm test` succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)