### PR TITLE
fix: remove unused dependencies

### DIFF
--- a/engine/Cargo.lock
+++ b/engine/Cargo.lock
@@ -3061,7 +3061,6 @@ dependencies = [
  "homunculus_audio",
  "homunculus_core",
  "homunculus_drag",
- "homunculus_effects",
  "homunculus_hit_test",
  "homunculus_http_server",
  "homunculus_mod",
@@ -3076,7 +3075,6 @@ dependencies = [
  "homunculus_windows",
  "reqwest",
  "serde",
- "serde_json",
  "tokio",
  "tracing-appender",
 ]
@@ -4328,7 +4326,6 @@ dependencies = [
  "serde",
  "serde_json",
  "thiserror 2.0.18",
- "tracing",
  "utoipa",
 ]
 
@@ -4443,7 +4440,6 @@ dependencies = [
  "homunculus_core",
  "homunculus_utils",
  "libc",
- "serde_json",
 ]
 
 [[package]]
@@ -4505,7 +4501,6 @@ name = "homunculus_sitting"
 version = "0.1.0-alpha.4.2"
 dependencies = [
  "bevy",
- "bevy_vrm1",
  "homunculus_core",
  "homunculus_screen",
 ]
@@ -4529,7 +4524,6 @@ dependencies = [
  "bevy_tray_icon",
  "homunculus_core",
  "homunculus_utils",
- "tokio",
  "tracing",
 ]
 
@@ -4555,9 +4549,7 @@ version = "0.1.0-alpha.4.2"
 dependencies = [
  "bevy",
  "homunculus_core",
- "raw-window-handle",
  "serde",
- "windows 0.60.0",
 ]
 
 [[package]]

--- a/engine/Cargo.toml
+++ b/engine/Cargo.toml
@@ -29,10 +29,8 @@ bevy_vrm1 = { workspace = true }
 base64 = { workspace = true }
 reqwest = { workspace = true }
 serde = { workspace = true }
-serde_json = { workspace = true }
 homunculus_drag = { workspace = true }
 homunculus_core = { workspace = true }
-homunculus_effects = { workspace = true }
 homunculus_windows = { workspace = true }
 homunculus_hit_test = { workspace = true }
 homunculus_screen = { workspace = true }

--- a/engine/crates/homunculus_api/Cargo.toml
+++ b/engine/crates/homunculus_api/Cargo.toml
@@ -24,17 +24,16 @@ homunculus_speech = { workspace = true }
 homunculus_power_saver = { workspace = true }
 thiserror = { workspace = true }
 axum = { workspace = true, optional = true }
-tracing = { workspace = true }
 bevy_cef = { workspace = true }
 bevy_tweening = "0.15"
-homunculus_utils = { workspace = true }
+homunculus_utils = { workspace = true, optional = true }
 utoipa = { workspace = true, optional = true }
 
 [features]
 default = []
 develop = []
 axum = ["dep:axum"]
-openapi = ["dep:utoipa", "homunculus_utils/openapi", "homunculus_core/openapi", "homunculus_audio/openapi"]
+openapi = ["dep:utoipa", "dep:homunculus_utils", "homunculus_utils/openapi", "homunculus_core/openapi", "homunculus_audio/openapi"]
 
 [lints]
 workspace = true

--- a/engine/crates/homunculus_mod/Cargo.toml
+++ b/engine/crates/homunculus_mod/Cargo.toml
@@ -9,7 +9,6 @@ publish.workspace = true
 
 [dependencies]
 bevy = { workspace = true }
-serde_json = { workspace = true }
 homunculus_core = { workspace = true }
 homunculus_utils = { workspace = true }
 futures-lite = "2"

--- a/engine/crates/homunculus_sitting/Cargo.toml
+++ b/engine/crates/homunculus_sitting/Cargo.toml
@@ -9,7 +9,6 @@ publish.workspace = true
 
 [dependencies]
 bevy = { workspace = true }
-bevy_vrm1 = { workspace = true }
 homunculus_core = { workspace = true }
 homunculus_screen = { workspace = true }
 

--- a/engine/crates/homunculus_tray/Cargo.toml
+++ b/engine/crates/homunculus_tray/Cargo.toml
@@ -12,7 +12,6 @@ bevy = { workspace = true }
 bevy_tray_icon = { workspace = true }
 homunculus_core = { workspace = true }
 homunculus_utils = { workspace = true }
-tokio = { workspace = true, features = ["process"] }
 tracing = { workspace = true }
 
 [lints]

--- a/engine/crates/homunculus_tray/src/lib.rs
+++ b/engine/crates/homunculus_tray/src/lib.rs
@@ -101,12 +101,6 @@ fn handle_tray_clicks(
                     execute_command(mods_dir, command).await;
                 })
                 .detach();
-            // tokio::runtime::Builder::new_current_thread()
-            //     .build()
-            //     .unwrap()
-            //     .spawn(async move {
-            //         execute_command(mods_dir, command).await;
-            //     });
         } else {
             tracing::warn!("Unknown tray menu id: {id}");
         }

--- a/engine/crates/homunculus_windows/Cargo.toml
+++ b/engine/crates/homunculus_windows/Cargo.toml
@@ -12,12 +12,5 @@ bevy = { workspace = true }
 serde = { workspace = true }
 homunculus_core = { workspace = true }
 
-[target.'cfg(target_os="windows")'.dependencies]
-windows = { workspace = true, features = [
-    "Win32_Foundation",
-    "Win32_UI_WindowsAndMessaging",
-] }
-raw-window-handle = { workspace = true }
-
 [lints]
 workspace = true


### PR DESCRIPTION
## Summary

- Remove unused crate dependencies across 6 workspace members, detected by `cargo machete --with-metadata` and verified manually
- Affected crates: `desktop_homunculus`, `homunculus_api`, `homunculus_mod`, `homunculus_sitting`, `homunculus_tray`, `homunculus_windows`
- Make `homunculus_utils` optional in `homunculus_api` (only needed for `openapi` feature flag propagation)
- Delete commented-out tokio code in `homunculus_tray`

## Test plan

- [x] `cargo check --workspace` passes
- [x] `cargo test --workspace` passes
- [ ] CI passes (fmt, clippy, test)

🤖 Generated with [Claude Code](https://claude.com/claude-code)