### PR TITLE
feat(dialog): add native file dialog API for file and directory selection

### DIFF
--- a/docs/website/static/api/open-api.yml
+++ b/docs/website/static/api/open-api.yml
@@ -269,6 +269,75 @@ paths:
                   format: float
         '500':
           description: Conversion failed
+  /dialog/pick-file:
+    post:
+      tags:
+      - dialog
+      summary: Open a native OS single-file picker dialog.
+      description: |-
+        Returns the selected file path. If the user cancels the dialog,
+        `path` will be `null`. Optionally accepts filters and a default directory.
+      operationId: pick_file
+      requestBody:
+        content:
+          application/json:
+            schema:
+              oneOf:
+              - type: 'null'
+              - $ref: '#/components/schemas/PickFileRequest'
+      responses:
+        '200':
+          description: File selection result
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PickFileResponse'
+  /dialog/pick-files:
+    post:
+      tags:
+      - dialog
+      summary: Open a native OS multi-file picker dialog.
+      description: |-
+        Returns the selected file paths. If the user cancels the dialog,
+        `paths` will be an empty array. Optionally accepts filters and a default directory.
+      operationId: pick_files
+      requestBody:
+        content:
+          application/json:
+            schema:
+              oneOf:
+              - type: 'null'
+              - $ref: '#/components/schemas/PickFileRequest'
+      responses:
+        '200':
+          description: Multi-file selection result
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PickFilesResponse'
+  /dialog/pick-folder:
+    post:
+      tags:
+      - dialog
+      summary: Open a native OS directory picker dialog.
+      description: |-
+        Returns the selected directory path. If the user cancels the dialog,
+        `path` will be `null`. Optionally accepts a title and default directory.
+      operationId: pick_folder
+      requestBody:
+        content:
+          application/json:
+            schema:
+              oneOf:
+              - type: 'null'
+              - $ref: '#/components/schemas/PickFolderRequest'
+      responses:
+        '200':
+          description: Folder selection result
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PickFolderResponse'
   /displays:
     get:
       tags:
@@ -819,6 +888,169 @@ paths:
       responses:
         '200':
           description: Signal sent
+  /stt/languages:
+    get:
+      tags:
+      - stt
+      summary: List supported STT languages.
+      operationId: list_languages
+      responses:
+        '200':
+          description: List of supported language codes
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  type: string
+  /stt/models:
+    get:
+      tags:
+      - stt
+      summary: List downloaded STT models.
+      operationId: list_models
+      responses:
+        '200':
+          description: List of available models
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/ModelInfo'
+  /stt/models/download:
+    post:
+      tags:
+      - stt
+      summary: Download an STT model.
+      operationId: download_model
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ModelDownloadRequest'
+        required: true
+      responses:
+        '200':
+          description: Download result
+        '422':
+          description: Invalid model size
+        '500':
+          description: Download failed
+    delete:
+      tags:
+      - stt
+      summary: Cancel an in-progress model download.
+      description: |-
+        With `modelSize` query param: cancel a specific download.
+        Without: cancel all in-progress downloads.
+      operationId: cancel_download
+      parameters:
+      - name: modelSize
+        in: query
+        description: Model size to cancel. Omit to cancel all.
+        required: false
+        schema:
+          $ref: '#/components/schemas/SttModelSize'
+      responses:
+        '200':
+          description: Download(s) cancelled
+        '404':
+          description: No active download for the specified model
+  /stt/models/download/stream:
+    post:
+      tags:
+      - stt
+      summary: Download an STT model with NDJSON progress streaming.
+      description: |-
+        Streams progress events as NDJSON lines. If the model already exists,
+        returns a single `complete` event. Returns 409 if a download is already in progress.
+      operationId: download_model_stream
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ModelDownloadRequest'
+        required: true
+      responses:
+        '200':
+          description: NDJSON stream of download progress
+          content:
+            application/x-ndjson: {}
+        '409':
+          description: Download already in progress
+        '422':
+          description: Invalid model size
+  /stt/start:
+    post:
+      tags:
+      - stt
+      summary: Start an STT session.
+      operationId: start
+      requestBody:
+        content:
+          application/json:
+            schema:
+              oneOf:
+              - type: 'null'
+              - $ref: '#/components/schemas/SttStartOptions'
+      responses:
+        '200':
+          description: Session started
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SttStartResponse'
+        '409':
+          description: Session already active or loading
+        '412':
+          description: Model not available
+        '422':
+          description: Invalid language
+        '500':
+          description: Internal server error
+        '503':
+          description: Microphone unavailable
+  /stt/status:
+    get:
+      tags:
+      - stt
+      summary: Get the current STT session status.
+      operationId: status
+      responses:
+        '200':
+          description: Current session state
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SttState'
+  /stt/stop:
+    post:
+      tags:
+      - stt
+      summary: Stop the current STT session. Idempotent.
+      operationId: stop
+      responses:
+        '200':
+          description: Session stopped
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SttState'
+  /stt/stream:
+    get:
+      tags:
+      - stt
+      summary: Stream STT events via SSE.
+      description: |-
+        Events: `status`, `result`, `session_error`, `stopped`.
+        Sends current status on connect (late-join sync).
+      operationId: stream
+      responses:
+        '200':
+          description: SSE event stream
+          content:
+            text/event-stream: {}
   /vrm:
     get:
       tags:
