### PR TITLE
refactor: make bump-version read-only by removing VERSION argument

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -52,7 +52,7 @@ release-macos-universal:
 	$(MAKE) -C engine release-macos-universal
 
 bump-version:
-	$(PYTHON) scripts/bump_version.py $(VERSION)
+	$(PYTHON) scripts/bump_version.py
 
 check-version:
 	$(PYTHON) scripts/bump_version.py --check

--- a/scripts/bump_version.py
+++ b/scripts/bump_version.py
@@ -49,18 +49,6 @@ def load_config() -> dict[str, object]:
     return {"version": version, "targets": targets, "excludes": excludes}
 
 
-def write_version_to_config(version: str) -> None:
-    """Update the version field in version.toml."""
-    text = CONFIG_PATH.read_text(encoding="utf-8")
-    new_text = re.sub(
-        r'^(version\s*=\s*)"[^"]*"',
-        rf'\g<1>"{version}"',
-        text,
-        count=1,
-        flags=re.MULTILINE,
-    )
-    CONFIG_PATH.write_text(new_text, encoding="utf-8")
-
 
 def resolve_targets(
     targets: list[str], excludes: list[str]
@@ -176,17 +164,14 @@ def refresh_cargo_lock(version: str) -> None:
         print("WARNING: cargo update --workspace failed", file=sys.stderr)
 
 
-def bump(version: str | None = None) -> None:
+def bump() -> None:
+    """Read version from version.toml and propagate to all target files."""
     config = load_config()
     targets = config.get("targets", [])
     excludes = config.get("excludes", [])
 
-    if version is None:
-        version = str(config["version"])
-        print(f"Using version from version.toml: {version}")
-    else:
-        write_version_to_config(version)
-        print(f"Updated version.toml to {version}")
+    version = str(config["version"])
+    print(f"Using version from version.toml: {version}")
 
     validate_version(version)
     resolved = resolve_targets(targets, excludes)  # type: ignore[arg-type]
@@ -356,14 +341,18 @@ def check() -> None:
 
 def main() -> None:
     if len(sys.argv) < 2:
-        # No arguments: read from version.toml and propagate
         bump()
         return
 
     if sys.argv[1] == "--check":
         check()
     else:
-        bump(sys.argv[1])
+        print(
+            f"ERROR: Unknown argument '{sys.argv[1]}'. "
+            "Usage: bump_version.py [--check]",
+            file=sys.stderr,
+        )
+        sys.exit(1)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Problem

`make bump-version VERSION=x.y.z` allowed overwriting `version.toml` programmatically. The version source of truth should only be edited manually in `version.toml`, with `make bump-version` solely propagating it to target files.

## Solution

- **Makefile**: Removed `$(VERSION)` from the `bump-version` target so the argument is no longer forwarded.
- **scripts/bump_version.py**: Removed `write_version_to_config()` (no longer needed), simplified `bump()` to always read from `version.toml` (no parameter), and changed `main()` to error on unknown arguments with a usage message.

---

- [ ] If HTTP endpoints changed: I ran `make gen-open-api` and `pnpm build`
- [ ] This PR includes breaking changes