### PR TITLE
docs: add GitHub Issue templates (bug report, proposal, documentation)

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -26,12 +26,17 @@ Minimal steps to reproduce the issue.
 
 ## Environment
 
+- OS:
+- App version:
+- Build method:
+- GPU (Windows):
+- Mods installed:
+
 <!--
-- OS and version (e.g., macOS 15.3, Windows 11 24H2)
-- App version or commit hash
-- Build method: local build / MSI installer / DMG / GitHub Actions artifact
-- GPU and driver version (Windows — e.g., NVIDIA RTX 3080 Ti, driver 560.xx)
-- Mods installed (if any)
+  Examples:
+  - OS: macOS 15.3 / Windows 11 24H2
+  - Build method: local build / MSI installer / DMG / GitHub Actions artifact
+  - GPU: NVIDIA RTX 3080 Ti, driver 560.xx
 -->
 
 ## Logs / Crash Output

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,52 @@
+---
+name: Bug Report
+about: "Something isn't working — crashes, visual glitches, incorrect behavior"
+labels: [bug]
+---
+
+- [ ] I searched existing issues and found no duplicate
+- [ ] I can reproduce this on the latest release
+- [ ] I tested with no mods installed (or noted which mods are required below)
+
+## Actual Behavior
+
+What actually happened?
+
+## Expected Behavior
+
+What did you expect to happen?
+
+## Steps to Reproduce
+
+Minimal steps to reproduce the issue.
+
+1.
+2.
+3.
+
+## Environment
+
+<!--
+- OS and version (e.g., macOS 15.3, Windows 11 24H2)
+- App version or commit hash
+- Build method: local build / MSI installer / DMG / GitHub Actions artifact
+- GPU and driver version (Windows — e.g., NVIDIA RTX 3080 Ti, driver 560.xx)
+- Mods installed (if any)
+-->
+
+## Logs / Crash Output
+
+Paste relevant logs from `~/.homunculus/Logs/log.txt` or crash output.
+
+```
+(paste here)
+```
+
+## Screenshots
+
+<details>
+<summary>If applicable, add screenshots or screen recordings.</summary>
+
+(paste here)
+
+</details>

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -6,7 +6,6 @@ labels: [bug]
 
 - [ ] I searched existing issues and found no duplicate
 - [ ] I can reproduce this on the latest release
-- [ ] I tested with no mods installed (or noted which mods are required below)
 
 ## Actual Behavior
 

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Question
+    url: https://github.com/not-elm/desktop-homunculus/discussions
+    about: For questions and general help, please use GitHub Discussions.

--- a/.github/ISSUE_TEMPLATE/documentation.md
+++ b/.github/ISSUE_TEMPLATE/documentation.md
@@ -1,0 +1,19 @@
+---
+name: Documentation
+about: "Report missing, incorrect, or unclear documentation"
+labels: [documentation]
+---
+
+## Location
+
+Page URL or file path of the affected documentation.
+
+## Issue
+
+What's wrong?
+
+<!-- missing content / incorrect information / outdated / unclear wording -->
+
+## Suggested Fix
+
+How would you fix or improve it? (optional)

--- a/.github/ISSUE_TEMPLATE/proposal.md
+++ b/.github/ISSUE_TEMPLATE/proposal.md
@@ -10,6 +10,8 @@ labels: [enhancement]
 
 Is this a new feature or an improvement to an existing one?
 
+<!-- new feature / improvement to existing feature -->
+
 ## Problem / Current Behavior
 
 What problem does this solve, or what existing behavior would you like to change?

--- a/.github/ISSUE_TEMPLATE/proposal.md
+++ b/.github/ISSUE_TEMPLATE/proposal.md
@@ -1,0 +1,27 @@
+---
+name: Proposal
+about: "Suggest a new feature or improve an existing one"
+labels: [enhancement]
+---
+
+- [ ] I searched existing issues and discussions and found no duplicate
+
+## Type
+
+Is this a new feature or an improvement to an existing one?
+
+## Problem / Current Behavior
+
+What problem does this solve, or what existing behavior would you like to change?
+
+## Proposed Solution
+
+How would you like it to work?
+
+## Affected Area
+
+<!-- engine / packages / mods / docs / website / ci/build / other -->
+
+## Alternatives Considered
+
+Any alternative approaches you considered? (optional)

--- a/docs/website/docs/contributing/index.md
+++ b/docs/website/docs/contributing/index.md
@@ -14,7 +14,7 @@ See [Development Setup](./development-setup) for prerequisites and environment s
 ## How to Contribute
 
 - **Report bugs**: Open an issue on [GitHub Issues](https://github.com/not-elm/desktop-homunculus/issues)
-- **Suggest features**: Start a thread in [GitHub Discussions](https://github.com/not-elm/desktop-homunculus/discussions)
+- **Suggest features or improvements**: Open a [Proposal issue](https://github.com/not-elm/desktop-homunculus/issues/new?template=proposal.md) or start a thread in [GitHub Discussions](https://github.com/not-elm/desktop-homunculus/discussions)
 - **Submit code**: Fork the repo, create a branch, and open a Pull Request
 - **Ask questions**: Use [GitHub Discussions](https://github.com/not-elm/desktop-homunculus/discussions)
 

--- a/docs/website/i18n/ja/docusaurus-plugin-content-docs/current/contributing/index.md
+++ b/docs/website/i18n/ja/docusaurus-plugin-content-docs/current/contributing/index.md
@@ -14,7 +14,7 @@ sidebar_position: 1
 ## コントリビューションの方法
 
 - **バグ報告**: [GitHub Issues](https://github.com/not-elm/desktop-homunculus/issues) で Issue を作成
-- **機能の提案**: [GitHub Discussions](https://github.com/not-elm/desktop-homunculus/discussions) でスレッドを開始
+- **機能の提案・改善**: [Proposal Issue](https://github.com/not-elm/desktop-homunculus/issues/new?template=proposal.md) を作成、または [GitHub Discussions](https://github.com/not-elm/desktop-homunculus/discussions) でスレッドを開始
 - **コードの提出**: リポジトリをフォークしてブランチを作成し、プルリクエストを開く
 - **質問**: [GitHub Discussions](https://github.com/not-elm/desktop-homunculus/discussions) を利用
 


### PR DESCRIPTION
## Problem

No issue templates existed, leading to inconsistent bug reports and feature requests.
The Contributing guide routed feature suggestions exclusively to Discussions, contradicting the intent to accept them via Issues as well.

## Solution

Added 3 issue templates and `config.yml` to `.github/ISSUE_TEMPLATE/`, and updated Contributing guides (EN + JA).

- **Bug Report** (`bug_report.md`, label: `bug`) — Preflight checklist, Actual/Expected Behavior, Steps to Reproduce, Environment, Logs, Screenshots
- **Proposal** (`proposal.md`, label: `enhancement`) — Unified Feature Request + Improvement. Type, Problem, Solution, Affected Area, Alternatives
- **Documentation** (`documentation.md`, label: `documentation`) — Location, Issue, Suggested Fix
- **config.yml** — Disables blank issues, routes Questions to GitHub Discussions
- **Contributing guide update** — Allows feature proposals via Issues (EN + JA)

Template style follows the existing PR template pattern (HTML comment guides).
Preflight checklists inspired by Bevy, Tauri, Electron, and Vite.

---

- [ ] This PR includes breaking changes