@@ -2027,6 +2259,21 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/ExpressionInfo'
+    FileFilter:
+      type: object
+      description: A file type filter for native file dialogs.
+      required:
+      - name
+      - extensions
+      properties:
+        extensions:
+          type: array
+          items:
+            type: string
+          description: File extensions without leading dot (e.g. `["png", "jpg"]`).
+        name:
+          type: string
+          description: Display name for the filter (e.g. "Images").
     GlobalDisplay:
       type: object
       required:
@@ -2166,6 +2413,30 @@ components:
           type: string
         text:
           type: string
+    ModelDownloadRequest:
+      type: object
+      description: Request body for model download.
+      required:
+      - modelSize
+      properties:
+        modelSize:
+          $ref: '#/components/schemas/SttModelSize'
+    ModelInfo:
+      type: object
+      description: Model info for the list endpoint.
+      required:
+      - modelSize
+      - sizeBytes
+      - path
+      properties:
+        modelSize:
+          $ref: '#/components/schemas/SttModelSize'
+        path:
+          type: string
+        sizeBytes:
+          type: integer
+          format: int64
+          minimum: 0
     MoveTarget:
       oneOf:
       - type: object
@@ -2279,6 +2550,70 @@ components:
           - 'null'
         profile:
           type: string
+    PickFileRequest:
+      type: object
+      description: Request body for file picker dialogs.
+      properties:
+        defaultPath:
+          type:
+          - string
+          - 'null'
+          description: Initial directory to open the dialog in.
+        filters:
+          type:
+          - array
+          - 'null'
+          items:
+            $ref: '#/components/schemas/FileFilter'
+          description: File type filters shown in the dialog.
+        title:
+          type:
+          - string
+          - 'null'
+          description: Dialog window title. Defaults to `"Select File"` or `"Select Files"`.
+    PickFileResponse:
+      type: object
+      description: Response from the single file picker dialog.
+      properties:
+        path:
+          type:
+          - string
+          - 'null'
+          description: The selected file path, or `null` if the user cancelled.
+    PickFilesResponse:
+      type: object
+      description: Response from the multi-file picker dialog.
+      required:
+      - paths
+      properties:
+        paths:
+          type: array
+          items:
+            type: string
+          description: The selected file paths. Empty if the user cancelled.
+    PickFolderRequest:
+      type: object
+      description: Request body for folder picker dialog.
+      properties:
+        defaultPath:
+          type:
+          - string
+          - 'null'
+          description: Initial directory to open the dialog in.
+        title:
+          type:
+          - string
+          - 'null'
+          description: Dialog window title. Defaults to `"Select Directory"`.
+    PickFolderResponse:
+      type: object
+      description: Response from the folder picker dialog.
+      properties:
+        path:
+          type:
+          - string
+          - 'null'
+          description: The selected directory path, or `null` if the user cancelled.
     PlatformInfo:
       type: object
       required:
@@ -2590,6 +2925,88 @@ components:
         properties:
           asset:
             $ref: '#/components/schemas/AssetId'
+    SttModelSize:
+      type: string
+      description: Whisper model size variants.
+      enum:
+      - tiny
+      - base
+      - small
+      - medium
+      - large-v3-turbo
+      - large-v3
+    SttStartOptions:
+      type: object
+      description: Session start options.
+      properties:
+        language:
+          type: string
+        modelSize:
+          $ref: '#/components/schemas/SttModelSize'
+    SttStartResponse:
+      allOf:
+      - $ref: '#/components/schemas/SttState'
+      - type: object
+        required:
+        - restarted
+        properties:
+          restarted:
+            type: boolean
+            description: True if an existing Listening session was implicitly stopped.
+      description: Response from the start endpoint, includes restart indicator.
+    SttState:
+      oneOf:
+      - type: object
+        required:
+        - state
+        properties:
+          state:
+            type: string
+            enum:
+            - idle
+      - type: object
+        required:
+        - language
+        - modelSize
+        - state
+        properties:
+          language:
+            type: string
+          modelSize:
+            $ref: '#/components/schemas/SttModelSize'
+          state:
+            type: string
+            enum:
+            - loading
+      - type: object
+        required:
+        - language
+        - modelSize
+        - state
+        properties:
+          language:
+            type: string
+          modelSize:
+            $ref: '#/components/schemas/SttModelSize'
+          state:
+            type: string
+            enum:
+            - listening
+      - type: object
+        required:
+        - error
+        - message
+        - state
+        properties:
+          error:
+            type: string
+          message:
+            type: string
+          state:
+            type: string
+            enum:
+            - error
+      description: STT session state.
     TimelineBody:
       allOf:
       - type:
@@ -3049,3 +3466,7 @@ tags:
   description: Asset management
 - name: rpc
   description: MOD service RPC registration and proxy
+- name: stt
+  description: Speech-to-text
+- name: dialog
+  description: Native OS dialogs

