### PR TITLE
fix(windows): use PreMultiplied alpha mode for NVIDIA GPU transparency

### DIFF
--- a/engine/crates/homunculus_windows/src/lib.rs
+++ b/engine/crates/homunculus_windows/src/lib.rs
@@ -246,11 +246,13 @@ fn create_window(layer: usize, size: Vec2) -> Window {
         transparent: true,
         has_shadow: false,
         composite_alpha_mode: if cfg!(target_os = "windows") {
-            CompositeAlphaMode::Auto
+            CompositeAlphaMode::PreMultiplied
         } else {
             CompositeAlphaMode::PostMultiplied
         },
         #[cfg(target_os = "macos")]
+        present_mode: PresentMode::AutoVsync,
+        #[cfg(target_os = "windows")]
         present_mode: PresentMode::AutoVsync,
         resizable: false,
         decorations: false,


### PR DESCRIPTION
## Summary
- Use `CompositeAlphaMode::PreMultiplied` instead of `Auto` on Windows to fix black (opaque) window background on NVIDIA GPU drivers
- Explicitly set `PresentMode::AutoVsync` on Windows to match macOS behavior

## Test plan
- [ ] Verify transparent window background works on Windows with NVIDIA GPU
- [ ] Verify no regression on Windows with AMD/Intel GPU
- [ ] Verify no regression on macOS

🤖 Generated with [Claude Code](https://claude.com/claude-code)