### PR TITLE
update: bump bevy_cef to v0.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,0 @@
-## Unreleased
-
-### Others
-
-- bump up `bevy_cef` version to v0.2.1


### PR DESCRIPTION
## Summary
- Bump `bevy_cef` dependency from v0.2.0 to v0.2.1
- Updates `engine/Cargo.lock` to reflect the new version

🤖 Generated with [Claude Code](https://claude.com/claude-code)