--- a/engine/Cargo.lock
+++ b/engine/Cargo.lock
@@ -321,6 +321,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "ashpd"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2f3f79755c74fd155000314eb349864caa787c6592eace6c6882dad873d9c39"
+dependencies = [
+ "async-fs",
+ "async-net",
+ "enumflags2",
+ "futures-channel",
+ "futures-util",
+ "rand 0.9.2",
+ "raw-window-handle",
+ "serde",
+ "serde_repr",
+ "url",
+ "wayland-backend",
+ "wayland-client",
+ "wayland-protocols",
+ "zbus",
+]
+
+[[package]]
 name = "assert_type_match"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -420,6 +442,64 @@ dependencies = [
  "event-listener",
  "event-listener-strategy",
  "pin-project-lite",
+]
+
+[[package]]
+name = "async-net"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b948000fad4873c1c9339d60f2623323a0cfd3816e5181033c6a5cb68b2accf7"
+dependencies = [
+ "async-io",
+ "blocking",
+ "futures-lite",
+]
+
+[[package]]
+name = "async-process"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc50921ec0055cdd8a16de48773bfeec5c972598674347252c0399676be7da75"
+dependencies = [
+ "async-channel",
+ "async-io",
+ "async-lock",
+ "async-signal",
+ "async-task",
+ "blocking",
+ "cfg-if",
+ "event-listener",
+ "futures-lite",
+ "rustix 1.1.4",
+]
+
+[[package]]
+name = "async-recursion"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b43422f69d8ff38f95f1b2bb76517c91589a924d1559a0e935d7c8ce0274c11"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "async-signal"
+version = "0.2.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43c070bbf59cd3570b6b2dd54cd772527c7c3620fce8be898406dd3ed6adc64c"
+dependencies = [
+ "async-io",
+ "async-lock",
+ "atomic-waker",
+ "cfg-if",
+ "futures-core",
+ "futures-io",
+ "rustix 1.1.4",
+ "signal-hook-registry",
+ "slab",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3365,6 +3445,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "endi"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "66b7e2430c6dff6a955451e2cfc438f09cea1965a9d6f87f7e3b90decc014099"
+
+[[package]]
+name = "enumflags2"
+version = "0.7.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1027f7680c853e056ebcec683615fb6fbbc07dbaa13b4d5d9442b146ded4ecef"
+dependencies = [
+ "enumflags2_derive",
+ "serde",
+]
+
+[[package]]
+name = "enumflags2_derive"
+version = "0.7.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67c78a4d8fdf9953a5c9d458f9efe940fd97a0cab0941c075a813ac594733827"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "enumn"
 version = "0.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4356,6 +4463,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
 
 [[package]]
+name = "hex"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
+
+[[package]]
 name = "hexasphere"
 version = "16.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4506,6 +4619,7 @@ dependencies = [
  "homunculus_utils",
  "http-body-util",
  "reqwest",
+ "rfd",
  "serde",
  "serde_json",
  "tokio",
@@ -6543,6 +6657,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "ordered-stream"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9aa2b01e1d916879f73a53d01d1d6cee68adbb31d6d9177a8cfce093cced1d50"
+dependencies = [
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
 name = "owned_ttf_parser"
 version = "0.25.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7201,6 +7325,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "rfd"
+version = "0.15.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef2bee61e6cffa4635c72d7d81a84294e28f0930db0ddcb0f66d10244674ebed"
+dependencies = [
+ "ashpd",
+ "block2 0.6.2",
+ "dispatch2",
+ "js-sys",
+ "log",
+ "objc2 0.6.4",
+ "objc2-app-kit 0.3.2",
+ "objc2-core-foundation",
+ "objc2-foundation 0.3.2",
+ "pollster",
+ "raw-window-handle",
+ "urlencoding",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
 name = "ring"
 version = "0.17.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7663,6 +7811,17 @@ dependencies = [
  "itoa",
  "serde",
  "serde_core",
+]
+
+[[package]]
+name = "serde_repr"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "175ee3e80ae9982737ca543e96133087cbd9a485eecc3bc4de9c1a37b47ea59c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -8792,6 +8951,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8c1ae7cc0fdb8b842d65d127cb981574b0d2b249b74d1c7a2986863dc134f71"
 
 [[package]]
+name = "uds_windows"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2f6fb2847f6742cd76af783a2a2c49e9375d0a111c7bef6f71cd9e738c72d6e"
+dependencies = [
+ "memoffset",
+ "tempfile",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "unicode-bidi"
 version = "0.3.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8894,7 +9064,14 @@ dependencies = [
  "idna",
  "percent-encoding",
  "serde",
+ "serde_derive",
 ]
+
+[[package]]
+name = "urlencoding"
+version = "2.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "daf8dba3b7eb870caf1ddeed7bc9d2a049f3cfdfae7cb521b087cc33ae4c49da"
 
 [[package]]
 name = "utf-8"
@@ -10476,6 +10653,67 @@ dependencies = [
 ]
 
 [[package]]
+name = "zbus"
+version = "5.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca82f95dbd3943a40a53cfded6c2d0a2ca26192011846a1810c4256ef92c60bc"
+dependencies = [
+ "async-broadcast",
+ "async-executor",
+ "async-io",
+ "async-lock",
+ "async-process",
+ "async-recursion",
+ "async-task",
+ "async-trait",
+ "blocking",
+ "enumflags2",
+ "event-listener",
+ "futures-core",
+ "futures-lite",
+ "hex",
+ "libc",
+ "ordered-stream",
+ "rustix 1.1.4",
+ "serde",
+ "serde_repr",
+ "tracing",
+ "uds_windows",
+ "uuid",
+ "windows-sys 0.61.2",
+ "winnow 0.7.15",
+ "zbus_macros",
+ "zbus_names",
+ "zvariant",
+]
+
+[[package]]
+name = "zbus_macros"
+version = "5.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "897e79616e84aac4b2c46e9132a4f63b93105d54fe8c0e8f6bffc21fa8d49222"
+dependencies = [
+ "proc-macro-crate 3.5.0",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+ "zbus_names",
+ "zvariant",
+ "zvariant_utils",
+]
+
+[[package]]
+name = "zbus_names"
+version = "4.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ffd8af6d5b78619bab301ff3c560a5bd22426150253db278f164d6cf3b72c50f"
+dependencies = [
+ "serde",
+ "winnow 0.7.15",
+ "zvariant",
+]
+
+[[package]]
 name = "zeno"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -10580,4 +10818,45 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "29ce2c8a9384ad323cf564b67da86e21d3cfdff87908bc1223ed5c99bc792713"
 dependencies = [
  "zune-core",
+]
+
+[[package]]
+name = "zvariant"
+version = "5.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5708299b21903bbe348e94729f22c49c55d04720a004aa350f1f9c122fd2540b"
+dependencies = [
+ "endi",
+ "enumflags2",
+ "serde",
+ "url",
+ "winnow 0.7.15",
+ "zvariant_derive",
+ "zvariant_utils",
+]
+
+[[package]]
+name = "zvariant_derive"
+version = "5.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b59b012ebe9c46656f9cc08d8da8b4c726510aef12559da3e5f1bf72780752c"
+dependencies = [
+ "proc-macro-crate 3.5.0",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+ "zvariant_utils",
+]
+
+[[package]]
+name = "zvariant_utils"
+version = "3.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f75c23a64ef8f40f13a6989991e643554d9bef1d682a281160cf0c1bc389c5e9"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "serde",
+ "syn 2.0.117",
+ "winnow 0.7.15",
 ]

--- a/engine/Cargo.toml
+++ b/engine/Cargo.toml
@@ -101,6 +101,7 @@ serde_json = { version = "1" }
 anyhow = { version = "1", features = ["std"] }
 base64 = "0.22"
 reqwest = { version = "0.12", features = ["json"] }
+rfd = "0.15"
 bevy_egui = { version = "0.39.0" }
 bevy-inspector-egui = { version = "0.36.0" }
 bevy_tweening = "0.15"

--- a/engine/crates/homunculus_http_server/Cargo.toml
+++ b/engine/crates/homunculus_http_server/Cargo.toml
@@ -33,6 +33,7 @@ tower-http = { version = "0.6", features = ["cors", "trace"] }
 async-channel = { workspace = true }
 utoipa = { workspace = true }
 utoipa-axum = { workspace = true }
+rfd = { workspace = true }
 
 [dev-dependencies]
 serde_json = "1.0.140"

--- a/engine/crates/homunculus_http_server/src/lib.rs
+++ b/engine/crates/homunculus_http_server/src/lib.rs
@@ -112,6 +112,7 @@ use utoipa_axum::{router::OpenApiRouter, routes};
         (name = "assets", description = "Asset management"),
         (name = "rpc", description = "MOD service RPC registration and proxy"),
         (name = "stt", description = "Speech-to-text"),
+        (name = "dialog", description = "Native OS dialogs"),
     ),
     servers(
         (url = "http://localhost:3100", description = "Local development"),
@@ -225,6 +226,7 @@ fn build_openapi_router() -> OpenApiRouter<HttpState> {
         .nest("/mods", mods_router())
         .nest("/commands", commands_router())
         .nest("/stt", stt_router())
+        .nest("/dialog", dialog_router())
         .routes(routes!(assets::list))
         .nest("/rpc", rpc_openapi_router())
 }
@@ -304,6 +306,10 @@ fn stt_router() -> OpenApiRouter<HttpState> {
         .routes(routes!(stt::download_model_stream))
         .routes(routes!(stt::list_models))
         .routes(routes!(stt::list_languages))
+}
+
+fn dialog_router() -> OpenApiRouter<HttpState> {
+    OpenApiRouter::new().routes(routes!(route::dialog::pick_folder))
 }
 
 fn commands_router() -> OpenApiRouter<HttpState> {

--- a/engine/crates/homunculus_http_server/src/lib.rs
+++ b/engine/crates/homunculus_http_server/src/lib.rs
@@ -309,7 +309,10 @@ fn stt_router() -> OpenApiRouter<HttpState> {
 }
 
 fn dialog_router() -> OpenApiRouter<HttpState> {
-    OpenApiRouter::new().routes(routes!(route::dialog::pick_folder))
+    OpenApiRouter::new()
+        .routes(routes!(route::dialog::pick_folder))
+        .routes(routes!(route::dialog::pick_file))
+        .routes(routes!(route::dialog::pick_files))
 }
 
 fn commands_router() -> OpenApiRouter<HttpState> {

--- a/engine/crates/homunculus_http_server/src/route.rs
+++ b/engine/crates/homunculus_http_server/src/route.rs
@@ -7,6 +7,7 @@ pub(crate) mod app;
 pub(crate) mod assets;
 pub(crate) mod audio;
 pub(crate) mod coordinates;
+pub(crate) mod dialog;
 pub(crate) mod displays;
 pub(crate) mod effects;
 pub(crate) mod entities;

--- a/engine/crates/homunculus_http_server/src/route/dialog.rs
+++ b/engine/crates/homunculus_http_server/src/route/dialog.rs
@@ -5,7 +5,7 @@ use serde::{Deserialize, Serialize};
 use utoipa::ToSchema;
 
 /// A file type filter for native file dialogs.
-#[derive(Serialize, Deserialize, Debug, Clone, ToSchema)]
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, ToSchema)]
 #[serde(rename_all = "camelCase")]
 pub struct FileFilter {
     /// Display name for the filter (e.g. "Images").
@@ -160,4 +160,84 @@ fn build_file_dialog(
         dialog = dialog.set_directory(path);
     }
     dialog
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn pick_file_request_deserialize_empty() {
+        let json = "{}";
+        let req: PickFileRequest = serde_json::from_str(json).unwrap();
+        assert_eq!(req.title, None);
+        assert_eq!(req.filters, None);
+        assert_eq!(req.default_path, None);
+    }
+
+    #[test]
+    fn pick_file_request_deserialize_full() {
+        let json = r#"{
+            "title": "Choose",
+            "filters": [{"name": "Images", "extensions": ["png", "jpg"]}],
+            "defaultPath": "/tmp"
+        }"#;
+        let req: PickFileRequest = serde_json::from_str(json).unwrap();
+        assert_eq!(req.title.as_deref(), Some("Choose"));
+        assert_eq!(req.filters.as_ref().unwrap().len(), 1);
+        assert_eq!(req.filters.as_ref().unwrap()[0].name, "Images");
+        assert_eq!(
+            req.filters.as_ref().unwrap()[0].extensions,
+            vec!["png", "jpg"]
+        );
+        assert_eq!(req.default_path.as_deref(), Some("/tmp"));
+    }
+
+    #[test]
+    fn pick_folder_request_deserialize_empty() {
+        let json = "{}";
+        let req: PickFolderRequest = serde_json::from_str(json).unwrap();
+        assert_eq!(req.title, None);
+        assert_eq!(req.default_path, None);
+    }
+
+    #[test]
+    fn pick_folder_request_deserialize_full() {
+        let json = r#"{"title": "Pick Dir", "defaultPath": "/home"}"#;
+        let req: PickFolderRequest = serde_json::from_str(json).unwrap();
+        assert_eq!(req.title.as_deref(), Some("Pick Dir"));
+        assert_eq!(req.default_path.as_deref(), Some("/home"));
+    }
+
+    #[test]
+    fn pick_file_response_serialize_with_path() {
+        let resp = PickFileResponse {
+            path: Some("/tmp/file.txt".to_string()),
+        };
+        let json = serde_json::to_value(&resp).unwrap();
+        assert_eq!(json["path"], "/tmp/file.txt");
+    }
+
+    #[test]
+    fn pick_file_response_serialize_cancelled() {
+        let resp = PickFileResponse { path: None };
+        let json = serde_json::to_value(&resp).unwrap();
+        assert!(json["path"].is_null());
+    }
+
+    #[test]
+    fn pick_files_response_serialize_with_paths() {
+        let resp = PickFilesResponse {
+            paths: vec!["/a.txt".to_string(), "/b.txt".to_string()],
+        };
+        let json = serde_json::to_value(&resp).unwrap();
+        assert_eq!(json["paths"], serde_json::json!(["/a.txt", "/b.txt"]));
+    }
+
+    #[test]
+    fn pick_files_response_serialize_cancelled() {
+        let resp = PickFilesResponse { paths: vec![] };
+        let json = serde_json::to_value(&resp).unwrap();
+        assert_eq!(json["paths"], serde_json::json!([]));
+    }
 }

