### PR TITLE
feat(cli): add auto-update notification

### DIFF
--- a/packages/cli/bin/hmcs
+++ b/packages/cli/bin/hmcs
@@ -4,6 +4,17 @@
 
 const { execFileSync } = require("child_process");
 const path = require("path");
+const cliPkg = require("../package.json");
+const distTag = cliPkg.version.includes("alpha")
+  ? "alpha"
+  : cliPkg.version.includes("beta")
+    ? "beta"
+    : cliPkg.version.includes("rc")
+      ? "rc"
+      : "latest";
+import("update-notifier").then(({ default: updateNotifier }) => {
+  updateNotifier({ pkg: cliPkg, distTag }).notify();
+}).catch(() => {});
 
 const PLATFORM_MAP = {
   "darwin-arm64": "@hmcs/cli-darwin-arm64",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -13,5 +13,8 @@
   },
   "files": [
     "bin"
-  ]
+  ],
+  "dependencies": {
+    "update-notifier": "^6.0.0"
+  }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -235,7 +235,11 @@ importers:
         specifier: ^3.25.76
         version: 3.25.76
 
-  packages/cli: {}
+  packages/cli:
+    dependencies:
+      update-notifier:
+        specifier: ^6.0.0
+        version: 6.0.2
 
   packages/sdk:
     dependencies:


### PR DESCRIPTION
## Summary

- Add `update-notifier` to the Node.js CLI wrapper (`packages/cli/bin/hmcs`) to notify users when a newer version of `@hmcs/cli` is available on npm
- Automatically selects the correct npm dist-tag (`alpha`/`beta`/`rc`/`latest`) based on the current version string, so prerelease users also get notified
- Uses dynamic `import()` since `update-notifier` v6 is ESM-only and the wrapper is CJS

## Test plan

- [ ] Run `node packages/cli/bin/hmcs --version` and verify no import errors
- [ ] Verify update check runs in background (no CLI slowdown)
- [ ] Verify `NO_UPDATE_NOTIFIER=1` suppresses the notification
- [ ] Verify notification appears after 24h when a newer version exists on npm

🤖 Generated with [Claude Code](https://claude.com/claude-code)