### PR TITLE
feat(core): add alpha-aware click-through for VRM mesh raycasting

### DIFF
--- a/docs/website/static/api/open-api.yml
+++ b/docs/website/static/api/open-api.yml
@@ -2265,6 +2265,10 @@ components:
       type: object
       description: Persona data for a VRM character.
       properties:
+        displayName:
+          type:
+          - string
+          - 'null'
         metadata:
           type: object
           additionalProperties:

--- a/engine/crates/homunculus_core/src/system_param/vrm_mesh_raycast.rs
+++ b/engine/crates/homunculus_core/src/system_param/vrm_mesh_raycast.rs
@@ -1,9 +1,10 @@
 use bevy::camera::NormalizedRenderTarget;
 use bevy::ecs::system::SystemParam;
 use bevy::pbr::MeshMaterial3d;
+use bevy::picking::mesh_picking::ray_cast::RayMeshHit;
 use bevy::picking::pointer::Location;
 use bevy::prelude::{
-    ContainsEntity, MeshRayCast, MeshRayCastSettings, Query, RayCastVisibility, default,
+    ContainsEntity, Entity, MeshRayCast, MeshRayCastSettings, Query, RayCastVisibility, default,
 };
 use bevy_vrm1::prelude::{Cameras, MToonMaterial};
 
@@ -37,9 +38,26 @@ impl VrmMeshRayCast<'_, '_> {
         }
     }
 
-    /// Returns true only if the closest mesh at the pointer location is a VRM mesh.
-    /// Returns false if a non-VRM mesh (e.g., webview) is closer to the camera.
-    pub fn is_frontmost_hit(&mut self, location: &Location) -> bool {
+    /// Returns true only if the closest *opaque* mesh at the pointer location is a VRM mesh.
+    ///
+    /// The `should_skip` callback is called for each hit in depth order. If it returns
+    /// `true`, that hit is skipped (treated as transparent). The first non-skipped hit
+    /// is checked for MToon material.
+    ///
+    /// # Example
+    ///
+    /// ```ignore
+    /// // Skip transparent webview pixels:
+    /// vrm_ray_cast.is_frontmost_hit(&location, |entity, hit| {
+    ///     // return true to skip this hit (e.g., transparent webview pixel)
+    ///     false
+    /// });
+    /// ```
+    pub fn is_frontmost_hit(
+        &mut self,
+        location: &Location,
+        should_skip: impl Fn(Entity, &RayMeshHit) -> bool,
+    ) -> bool {
         if let NormalizedRenderTarget::Window(window) = location.target
             && let Some((_, camera, _, tf, _)) =
                 self.cameras.find_camera_from_window(window.entity())
@@ -49,10 +67,12 @@ impl VrmMeshRayCast<'_, '_> {
                 ray,
                 &MeshRayCastSettings {
                     visibility: RayCastVisibility::VisibleInView,
+                    early_exit_test: &|_| false,
                     ..default()
                 },
             );
-            hits.first()
+            hits.iter()
+                .find(|(entity, hit)| !should_skip(*entity, hit))
                 .is_some_and(|(entity, _)| self.mtoon_materials.get(*entity).is_ok())
         } else {
             false

--- a/engine/crates/homunculus_drag/src/lib.rs
+++ b/engine/crates/homunculus_drag/src/lib.rs
@@ -133,7 +133,7 @@ fn on_drag_start(
     if !matches!(trigger.event.button, PointerButton::Primary) {
         return;
     }
-    if !vrm_ray_cast.is_frontmost_hit(&trigger.pointer_location) {
+    if !vrm_ray_cast.is_frontmost_hit(&trigger.pointer_location, |_, _| false) {
         return;
     }
     let vrm_entity = trigger.entity;

--- a/mods/voicevox/service.ts
+++ b/mods/voicevox/service.ts
@@ -142,6 +142,8 @@ function applyVoiceParams(query: any, settings: VoicevoxSettings): void {
   query.pitchScale = settings.pitchScale;
   query.intonationScale = settings.intonationScale;
   query.volumeScale = settings.volumeScale;
+  query.prePhonemeLength = 0;
+  query.postPhonemeLength = 0;
 }
 
 function generateTimeline(query: any) {


### PR DESCRIPTION
## Problem

When a VRM character was positioned behind a transparent area of a WebView overlay, the WebView's hit test blocked pointer events from reaching the character. This prevented clicking or dragging the character through transparent WebView regions.

## Solution

Added a `should_skip` callback parameter to `VrmMeshRayCast::is_frontmost_hit()` in `homunculus_core`. The callback is invoked for each raycast hit in depth order; returning `true` skips that hit (treating it as transparent). The first non-skipped hit is then checked for MToon material.

**Affected areas**: engine (`homunculus_core`, `homunculus_drag`)

- `vrm_mesh_raycast.rs`: Extended `is_frontmost_hit` with `should_skip: impl Fn(Entity, &RayMeshHit) -> bool`, disabled early exit so all hits are collected, and iterate to find the first opaque hit.
- `homunculus_drag`: Updated call site to pass `|_, _| false` (no skipping needed for drag).
- OpenAPI spec regenerated with Persona `displayName` field.

## Documentation

- [ ] Included in this PR
- [ ] Will be added in a follow-up PR
- [x] Not needed

---

- [ ] If HTTP endpoints changed: I ran `make gen-open-api` and `pnpm build`
- [ ] This PR includes breaking changes