--- a/engine/crates/homunculus_http_server/src/route/dialog.rs
+++ b/engine/crates/homunculus_http_server/src/route/dialog.rs
@@ -1,0 +1,35 @@
+//! `/dialog` provides native OS dialog operations.
+
+use axum::Json;
+use serde::{Deserialize, Serialize};
+use utoipa::ToSchema;
+
+/// Response from the folder picker dialog.
+#[derive(Serialize, Deserialize, Debug, Clone, ToSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct PickFolderResponse {
+    /// The selected directory path, or `null` if the user cancelled.
+    pub path: Option<String>,
+}
+
+/// Open a native OS directory picker dialog.
+///
+/// Returns the selected directory path. If the user cancels the dialog,
+/// `path` will be `null`.
+#[utoipa::path(
+    post,
+    path = "/pick-folder",
+    tag = "dialog",
+    responses(
+        (status = 200, description = "Folder selection result", body = PickFolderResponse),
+    ),
+)]
+pub async fn pick_folder() -> Json<PickFolderResponse> {
+    let handle = rfd::AsyncFileDialog::new()
+        .set_title("Select Directory")
+        .pick_folder()
+        .await;
+
+    let path = handle.map(|h| h.path().to_string_lossy().to_string());
+    Json(PickFolderResponse { path })
+}

