### PR TITLE
add: add `hmcs mod update` command

### DIFF
--- a/engine/crates/homunculus_cli/src/mods.rs
+++ b/engine/crates/homunculus_cli/src/mods.rs
@@ -31,6 +31,14 @@ pub enum ModsSubcommand {
         /// New mods directory path (omit to display current)
         mods_dir_path: Option<String>,
     },
+    /// Update installation MODs version.
+    Update {
+        ///  If no specific target, all MODs will be update.
+        mod_patterns: Vec<String>,
+        /// If this value is true, it updates mods to their latest versions
+        #[arg(long, short = 'L')]
+        latest: bool,
+    },
 }
 
 impl ModsArgs {
@@ -42,6 +50,10 @@ impl ModsArgs {
                 homunculus_utils::mods::uninstall(&mod_names)
             }
             ModsSubcommand::Path { mods_dir_path } => path::cmd_path(mods_dir_path.as_deref()),
+            ModsSubcommand::Update {
+                mod_patterns,
+                latest,
+            } => homunculus_utils::mods::update(&mod_patterns, latest),
         }
     }
 }

--- a/engine/crates/homunculus_utils/src/error.rs
+++ b/engine/crates/homunculus_utils/src/error.rs
@@ -22,6 +22,8 @@ pub enum ModsError {
     Uninstall(#[source] std::io::Error),
     #[error("failed to retrive installation mod path: {0}")]
     List(String),
+    #[error("failed to update mod: {0}")]
+    Update(String),
 }
 
 /// Errors that can occur when loading or saving config.

--- a/engine/crates/homunculus_utils/src/mods.rs
+++ b/engine/crates/homunculus_utils/src/mods.rs
@@ -1,5 +1,5 @@
 pub mod list;
-use std::process::Command;
+use std::process::{Command, Stdio};
 
 use crate::{
     config::HomunculusConfig,
@@ -63,7 +63,8 @@ const TSX_PACKAGE: &str = "tsx@4.21.0";
 /// quickly without network access.
 /// The installed tsx is used by mod services via `node --import tsx`.
 pub fn ensure_tsx() -> UtilResult {
-    let status = create_pnpm_command_base()?
+    let status = create_pnpm_command()?
+        .no_window()
         .arg("add")
         .arg("--save-dev")
         .arg("--save-exact")
@@ -86,7 +87,7 @@ pub fn install<S: AsRef<str>>(pkg: &[S]) -> UtilResult {
         validate_package_name(p.as_ref())?;
     }
 
-    let status = create_pnpm_command_base()?
+    let status = create_pnpm_command()?
         .arg("add")
         .args(pkg.iter().map(|s| s.as_ref()))
         .status()
@@ -106,7 +107,7 @@ pub fn uninstall<S: AsRef<str>>(mod_names: &[S]) -> UtilResult {
         validate_package_name(name.as_ref())?;
     }
 
-    let status = create_pnpm_command_base()?
+    let status = create_pnpm_command()?
         .arg("remove")
         .args(mod_names.iter().map(|s| s.as_ref()))
         .status()
@@ -120,6 +121,23 @@ pub fn uninstall<S: AsRef<str>>(mod_names: &[S]) -> UtilResult {
     Ok(())
 }
 
+pub fn update<S: AsRef<str>>(mod_patterns: &[S], install_latest: bool) -> UtilResult {
+    let mut cmd = create_pnpm_command()?;
+    cmd.arg("update");
+    if !mod_patterns.is_empty() {
+        cmd.args(mod_patterns.iter().map(|s| s.as_ref()));
+    }
+    if install_latest {
+        cmd.arg("--latest");
+    }
+    cmd.stdout(Stdio::inherit())
+        .stderr(Stdio::inherit())
+        .status()
+        .map_err(|e| UtilError::Mods(ModsError::Update(e.to_string())))?;
+
+    Ok(())
+}
+
 /// Returns the correct program name for pnpm on the current platform.
 ///
 /// On Windows, pnpm is installed as `pnpm.cmd` (a batch script),
@@ -128,12 +146,10 @@ pub fn pnpm_program() -> &'static str {
     if cfg!(windows) { "pnpm.cmd" } else { "pnpm" }
 }
 
-fn create_pnpm_command_base() -> UtilResult<Command> {
+fn create_pnpm_command() -> UtilResult<Command> {
     let config = HomunculusConfig::load()?;
     let mut command = Command::new(pnpm_program());
-    command
-        .no_window()
-        .args(["-C", &format!("{}", &config.mods_dir.display())]);
+    command.args(["-C", &format!("{}", &config.mods_dir.display())]);
     Ok(command)
 }
 

--- a/engine/crates/homunculus_utils/src/mods/list.rs
+++ b/engine/crates/homunculus_utils/src/mods/list.rs
@@ -1,6 +1,6 @@
 use crate::{
     error::{ModsError, UtilError, UtilResult},
-    mods::create_pnpm_command_base,
+    mods::create_pnpm_command,
     prelude::{ModInfo, ModPackageJson},
 };
 use std::{
@@ -45,7 +45,7 @@ fn list_mods<P: AsRef<Path>>(mod_paths: &[P]) -> Vec<ModInfo> {
 /// Returns a list of paths that may be MODs.
 /// It is not guaranteed that they are actually MODs, so you need to filter them appropriately.
 fn list_candidate_paths() -> UtilResult<Vec<PathBuf>> {
-    let output = create_pnpm_command_base()?
+    let output = create_pnpm_command()?
         .args(["ls", "--parseable", "-P", "--depth", "0"])
         .output()
         .map_err(|e| UtilError::Mods(ModsError::List(e.to_string())))?;


### PR DESCRIPTION
## Summary
- Add `hmcs mod update` subcommand to update installed MODs via `pnpm update`
- Supports optional mod name patterns to update specific mods, or updates all if none specified
- Supports `--latest` (`-L`) flag to update mods to their latest versions
- Refactor: rename `create_pnpm_command_base` to `create_pnpm_command` and move `.no_window()` to call sites that need it

## Test plan
- [ ] Run `hmcs mod update` to verify all mods are updated
- [ ] Run `hmcs mod update <mod-name>` to verify specific mod update
- [ ] Run `hmcs mod update --latest` to verify latest flag works
- [ ] Verify `hmcs mod install` and `hmcs mod uninstall` still work after refactor
- [ ] Run `cargo test --workspace` to check for regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)