### PR TITLE
feat(voicevox): add configurable pauseLength/prePhonemeLength/postPhonemeLength settings

### DIFF
--- a/mods/voicevox/service.ts
+++ b/mods/voicevox/service.ts
@@ -13,6 +13,9 @@ const DEFAULTS = {
   pitchScale: 0.0,
   intonationScale: 1.0,
   volumeScale: 1.0,
+  pauseLength: 1.0,
+  prePhonemeLength: 0.1,
+  postPhonemeLength: 0.1,
 };
 
 interface VoicevoxSettings {
@@ -21,6 +24,9 @@ interface VoicevoxSettings {
   pitchScale: number;
   intonationScale: number;
   volumeScale: number;
+  pauseLength: number;
+  prePhonemeLength: number;
+  postPhonemeLength: number;
 }
 
 const characterLocks = new Map<string, Promise<unknown>>();
@@ -142,6 +148,9 @@ function applyVoiceParams(query: any, settings: VoicevoxSettings): void {
   query.pitchScale = settings.pitchScale;
   query.intonationScale = settings.intonationScale;
   query.volumeScale = settings.volumeScale;
+  query.pauseLength = settings.pauseLength;
+  query.prePhonemeLength = settings.prePhonemeLength;
+  query.postPhonemeLength = settings.postPhonemeLength;
 }
 
 function generateTimeline(query: any) {

--- a/mods/voicevox/ui/src/App.tsx
+++ b/mods/voicevox/ui/src/App.tsx
@@ -50,6 +50,30 @@ const PARAMS: {
       max: 2.0,
       step: 0.05,
     },
+    {
+      key: "pauseLength",
+      label: "Pause Length",
+      desc: "Pause duration at punctuation marks",
+      min: 0,
+      max: 2.0,
+      step: 0.01,
+    },
+    {
+      key: "prePhonemeLength",
+      label: "Pre Phoneme Length",
+      desc: "Silence before speech starts",
+      min: 0,
+      max: 1.5,
+      step: 0.01,
+    },
+    {
+      key: "postPhonemeLength",
+      label: "Post Phoneme Length",
+      desc: "Silence after speech ends",
+      min: 0,
+      max: 1.5,
+      step: 0.01,
+    },
   ];
 
 export function App() {

--- a/mods/voicevox/ui/src/hooks/useVoicevoxSettings.ts
+++ b/mods/voicevox/ui/src/hooks/useVoicevoxSettings.ts
@@ -9,6 +9,9 @@ const DEFAULTS: VoicevoxSettings = {
   pitchScale: 0.0,
   intonationScale: 1.0,
   volumeScale: 1.0,
+  pauseLength: 1.0,
+  prePhonemeLength: 0.1,
+  postPhonemeLength: 0.1,
 };
 
 export interface VoicevoxSettings {
@@ -17,6 +20,9 @@ export interface VoicevoxSettings {
   pitchScale: number;
   intonationScale: number;
   volumeScale: number;
+  pauseLength: number;
+  prePhonemeLength: number;
+  postPhonemeLength: number;
 }
 
 export interface VoicevoxStyle {


### PR DESCRIPTION
## Problem

VOICEVOX audio query parameters `pauseLength`, `prePhonemeLength`, and `postPhonemeLength` were either hardcoded to `0` or not configurable. Users could not adjust pause duration at punctuation marks or silence padding before/after speech.

## Solution

Add 3 new configurable parameters to the VOICEVOX settings, matching VOICEVOX GUI defaults and ranges:

| Parameter | Default | Range | Description |
|---|---|---|---|
| Pause Length | 1.0 | 0 – 2.0 | Pause duration at punctuation marks |
| Pre Phoneme Length | 0.1 | 0 – 1.5 | Silence before speech starts |
| Post Phoneme Length | 0.1 | 0 – 1.5 | Silence after speech ends |

Changes across 3 files:
- `mods/voicevox/service.ts` — Added fields to `VoicevoxSettings` interface and `DEFAULTS`, replaced hardcoded `0` in `applyVoiceParams()` with settings values
- `mods/voicevox/ui/src/hooks/useVoicevoxSettings.ts` — Added fields to UI hook interface and defaults
- `mods/voicevox/ui/src/App.tsx` — Added 3 slider controls to the settings panel

## Documentation

- [x] Not needed

---

- [ ] If HTTP endpoints changed: I ran `make gen-open-api` and `pnpm build`
- [ ] This PR includes breaking changes