--- a/engine/crates/homunculus_http_server/src/route/dialog.rs
+++ b/engine/crates/homunculus_http_server/src/route/dialog.rs
@@ -4,6 +4,54 @@ use axum::Json;
 use serde::{Deserialize, Serialize};
 use utoipa::ToSchema;
 
+/// A file type filter for native file dialogs.
+#[derive(Serialize, Deserialize, Debug, Clone, ToSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct FileFilter {
+    /// Display name for the filter (e.g. "Images").
+    pub name: String,
+    /// File extensions without leading dot (e.g. `["png", "jpg"]`).
+    pub extensions: Vec<String>,
+}
+
+/// Request body for file picker dialogs.
+#[derive(Serialize, Deserialize, Debug, Clone, Default, ToSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct PickFileRequest {
+    /// Dialog window title. Defaults to `"Select File"` or `"Select Files"`.
+    pub title: Option<String>,
+    /// File type filters shown in the dialog.
+    pub filters: Option<Vec<FileFilter>>,
+    /// Initial directory to open the dialog in.
+    pub default_path: Option<String>,
+}
+
+/// Request body for folder picker dialog.
+#[derive(Serialize, Deserialize, Debug, Clone, Default, ToSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct PickFolderRequest {
+    /// Dialog window title. Defaults to `"Select Directory"`.
+    pub title: Option<String>,
+    /// Initial directory to open the dialog in.
+    pub default_path: Option<String>,
+}
+
+/// Response from the single file picker dialog.
+#[derive(Serialize, Deserialize, Debug, Clone, ToSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct PickFileResponse {
+    /// The selected file path, or `null` if the user cancelled.
+    pub path: Option<String>,
+}
+
+/// Response from the multi-file picker dialog.
+#[derive(Serialize, Deserialize, Debug, Clone, ToSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct PickFilesResponse {
+    /// The selected file paths. Empty if the user cancelled.
+    pub paths: Vec<String>,
+}
+
 /// Response from the folder picker dialog.
 #[derive(Serialize, Deserialize, Debug, Clone, ToSchema)]
 #[serde(rename_all = "camelCase")]
