### PR TITLE
fix: force download CEF Framework on setup

### DIFF
--- a/engine/scripts/setup_cef.py
+++ b/engine/scripts/setup_cef.py
@@ -42,11 +42,8 @@ def setup_cef() -> None:
 
 
 def _setup_cef_macos() -> None:
-    if CEF_SENTINEL_MACOS.exists():
-        log("CEF framework already installed. Skipping download.")
-    else:
-        log("Downloading CEF framework...")
-        run(["export-cef-dir", "--force", str(CEF_EXPORT_DIR_MACOS)])
+    log("Downloading CEF framework...")
+    run(["export-cef-dir", "--force", str(CEF_EXPORT_DIR_MACOS)])
 
     log("Copying debug render process...")
     CEF_DEBUG_RENDER_DST.parent.mkdir(parents=True, exist_ok=True)


### PR DESCRIPTION
## Summary
- Removes the sentinel file check in `setup_cef.py` so CEF framework is always downloaded during `make setup`
- Ensures the CEF framework stays up-to-date by forcing re-download instead of skipping when a previous installation exists

## Test plan
- [ ] Run `make setup` and verify CEF framework downloads successfully
- [ ] Run `make setup` again and confirm it re-downloads without errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)