### PR TITLE
feat(core): add displayName field to Persona

### DIFF
--- a/docs/website/static/api/open-api.yml
+++ b/docs/website/static/api/open-api.yml
@@ -2265,6 +2265,10 @@ components:
       type: object
       description: Persona data for a VRM character.
       properties:
+        displayName:
+          type:
+          - string
+          - 'null'
         metadata:
           type: object
           additionalProperties:

--- a/engine/crates/homunculus_core/src/components.rs
+++ b/engine/crates/homunculus_core/src/components.rs
@@ -81,6 +81,8 @@ pub struct Ocean {
 #[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
 #[serde(rename_all = "camelCase")]
 pub struct Persona {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub display_name: Option<String>,
     #[serde(default)]
     pub profile: String,
     #[serde(default, skip_serializing_if = "Option::is_none")]

--- a/engine/crates/homunculus_http_server/src/route/vrm/persona.rs
+++ b/engine/crates/homunculus_http_server/src/route/vrm/persona.rs
@@ -87,4 +87,40 @@ mod tests {
         let response = call(&mut app, router, request).await;
         assert_eq!(response.status(), StatusCode::OK);
     }
+
+    #[tokio::test]
+    async fn test_put_persona_with_display_name() {
+        let (mut app, router) = test_app();
+        let entity = app
+            .world_mut()
+            .spawn((
+                Persona::default(),
+                AssetIdComponent(AssetId::new("test::model.vrm")),
+            ))
+            .id();
+        app.update();
+
+        let persona = Persona {
+            display_name: Some("エルマー".to_string()),
+            profile: "A cheerful assistant".to_string(),
+            personality: Some("Friendly".to_string()),
+            ..Default::default()
+        };
+
+        let put_request =
+            axum::http::Request::put(format!("/vrm/{}/persona", entity.to_bits()))
+                .header("Content-Type", "application/json")
+                .body(axum::body::Body::from(
+                    serde_json::to_string(&persona).unwrap(),
+                ))
+                .unwrap();
+        let response = call(&mut app, router.clone(), put_request).await;
+        assert_eq!(response.status(), StatusCode::OK);
+
+        let get_request =
+            axum::http::Request::get(format!("/vrm/{}/persona", entity.to_bits()))
+                .body(axum::body::Body::empty())
+                .unwrap();
+        assert_response(&mut app, router, get_request, persona).await;
+    }
 }

--- a/mods/character-settings/ui/src/App.tsx
+++ b/mods/character-settings/ui/src/App.tsx
@@ -7,6 +7,8 @@ export function App() {
   const {
     loading,
     name,
+    displayName,
+    setDisplayName,
     tab,
     setTab,
     scale,
@@ -51,7 +53,7 @@ export function App() {
       {/* Header */}
       <div className="settings-header">
         <h1 className="settings-title">Settings</h1>
-        <span className="settings-entity-name">{name}</span>
+        <span className="settings-entity-name">{displayName || name}</span>
       </div>
 
       {/* Tabs */}
@@ -70,7 +72,13 @@ export function App() {
       {/* Content */}
       <div className={`settings-content${tab === "basic" ? " settings-content--visible" : ""}`}>
         {tab === "basic" && (
-          <BasicTab name={name} scale={scale} onScaleChange={setScale} />
+          <BasicTab
+            name={name}
+            displayName={displayName}
+            onDisplayNameChange={setDisplayName}
+            scale={scale}
+            onScaleChange={setScale}
+          />
         )}
         {tab === "persona" && (
           <PersonaTab

--- a/mods/character-settings/ui/src/components/BasicTab.tsx
+++ b/mods/character-settings/ui/src/components/BasicTab.tsx
@@ -1,19 +1,28 @@
 interface BasicTabProps {
   name: string;
+  displayName: string;
+  onDisplayNameChange: (displayName: string) => void;
   scale: number;
   onScaleChange: (scale: number) => void;
 }
 
-export function BasicTab({ name, scale, onScaleChange }: BasicTabProps) {
+export function BasicTab({
+  name,
+  displayName,
+  onDisplayNameChange,
+  scale,
+  onScaleChange,
+}: BasicTabProps) {
   return (
     <div className="settings-section">
       <label className="settings-label">
-        Name
+        Display Name
         <input
           type="text"
           className="settings-input"
-          value={name}
-          readOnly
+          value={displayName}
+          placeholder={name}
+          onChange={(e) => onDisplayNameChange(e.target.value)}
         />
       </label>
 

--- a/mods/character-settings/ui/src/hooks/useCharacterSettings.ts
+++ b/mods/character-settings/ui/src/hooks/useCharacterSettings.ts
@@ -8,6 +8,7 @@ export function useCharacterSettings() {
   const [entity, setEntity] = useState<number | null>(null);
   const [tab, setTab] = useState<Tab>("basic");
   const [name, setName] = useState("");
+  const [displayName, setDisplayName] = useState("");
   const [scale, setScale] = useState(1);
   const [profile, setProfile] = useState("");
   const [personality, setPersonality] = useState("");
@@ -35,6 +36,7 @@ export function useCharacterSettings() {
       if (cancelled) return;
 
       setName(vrmName);
+      setDisplayName(persona.displayName ?? "");
       setScale(transform.scale[0]);
       setProfile(persona.profile);
       setPersonality(persona.personality ?? "");
@@ -57,6 +59,7 @@ export function useCharacterSettings() {
     setSaving(true);
     try {
       await vrm.setPersona({
+        displayName: displayName || null,
         profile,
         personality: personality || null,
         ocean,
@@ -75,11 +78,13 @@ export function useCharacterSettings() {
     } finally {
       setSaving(false);
     }
-  }, [vrm, entity, profile, personality, ocean, scale, saving]);
+  }, [vrm, entity, displayName, profile, personality, ocean, scale, saving]);
 
   return {
     loading,
     name,
+    displayName,
+    setDisplayName,
     tab,
     setTab,
     scale,

--- a/packages/sdk/src/vrm.ts
+++ b/packages/sdk/src/vrm.ts
@@ -41,6 +41,7 @@ export interface Ocean {
  * @example
  * ```typescript
  * const persona: Persona = {
+ *   displayName: "エルマー",
  *   profile: "A cheerful virtual assistant",
  *   personality: "Friendly and helpful",
  *   ocean: { openness: 0.8, extraversion: 0.7 },
@@ -49,6 +50,8 @@ export interface Ocean {
  * ```
  */
 export interface Persona {
+    /** Optional display name / nickname for the character. */
+    displayName?: string | null;
     /** Character profile/background description. */
     profile: string;
     /** Personality description in natural language. */


### PR DESCRIPTION
## Summary
- Add `display_name` field to the `Persona` component in `homunculus_core`, propagating through the HTTP API, OpenAPI spec, TypeScript SDK (`@hmcs/sdk`), and character-settings UI
- The field allows users to set a custom display name for each character, editable via the BasicTab in character-settings
- Includes a round-trip integration test verifying `displayName` survives a set/get cycle through the persona HTTP API

## Test plan
- [ ] `cargo test -p homunculus_http_server` passes (includes the new `display_name` round-trip test)
- [ ] `pnpm build` succeeds for `@hmcs/sdk` with the new `displayName` field
- [ ] `pnpm build` succeeds for `character-settings` mod UI
- [ ] Manually verify display name is editable in the character-settings BasicTab overlay

🤖 Generated with [Claude Code](https://claude.com/claude-code)