@@ -15,21 +63,101 @@ pub struct PickFolderResponse {
 /// Open a native OS directory picker dialog.
 ///
 /// Returns the selected directory path. If the user cancels the dialog,
-/// `path` will be `null`.
+/// `path` will be `null`. Optionally accepts a title and default directory.
 #[utoipa::path(
     post,
     path = "/pick-folder",
     tag = "dialog",
+    request_body(content = Option<PickFolderRequest>, content_type = "application/json"),
     responses(
         (status = 200, description = "Folder selection result", body = PickFolderResponse),
     ),
 )]
-pub async fn pick_folder() -> Json<PickFolderResponse> {
-    let handle = rfd::AsyncFileDialog::new()
-        .set_title("Select Directory")
-        .pick_folder()
-        .await;
-
+pub async fn pick_folder(body: Option<Json<PickFolderRequest>>) -> Json<PickFolderResponse> {
+    let req = body.map(|Json(r)| r).unwrap_or_default();
+    let dialog = build_file_dialog(
+        req.title.as_deref(),
+        "Select Directory",
+        None,
+        req.default_path.as_deref(),
+    );
+    let handle = dialog.pick_folder().await;
     let path = handle.map(|h| h.path().to_string_lossy().to_string());
     Json(PickFolderResponse { path })
+}
+
+/// Open a native OS single-file picker dialog.
+///
+/// Returns the selected file path. If the user cancels the dialog,
+/// `path` will be `null`. Optionally accepts filters and a default directory.
+#[utoipa::path(
+    post,
+    path = "/pick-file",
+    tag = "dialog",
+    request_body(content = Option<PickFileRequest>, content_type = "application/json"),
+    responses(
+        (status = 200, description = "File selection result", body = PickFileResponse),
+    ),
+)]
+pub async fn pick_file(body: Option<Json<PickFileRequest>>) -> Json<PickFileResponse> {
+    let req = body.map(|Json(r)| r).unwrap_or_default();
+    let dialog = build_file_dialog(
+        req.title.as_deref(),
+        "Select File",
+        req.filters.as_deref(),
+        req.default_path.as_deref(),
+    );
+    let handle = dialog.pick_file().await;
+    let path = handle.map(|h| h.path().to_string_lossy().to_string());
+    Json(PickFileResponse { path })
+}
+
+/// Open a native OS multi-file picker dialog.
+///
+/// Returns the selected file paths. If the user cancels the dialog,
+/// `paths` will be an empty array. Optionally accepts filters and a default directory.
+#[utoipa::path(
+    post,
+    path = "/pick-files",
+    tag = "dialog",
+    request_body(content = Option<PickFileRequest>, content_type = "application/json"),
+    responses(
+        (status = 200, description = "Multi-file selection result", body = PickFilesResponse),
+    ),
+)]
+pub async fn pick_files(body: Option<Json<PickFileRequest>>) -> Json<PickFilesResponse> {
+    let req = body.map(|Json(r)| r).unwrap_or_default();
+    let dialog = build_file_dialog(
+        req.title.as_deref(),
+        "Select Files",
+        req.filters.as_deref(),
+        req.default_path.as_deref(),
+    );
+    let handles = dialog.pick_files().await;
+    let paths = handles
+        .unwrap_or_default()
+        .iter()
+        .map(|h| h.path().to_string_lossy().to_string())
+        .collect();
+    Json(PickFilesResponse { paths })
+}
+
+/// Build an `AsyncFileDialog` with optional title, filters, and default path.
+fn build_file_dialog(
+    title: Option<&str>,
+    default_title: &str,
+    filters: Option<&[FileFilter]>,
+    default_path: Option<&str>,
+) -> rfd::AsyncFileDialog {
+    let mut dialog = rfd::AsyncFileDialog::new().set_title(title.unwrap_or(default_title));
+    if let Some(filters) = filters {
+        for f in filters {
+            let ext_refs: Vec<&str> = f.extensions.iter().map(String::as_str).collect();
+            dialog = dialog.add_filter(&f.name, &ext_refs);
+        }
+    }
+    if let Some(path) = default_path {
+        dialog = dialog.set_directory(path);
+    }
+    dialog
 }

--- a/mods/agent/ui/settings/src/components/DirectoryListField.tsx
+++ b/mods/agent/ui/settings/src/components/DirectoryListField.tsx
@@ -1,0 +1,126 @@
+import { useState } from "react";
+import { dialog } from "@hmcs/sdk";
+
+interface DirectoryListFieldProps {
+  label: string;
+  description?: string;
+  paths: string[];
+  defaultIndex: number;
+  onAdd: (path: string) => void;
+  onRemove: (index: number) => void;
+  onSetDefault: (index: number) => void;
+}
+
+export function DirectoryListField({
+  label,
+  description,
+  paths,
+  defaultIndex,
+  onAdd,
+  onRemove,
+  onSetDefault,
+}: DirectoryListFieldProps) {
+  const [inputValue, setInputValue] = useState("");
+  const [browsing, setBrowsing] = useState(false);
+
+  function handleAdd() {
+    const trimmed = inputValue.trim();
+    if (!trimmed) return;
+    onAdd(trimmed);
+    setInputValue("");
+  }
+
+  function handleKeyDown(e: React.KeyboardEvent<HTMLInputElement>) {
+    if (e.key === "Enter") handleAdd();
+  }
+
+  async function handleBrowse() {
+    setBrowsing(true);
+    try {
+      const path = await dialog.pickFolder();
+      if (path) {
+        onAdd(path);
+      }
+    } finally {
+      setBrowsing(false);
+    }
+  }
+
+  return (
+    <label className="settings-label">
+      {label}
+      {description && (
+        <span className="settings-label-desc">{description}</span>
+      )}
+      <div className="agent-dir-list">
+        {paths.map((path, i) => (
+          <DirectoryItem
+            key={i}
+            path={path}
+            isDefault={i === defaultIndex}
+            onSetDefault={() => onSetDefault(i)}
+            onRemove={() => onRemove(i)}
+          />
+        ))}
+      </div>
+      <div className="agent-add-row">
+        <input
+          className="agent-add-input"
+          type="text"
+          placeholder="Add directory path..."
+          value={inputValue}
+          onChange={(e) => setInputValue(e.target.value)}
+          onKeyDown={handleKeyDown}
+        />
+        <button className="agent-add-btn" type="button" onClick={handleAdd}>
+          Add
+        </button>
+        <button
+          className="agent-add-btn"
+          type="button"
+          onClick={handleBrowse}
+          disabled={browsing}
+        >
+          Browse
+        </button>
+      </div>
+    </label>
+  );
+}
+
+interface DirectoryItemProps {
+  path: string;
+  isDefault: boolean;
+  onSetDefault: () => void;
+  onRemove: () => void;
+}
+
+function DirectoryItem({
+  path,
+  isDefault,
+  onSetDefault,
+  onRemove,
+}: DirectoryItemProps) {
+  return (
+    <div className="agent-dir-item">
+      <input
+        className="agent-dir-radio"
+        type="radio"
+        checked={isDefault}
+        onChange={onSetDefault}
+        aria-label={`Set ${path} as default`}
+      />
+      <span className="agent-dir-path" title={path}>
+        {path}
+      </span>
+      <button
+        className="agent-dir-remove"
+        type="button"
+        onClick={onRemove}
+        aria-label={`Remove ${path}`}
+      >
+        ×
+      </button>
+    </div>
+  );
+}

--- a/packages/sdk/src/dialog.ts
+++ b/packages/sdk/src/dialog.ts
@@ -10,19 +10,113 @@ import { host } from "./host";
  * ```typescript
  * import { dialog } from "@hmcs/sdk";
  *
- * const result = await dialog.pickFolder();
- * if (result) {
- *   console.log(`Selected: ${result}`);
- * }
+ * // Pick a single file
+ * const file = await dialog.pickFile({ filters: [{ name: "Images", extensions: ["png", "jpg"] }] });
+ *
+ * // Pick multiple files
+ * const files = await dialog.pickFiles();
+ *
+ * // Pick a folder
+ * const folder = await dialog.pickFolder();
  * ```
  */
 export namespace dialog {
+  /**
+   * A file type filter for native file dialogs.
+   *
+   * @example
+   * ```typescript
+   * const imageFilter: dialog.FileFilter = {
+   *   name: "Images",
+   *   extensions: ["png", "jpg", "jpeg", "gif"]
+   * };
+   * ```
+   */
+  export interface FileFilter {
+    /** Display name for the filter (e.g. "Images"). */
+    name: string;
+    /** File extensions without leading dot (e.g. `["png", "jpg"]`). */
+    extensions: string[];
+  }
+
+  /** Options for file picker dialogs. */
+  export interface PickFileOptions {
+    /** Dialog window title. */
+    title?: string;
+    /** Initial directory to open the dialog in. */
+    defaultPath?: string;
+    /** File type filters shown in the dialog. */
+    filters?: FileFilter[];
+  }
+
+  /** Options for folder picker dialog. */
+  export interface PickFolderOptions {
+    /** Dialog window title. */
+    title?: string;
+    /** Initial directory to open the dialog in. */
+    defaultPath?: string;
+  }
+
+  /**
+   * Opens a native OS single-file picker dialog.
+   *
+   * Displays the platform's standard file selection dialog. Returns the
+   * selected file path as a string, or `null` if the user cancels.
+   *
+   * @param options - Optional dialog configuration
+   * @returns The selected file path, or `null` if cancelled
+   *
+   * @example
+   * ```typescript
+   * const file = await dialog.pickFile({
+   *   title: "Select a VRM model",
+   *   filters: [{ name: "VRM", extensions: ["vrm"] }],
+   *   defaultPath: "/Users/me/models"
+   * });
+   * if (file) {
+   *   console.log(`Selected: ${file}`);
+   * }
+   * ```
+   */
+  export async function pickFile(options?: PickFileOptions): Promise<string | null> {
+    const response = await host.post(host.createUrl("dialog/pick-file"), options);
+    const body = (await response.json()) as { path: string | null };
+    return body.path;
+  }
+
+  /**
+   * Opens a native OS multi-file picker dialog.
+   *
+   * Displays the platform's standard multi-file selection dialog. Returns
+   * an array of selected file paths, or an empty array if the user cancels.
+   *
+   * @param options - Optional dialog configuration
+   * @returns Array of selected file paths (empty if cancelled)
+   *
+   * @example
+   * ```typescript
+   * const files = await dialog.pickFiles({
+   *   title: "Select images",
+   *   filters: [{ name: "Images", extensions: ["png", "jpg", "jpeg"] }]
+   * });
+   * for (const file of files) {
+   *   console.log(`Selected: ${file}`);
+   * }
+   * ```
+   */
+  export async function pickFiles(options?: PickFileOptions): Promise<string[]> {
+    const response = await host.post(host.createUrl("dialog/pick-files"), options);
+    const body = (await response.json()) as { paths: string[] };
+    return body.paths;
+  }
+
   /**
    * Opens a native OS directory picker dialog.
    *
    * Displays the platform's standard folder selection dialog. Returns the
    * selected directory path as a string, or `null` if the user cancels.
    *
+   * @param options - Optional dialog configuration
    * @returns The selected directory path, or `null` if cancelled
    *
    * @example
@@ -33,8 +127,8 @@ export namespace dialog {
    * }
    * ```
    */
-  export async function pickFolder(): Promise<string | null> {
-    const response = await host.post(host.createUrl("dialog/pick-folder"));
+  export async function pickFolder(options?: PickFolderOptions): Promise<string | null> {
+    const response = await host.post(host.createUrl("dialog/pick-folder"), options);
     const body = (await response.json()) as { path: string | null };
     return body.path;
   }

--- a/packages/sdk/src/dialog.ts
+++ b/packages/sdk/src/dialog.ts
@@ -1,0 +1,41 @@
+import { host } from "./host";
+
+/**
+ * Native OS dialog API namespace for file and directory selection.
+ *
+ * Provides access to native OS file picker dialogs. These dialogs are
+ * rendered by the operating system and appear as standard system windows.
+ *
+ * @example
+ * ```typescript
+ * import { dialog } from "@hmcs/sdk";
+ *
+ * const result = await dialog.pickFolder();
+ * if (result) {
+ *   console.log(`Selected: ${result}`);
+ * }
+ * ```
+ */
+export namespace dialog {
+  /**
+   * Opens a native OS directory picker dialog.
+   *
+   * Displays the platform's standard folder selection dialog. Returns the
+   * selected directory path as a string, or `null` if the user cancels.
+   *
+   * @returns The selected directory path, or `null` if cancelled
+   *
+   * @example
+   * ```typescript
+   * const folder = await dialog.pickFolder();
+   * if (folder) {
+   *   console.log(`User chose: ${folder}`);
+   * }
+   * ```
+   */
+  export async function pickFolder(): Promise<string | null> {
+    const response = await host.post(host.createUrl("dialog/pick-folder"));
+    const body = (await response.json()) as { path: string | null };
+    return body.path;
+  }
+}

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -39,6 +39,7 @@
  */
 
 export * from "./coordinates";
+export * from "./dialog";
 export * from "./displays";
 export * from "./audio";
 export * from "./effects";


### PR DESCRIPTION
## Problem

There was no mechanism for WebView-based UIs to open native OS file dialogs. MOD developers had no way to let users browse for files or directories from within the application.

## Solution

Added a complete native file dialog API using the `rfd` crate, exposed via HTTP endpoints and TypeScript SDK:

**Endpoints (engine):**
- `POST /dialog/pick-folder` — directory picker (new: accepts optional `title` and `defaultPath`)
- `POST /dialog/pick-file` — single-file picker with optional filters
- `POST /dialog/pick-files` — multi-file picker with optional filters

All endpoints accept an optional JSON body with `title`, `defaultPath`, and `filters` (file endpoints only). Cancellation returns `null` or `[]`.

**SDK (packages/sdk):**
- `dialog.pickFolder(options?)`, `dialog.pickFile(options?)`, `dialog.pickFiles(options?)` — typed wrappers with full JSDoc

**UI (mods/agent):**
- `DirectoryListField` component with Browse button for directory selection

**Testing:**
- 8 serde round-trip tests for all request/response types
- OpenAPI spec regenerated

Affected areas: engine, packages/sdk, mods/agent, docs (OpenAPI)

## Documentation

- [ ] Included in this PR
- [ ] Will be added in a follow-up PR
- [x] Not needed

---

- [x] If HTTP endpoints changed: I ran `make gen-open-api` and `pnpm build`
- [ ] This PR includes breaking changes