### PR TITLE
feat: add persona identity fields (display name, age, gender, pronoun) to character settings

### DIFF
--- a/engine/crates/homunculus_core/src/components.rs
+++ b/engine/crates/homunculus_core/src/components.rs
@@ -76,6 +76,18 @@ pub struct Ocean {
     pub neuroticism: Option<f64>,
 }
 
+/// Gender identity for a VRM character.
+#[derive(Debug, Clone, Serialize, Deserialize, Default, PartialEq)]
+#[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
+#[serde(rename_all = "camelCase")]
+pub enum Gender {
+    Male,
+    Female,
+    Other,
+    #[default]
+    Unknown,
+}
+
 /// Persona data for a VRM character.
 #[derive(Component, Debug, Clone, Serialize, Deserialize, Default, PartialEq)]
 #[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
@@ -83,6 +95,12 @@ pub struct Ocean {
 pub struct Persona {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub display_name: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub age: Option<u32>,
+    #[serde(default)]
+    pub gender: Gender,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub first_person_pronoun: Option<String>,
     #[serde(default)]
     pub profile: String,
     #[serde(default, skip_serializing_if = "Option::is_none")]

--- a/engine/crates/homunculus_core/src/components.rs
+++ b/engine/crates/homunculus_core/src/components.rs
@@ -81,6 +81,8 @@ pub struct Ocean {
 #[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
 #[serde(rename_all = "camelCase")]
 pub struct Persona {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub display_name: Option<String>,
     #[serde(default)]
     pub profile: String,
     #[serde(default, skip_serializing_if = "Option::is_none")]

--- a/engine/crates/homunculus_http_server/src/route/vrm/persona.rs
+++ b/engine/crates/homunculus_http_server/src/route/vrm/persona.rs
@@ -107,20 +107,18 @@ mod tests {
             ..Default::default()
         };
 
-        let put_request =
-            axum::http::Request::put(format!("/vrm/{}/persona", entity.to_bits()))
-                .header("Content-Type", "application/json")
-                .body(axum::body::Body::from(
-                    serde_json::to_string(&persona).unwrap(),
-                ))
-                .unwrap();
+        let put_request = axum::http::Request::put(format!("/vrm/{}/persona", entity.to_bits()))
+            .header("Content-Type", "application/json")
+            .body(axum::body::Body::from(
+                serde_json::to_string(&persona).unwrap(),
+            ))
+            .unwrap();
         let response = call(&mut app, router.clone(), put_request).await;
         assert_eq!(response.status(), StatusCode::OK);
 
-        let get_request =
-            axum::http::Request::get(format!("/vrm/{}/persona", entity.to_bits()))
-                .body(axum::body::Body::empty())
-                .unwrap();
+        let get_request = axum::http::Request::get(format!("/vrm/{}/persona", entity.to_bits()))
+            .body(axum::body::Body::empty())
+            .unwrap();
         assert_response(&mut app, router, get_request, persona).await;
     }
 
@@ -146,20 +144,18 @@ mod tests {
             ..Default::default()
         };
 
-        let put_request =
-            axum::http::Request::put(format!("/vrm/{}/persona", entity.to_bits()))
-                .header("Content-Type", "application/json")
-                .body(axum::body::Body::from(
-                    serde_json::to_string(&persona).unwrap(),
-                ))
-                .unwrap();
+        let put_request = axum::http::Request::put(format!("/vrm/{}/persona", entity.to_bits()))
+            .header("Content-Type", "application/json")
+            .body(axum::body::Body::from(
+                serde_json::to_string(&persona).unwrap(),
+            ))
+            .unwrap();
         let response = call(&mut app, router.clone(), put_request).await;
         assert_eq!(response.status(), StatusCode::OK);
 
-        let get_request =
-            axum::http::Request::get(format!("/vrm/{}/persona", entity.to_bits()))
-                .body(axum::body::Body::empty())
-                .unwrap();
+        let get_request = axum::http::Request::get(format!("/vrm/{}/persona", entity.to_bits()))
+            .body(axum::body::Body::empty())
+            .unwrap();
         assert_response(&mut app, router, get_request, persona).await;
     }
 }

--- a/engine/crates/homunculus_http_server/src/route/vrm/persona.rs
+++ b/engine/crates/homunculus_http_server/src/route/vrm/persona.rs
@@ -87,4 +87,40 @@ mod tests {
         let response = call(&mut app, router, request).await;
         assert_eq!(response.status(), StatusCode::OK);
     }
+
+    #[tokio::test]
+    async fn test_put_persona_with_display_name() {
+        let (mut app, router) = test_app();
+        let entity = app
+            .world_mut()
+            .spawn((
+                Persona::default(),
+                AssetIdComponent(AssetId::new("test::model.vrm")),
+            ))
+            .id();
+        app.update();
+
+        let persona = Persona {
+            display_name: Some("エルマー".to_string()),
+            profile: "A cheerful assistant".to_string(),
+            personality: Some("Friendly".to_string()),
+            ..Default::default()
+        };
+
+        let put_request =
+            axum::http::Request::put(format!("/vrm/{}/persona", entity.to_bits()))
+                .header("Content-Type", "application/json")
+                .body(axum::body::Body::from(
+                    serde_json::to_string(&persona).unwrap(),
+                ))
+                .unwrap();
+        let response = call(&mut app, router.clone(), put_request).await;
+        assert_eq!(response.status(), StatusCode::OK);
+
+        let get_request =
+            axum::http::Request::get(format!("/vrm/{}/persona", entity.to_bits()))
+                .body(axum::body::Body::empty())
+                .unwrap();
+        assert_response(&mut app, router, get_request, persona).await;
+    }
 }

--- a/engine/crates/homunculus_http_server/src/route/vrm/persona.rs
+++ b/engine/crates/homunculus_http_server/src/route/vrm/persona.rs
@@ -46,7 +46,7 @@ mod tests {
     use crate::tests::{assert_response, call, test_app};
     use axum::http::StatusCode;
     use bevy::prelude::*;
-    use homunculus_core::prelude::{AssetId, AssetIdComponent, Persona};
+    use homunculus_core::prelude::{AssetId, AssetIdComponent, Gender, Persona};
 
     #[tokio::test]
     async fn test_get_persona() {
@@ -104,6 +104,45 @@ mod tests {
             display_name: Some("エルマー".to_string()),
             profile: "A cheerful assistant".to_string(),
             personality: Some("Friendly".to_string()),
+            ..Default::default()
+        };
+
+        let put_request =
+            axum::http::Request::put(format!("/vrm/{}/persona", entity.to_bits()))
+                .header("Content-Type", "application/json")
+                .body(axum::body::Body::from(
+                    serde_json::to_string(&persona).unwrap(),
+                ))
+                .unwrap();
+        let response = call(&mut app, router.clone(), put_request).await;
+        assert_eq!(response.status(), StatusCode::OK);
+
+        let get_request =
+            axum::http::Request::get(format!("/vrm/{}/persona", entity.to_bits()))
+                .body(axum::body::Body::empty())
+                .unwrap();
+        assert_response(&mut app, router, get_request, persona).await;
+    }
+
+    #[tokio::test]
+    async fn test_put_persona_with_identity_fields() {
+        let (mut app, router) = test_app();
+        let entity = app
+            .world_mut()
+            .spawn((
+                Persona::default(),
+                AssetIdComponent(AssetId::new("test::model.vrm")),
+            ))
+            .id();
+        app.update();
+
+        let persona = Persona {
+            display_name: Some("テスト".to_string()),
+            age: Some(25),
+            gender: Gender::Female,
+            first_person_pronoun: Some("わたし".to_string()),
+            profile: "Test profile".to_string(),
+            personality: Some("Cheerful".to_string()),
             ..Default::default()
         };
 

--- a/mods/character-settings/package.json
+++ b/mods/character-settings/package.json
@@ -31,6 +31,7 @@
   "dependencies": {
     "@hmcs/sdk": "workspace:*",
     "@hmcs/ui": "workspace:*",
+    "@radix-ui/react-radio-group": "^1.3.8",
     "react": "^19.2.4",
     "react-dom": "^19.2.4",
     "zod": "^3.25.76"

--- a/mods/character-settings/ui/src/App.tsx
+++ b/mods/character-settings/ui/src/App.tsx
@@ -19,8 +19,6 @@ export function App() {
     setPersonality,
     age,
     setAge,
-    ageUnknown,
-    setAgeUnknown,
     gender,
     setGender,
     firstPersonPronoun,
@@ -85,9 +83,7 @@ export function App() {
             displayName={displayName}
             onDisplayNameChange={setDisplayName}
             age={age}
-            ageUnknown={ageUnknown}
             onAgeChange={setAge}
-            onAgeUnknownChange={setAgeUnknown}
             gender={gender}
             onGenderChange={setGender}
             firstPersonPronoun={firstPersonPronoun}

--- a/mods/character-settings/ui/src/App.tsx
+++ b/mods/character-settings/ui/src/App.tsx
@@ -8,6 +8,7 @@ export function App() {
     loading,
     name,
     displayName,
+    setDisplayName,
     tab,
     setTab,
     scale,
@@ -16,6 +17,14 @@ export function App() {
     setProfile,
     personality,
     setPersonality,
+    age,
+    setAge,
+    ageUnknown,
+    setAgeUnknown,
+    gender,
+    setGender,
+    firstPersonPronoun,
+    setFirstPersonPronoun,
     ocean,
     setOcean,
     saving,
@@ -72,6 +81,17 @@ export function App() {
       <div className={`settings-content${tab === "persona" ? " settings-content--visible" : ""}`}>
         {tab === "persona" && (
           <PersonaTab
+            name={name}
+            displayName={displayName}
+            onDisplayNameChange={setDisplayName}
+            age={age}
+            ageUnknown={ageUnknown}
+            onAgeChange={setAge}
+            onAgeUnknownChange={setAgeUnknown}
+            gender={gender}
+            onGenderChange={setGender}
+            firstPersonPronoun={firstPersonPronoun}
+            onFirstPersonPronounChange={setFirstPersonPronoun}
             profile={profile}
             personality={personality}
             onProfileChange={setProfile}

--- a/mods/character-settings/ui/src/App.tsx
+++ b/mods/character-settings/ui/src/App.tsx
@@ -1,5 +1,5 @@
 import { useCharacterSettings, type Tab } from "./hooks/useCharacterSettings";
-import { BasicTab } from "./components/BasicTab";
+import { AppearanceTab } from "./components/AppearanceTab";
 import { PersonaTab } from "./components/PersonaTab";
 import { OceanTab } from "./components/OceanTab";
 
@@ -8,7 +8,6 @@ export function App() {
     loading,
     name,
     displayName,
-    setDisplayName,
     tab,
     setTab,
     scale,
@@ -34,9 +33,9 @@ export function App() {
   }
 
   const tabs: { id: Tab; label: string }[] = [
-    { id: "basic", label: "Basic" },
     { id: "persona", label: "Persona" },
     { id: "ocean", label: "OCEAN" },
+    { id: "appearance", label: "Appearance" },
   ];
 
   return (
@@ -70,16 +69,7 @@ export function App() {
       </div>
 
       {/* Content */}
-      <div className={`settings-content${tab === "basic" ? " settings-content--visible" : ""}`}>
-        {tab === "basic" && (
-          <BasicTab
-            name={name}
-            displayName={displayName}
-            onDisplayNameChange={setDisplayName}
-            scale={scale}
-            onScaleChange={setScale}
-          />
-        )}
+      <div className={`settings-content${tab === "persona" ? " settings-content--visible" : ""}`}>
         {tab === "persona" && (
           <PersonaTab
             profile={profile}
@@ -89,6 +79,12 @@ export function App() {
           />
         )}
         {tab === "ocean" && <OceanTab ocean={ocean} onChange={setOcean} />}
+        {tab === "appearance" && (
+          <AppearanceTab
+            scale={scale}
+            onScaleChange={setScale}
+          />
+        )}
       </div>
 
       {/* Footer */}

--- a/mods/character-settings/ui/src/App.tsx
+++ b/mods/character-settings/ui/src/App.tsx
@@ -7,6 +7,8 @@ export function App() {
   const {
     loading,
     name,
+    displayName,
+    setDisplayName,
     tab,
     setTab,
     scale,
@@ -51,7 +53,7 @@ export function App() {
       {/* Header */}
       <div className="settings-header">
         <h1 className="settings-title">Settings</h1>
-        <span className="settings-entity-name">{name}</span>
+        <span className="settings-entity-name">{displayName || name}</span>
       </div>
 
       {/* Tabs */}
@@ -70,7 +72,13 @@ export function App() {
       {/* Content */}
       <div className={`settings-content${tab === "basic" ? " settings-content--visible" : ""}`}>
         {tab === "basic" && (
-          <BasicTab name={name} scale={scale} onScaleChange={setScale} />
+          <BasicTab
+            name={name}
+            displayName={displayName}
+            onDisplayNameChange={setDisplayName}
+            scale={scale}
+            onScaleChange={setScale}
+          />
         )}
         {tab === "persona" && (
           <PersonaTab

--- a/mods/character-settings/ui/src/components/AppearanceTab.tsx
+++ b/mods/character-settings/ui/src/components/AppearanceTab.tsx
@@ -1,31 +1,14 @@
-interface BasicTabProps {
-  name: string;
-  displayName: string;
-  onDisplayNameChange: (displayName: string) => void;
+interface AppearanceTabProps {
   scale: number;
   onScaleChange: (scale: number) => void;
 }
 
-export function BasicTab({
-  name,
-  displayName,
-  onDisplayNameChange,
+export function AppearanceTab({
   scale,
   onScaleChange,
-}: BasicTabProps) {
+}: AppearanceTabProps) {
   return (
     <div className="settings-section">
-      <label className="settings-label">
-        Display Name
-        <input
-          type="text"
-          className="settings-input"
-          value={displayName}
-          placeholder={name}
-          onChange={(e) => onDisplayNameChange(e.target.value)}
-        />
-      </label>
-
       <label className="settings-label">
         Scale
         <div className="settings-slider-row">

--- a/mods/character-settings/ui/src/components/BasicTab.tsx
+++ b/mods/character-settings/ui/src/components/BasicTab.tsx
@@ -1,19 +1,28 @@
 interface BasicTabProps {
   name: string;
+  displayName: string;
+  onDisplayNameChange: (displayName: string) => void;
   scale: number;
   onScaleChange: (scale: number) => void;
 }
 
-export function BasicTab({ name, scale, onScaleChange }: BasicTabProps) {
+export function BasicTab({
+  name,
+  displayName,
+  onDisplayNameChange,
+  scale,
+  onScaleChange,
+}: BasicTabProps) {
   return (
     <div className="settings-section">
       <label className="settings-label">
-        Name
+        Display Name
         <input
           type="text"
           className="settings-input"
-          value={name}
-          readOnly
+          value={displayName}
+          placeholder={name}
+          onChange={(e) => onDisplayNameChange(e.target.value)}
         />
       </label>
 

--- a/mods/character-settings/ui/src/components/PersonaTab.tsx
+++ b/mods/character-settings/ui/src/components/PersonaTab.tsx
@@ -1,14 +1,16 @@
 import type { Gender } from "@hmcs/sdk";
-import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@hmcs/ui";
+import { useRef } from "react";
+import * as RadioGroupPrimitive from "@radix-ui/react-radio-group";
+import {
+  Select, SelectContent, SelectItem, SelectTrigger, SelectValue,
+} from "@hmcs/ui";
 
 interface PersonaTabProps {
   name: string;
   displayName: string;
   onDisplayNameChange: (displayName: string) => void;
   age: number | null;
-  ageUnknown: boolean;
   onAgeChange: (age: number | null) => void;
-  onAgeUnknownChange: (unknown: boolean) => void;
   gender: Gender;
   onGenderChange: (gender: Gender) => void;
   firstPersonPronoun: string;
@@ -31,9 +33,7 @@ export function PersonaTab({
   displayName,
   onDisplayNameChange,
   age,
-  ageUnknown,
   onAgeChange,
-  onAgeUnknownChange,
   gender,
   onGenderChange,
   firstPersonPronoun,
@@ -56,12 +56,7 @@ export function PersonaTab({
         />
       </label>
 
-      <AgeField
-        age={age}
-        ageUnknown={ageUnknown}
-        onAgeChange={onAgeChange}
-        onAgeUnknownChange={onAgeUnknownChange}
-      />
+      <AgeField value={age} onChange={onAgeChange} />
 
       <div className="settings-label">
         Gender
@@ -116,46 +111,91 @@ export function PersonaTab({
 }
 
 interface AgeFieldProps {
-  age: number | null;
-  ageUnknown: boolean;
-  onAgeChange: (age: number | null) => void;
-  onAgeUnknownChange: (unknown: boolean) => void;
+  value: number | null;
+  onChange: (age: number | null) => void;
 }
 
-function AgeField({ age, ageUnknown, onAgeChange, onAgeUnknownChange }: AgeFieldProps) {
-  function handleUnknownToggle(checked: boolean) {
-    onAgeUnknownChange(checked);
-    if (checked) onAgeChange(null);
+function AgeField({ value, onChange }: AgeFieldProps) {
+  const preservedAge = useRef<number | null>(null);
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  const isUnknown = value == null && preservedAge.current != null;
+  const radioValue = isUnknown ? "unknown" : "specify";
+
+  function handleModeChange(newMode: string) {
+    if (newMode === "unknown") {
+      if (value != null) preservedAge.current = value;
+      onChange(null);
+    } else {
+      const restored = preservedAge.current;
+      if (restored != null) onChange(restored);
+      requestAnimationFrame(() => inputRef.current?.focus());
+    }
   }
 
-  function handleAgeInput(value: string) {
-    const num = parseInt(value, 10);
-    onAgeChange(isNaN(num) ? null : Math.min(Math.max(num, 0), 999));
+  function handleInput(raw: string) {
+    const digits = raw.replace(/[^0-9]/g, "");
+    if (digits === "") {
+      onChange(null);
+      return;
+    }
+    onChange(Math.min(parseInt(digits, 10), 999));
   }
 
   return (
-    <div className="settings-label">
-      Age
-      <div className="settings-age-row">
-        <input
-          type="number"
-          className="settings-input settings-age-input"
-          min={0}
-          max={999}
-          value={ageUnknown ? "" : (age ?? "")}
-          disabled={ageUnknown}
-          onChange={(e) => handleAgeInput(e.target.value)}
-          placeholder="—"
-        />
-        <label className="settings-checkbox-label">
-          <input
-            type="checkbox"
-            checked={ageUnknown}
-            onChange={(e) => handleUnknownToggle(e.target.checked)}
-          />
-          年齢不詳
-        </label>
+    <fieldset className="settings-label settings-age-field">
+      <legend className="settings-age-legend">Age</legend>
+      <RadioGroupPrimitive.Root
+        className="settings-age-segments"
+        value={radioValue}
+        onValueChange={handleModeChange}
+        data-mode={radioValue === "unknown" ? "unknown" : "specify"}
+      >
+        <RadioGroupPrimitive.Item
+          value="specify"
+          className="settings-age-segment"
+          aria-label="年齢を指定"
+          data-mode="specify"
+        >
+          指定
+        </RadioGroupPrimitive.Item>
+        <RadioGroupPrimitive.Item
+          value="unknown"
+          className="settings-age-segment"
+          aria-label="年齢不詳"
+          data-mode="unknown"
+        >
+          不詳
+        </RadioGroupPrimitive.Item>
+      </RadioGroupPrimitive.Root>
+      <div
+        className="settings-age-value-area"
+        role="status"
+        aria-live="polite"
+        data-mode={radioValue === "unknown" ? "unknown" : "specify"}
+      >
+        {radioValue === "unknown" ? (
+          <span className="settings-age-unknown-readout">不詳</span>
+        ) : (
+          <>
+            <input
+              ref={inputRef}
+              type="text"
+              inputMode="numeric"
+              pattern="[0-9]*"
+              className="settings-age-input"
+              value={value ?? ""}
+              onChange={(e) => handleInput(e.target.value)}
+              aria-label="Age value"
+              aria-describedby="age-suffix"
+              placeholder="—"
+            />
+            <span id="age-suffix" className="settings-age-suffix" aria-hidden="true">
+              歳
+            </span>
+          </>
+        )}
       </div>
-    </div>
+    </fieldset>
   );
 }

--- a/mods/character-settings/ui/src/components/PersonaTab.tsx
+++ b/mods/character-settings/ui/src/components/PersonaTab.tsx
@@ -1,11 +1,42 @@
+import type { Gender } from "@hmcs/sdk";
+
 interface PersonaTabProps {
+  name: string;
+  displayName: string;
+  onDisplayNameChange: (displayName: string) => void;
+  age: number | null;
+  ageUnknown: boolean;
+  onAgeChange: (age: number | null) => void;
+  onAgeUnknownChange: (unknown: boolean) => void;
+  gender: Gender;
+  onGenderChange: (gender: Gender) => void;
+  firstPersonPronoun: string;
+  onFirstPersonPronounChange: (pronoun: string) => void;
   profile: string;
   personality: string;
   onProfileChange: (profile: string) => void;
   onPersonalityChange: (personality: string) => void;
 }
 
+const GENDER_OPTIONS: { value: Gender; label: string }[] = [
+  { value: "unknown", label: "不明" },
+  { value: "male", label: "男" },
+  { value: "female", label: "女" },
+  { value: "other", label: "その他" },
+];
+
 export function PersonaTab({
+  name,
+  displayName,
+  onDisplayNameChange,
+  age,
+  ageUnknown,
+  onAgeChange,
+  onAgeUnknownChange,
+  gender,
+  onGenderChange,
+  firstPersonPronoun,
+  onFirstPersonPronounChange,
   profile,
   personality,
   onProfileChange,
@@ -13,6 +44,50 @@ export function PersonaTab({
 }: PersonaTabProps) {
   return (
     <div className="settings-section">
+      <label className="settings-label">
+        Display Name
+        <input
+          type="text"
+          className="settings-input"
+          value={displayName}
+          placeholder={name}
+          onChange={(e) => onDisplayNameChange(e.target.value)}
+        />
+      </label>
+
+      <AgeField
+        age={age}
+        ageUnknown={ageUnknown}
+        onAgeChange={onAgeChange}
+        onAgeUnknownChange={onAgeUnknownChange}
+      />
+
+      <label className="settings-label">
+        Gender
+        <select
+          className="settings-input"
+          value={gender}
+          onChange={(e) => onGenderChange(e.target.value as Gender)}
+        >
+          {GENDER_OPTIONS.map((opt) => (
+            <option key={opt.value} value={opt.value}>
+              {opt.label}
+            </option>
+          ))}
+        </select>
+      </label>
+
+      <label className="settings-label">
+        First Person Pronoun
+        <input
+          type="text"
+          className="settings-input"
+          value={firstPersonPronoun}
+          placeholder="例: わたし、僕、俺"
+          onChange={(e) => onFirstPersonPronounChange(e.target.value)}
+        />
+      </label>
+
       <label className="settings-label">
         Profile
         <textarea
@@ -34,6 +109,51 @@ export function PersonaTab({
           placeholder="Personality traits in natural language..."
         />
       </label>
+    </div>
+  );
+}
+
+interface AgeFieldProps {
+  age: number | null;
+  ageUnknown: boolean;
+  onAgeChange: (age: number | null) => void;
+  onAgeUnknownChange: (unknown: boolean) => void;
+}
+
+function AgeField({ age, ageUnknown, onAgeChange, onAgeUnknownChange }: AgeFieldProps) {
+  function handleUnknownToggle(checked: boolean) {
+    onAgeUnknownChange(checked);
+    if (checked) onAgeChange(null);
+  }
+
+  function handleAgeInput(value: string) {
+    const num = parseInt(value, 10);
+    onAgeChange(isNaN(num) ? null : Math.min(Math.max(num, 0), 999));
+  }
+
+  return (
+    <div className="settings-label">
+      Age
+      <div className="settings-age-row">
+        <input
+          type="number"
+          className="settings-input settings-age-input"
+          min={0}
+          max={999}
+          value={ageUnknown ? "" : (age ?? "")}
+          disabled={ageUnknown}
+          onChange={(e) => handleAgeInput(e.target.value)}
+          placeholder="—"
+        />
+        <label className="settings-checkbox-label">
+          <input
+            type="checkbox"
+            checked={ageUnknown}
+            onChange={(e) => handleUnknownToggle(e.target.checked)}
+          />
+          年齢不詳
+        </label>
+      </div>
     </div>
   );
 }

--- a/mods/character-settings/ui/src/components/PersonaTab.tsx
+++ b/mods/character-settings/ui/src/components/PersonaTab.tsx
@@ -1,4 +1,5 @@
 import type { Gender } from "@hmcs/sdk";
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@hmcs/ui";
 
 interface PersonaTabProps {
   name: string;
@@ -62,20 +63,21 @@ export function PersonaTab({
         onAgeUnknownChange={onAgeUnknownChange}
       />
 
-      <label className="settings-label">
+      <div className="settings-label">
         Gender
-        <select
-          className="settings-input"
-          value={gender}
-          onChange={(e) => onGenderChange(e.target.value as Gender)}
-        >
-          {GENDER_OPTIONS.map((opt) => (
-            <option key={opt.value} value={opt.value}>
-              {opt.label}
-            </option>
-          ))}
-        </select>
-      </label>
+        <Select value={gender} onValueChange={(v) => onGenderChange(v as Gender)}>
+          <SelectTrigger className="settings-input">
+            <SelectValue />
+          </SelectTrigger>
+          <SelectContent>
+            {GENDER_OPTIONS.map((opt) => (
+              <SelectItem key={opt.value} value={opt.value}>
+                {opt.label}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+      </div>
 
       <label className="settings-label">
         First Person Pronoun

--- a/mods/character-settings/ui/src/components/PersonaTab.tsx
+++ b/mods/character-settings/ui/src/components/PersonaTab.tsx
@@ -22,10 +22,10 @@ interface PersonaTabProps {
 }
 
 const GENDER_OPTIONS: { value: Gender; label: string }[] = [
-  { value: "unknown", label: "不明" },
-  { value: "male", label: "男" },
-  { value: "female", label: "女" },
-  { value: "other", label: "その他" },
+  { value: "unknown", label: "Unknown" },
+  { value: "male", label: "Male" },
+  { value: "female", label: "Female" },
+  { value: "other", label: "Other" },
 ];
 
 export function PersonaTab({
@@ -80,7 +80,7 @@ export function PersonaTab({
           type="text"
           className="settings-input"
           value={firstPersonPronoun}
-          placeholder="例: わたし、僕、俺"
+          placeholder="e.g. watashi, boku, ore"
           onChange={(e) => onFirstPersonPronounChange(e.target.value)}
         />
       </label>
@@ -154,18 +154,18 @@ function AgeField({ value, onChange }: AgeFieldProps) {
         <RadioGroupPrimitive.Item
           value="specify"
           className="settings-age-segment"
-          aria-label="年齢を指定"
+          aria-label="Specify age"
           data-mode="specify"
         >
-          指定
+          Specify
         </RadioGroupPrimitive.Item>
         <RadioGroupPrimitive.Item
           value="unknown"
           className="settings-age-segment"
-          aria-label="年齢不詳"
+          aria-label="Age unknown"
           data-mode="unknown"
         >
-          不詳
+          Unknown
         </RadioGroupPrimitive.Item>
       </RadioGroupPrimitive.Root>
       <div
@@ -175,7 +175,7 @@ function AgeField({ value, onChange }: AgeFieldProps) {
         data-mode={radioValue === "unknown" ? "unknown" : "specify"}
       >
         {radioValue === "unknown" ? (
-          <span className="settings-age-unknown-readout">不詳</span>
+          <span className="settings-age-unknown-readout">Unknown</span>
         ) : (
           <>
             <input
@@ -187,12 +187,8 @@ function AgeField({ value, onChange }: AgeFieldProps) {
               value={value ?? ""}
               onChange={(e) => handleInput(e.target.value)}
               aria-label="Age value"
-              aria-describedby="age-suffix"
               placeholder="—"
             />
-            <span id="age-suffix" className="settings-age-suffix" aria-hidden="true">
-              歳
-            </span>
           </>
         )}
       </div>

--- a/mods/character-settings/ui/src/hooks/useCharacterSettings.ts
+++ b/mods/character-settings/ui/src/hooks/useCharacterSettings.ts
@@ -13,7 +13,6 @@ export function useCharacterSettings() {
   const [profile, setProfile] = useState("");
   const [personality, setPersonality] = useState("");
   const [age, setAge] = useState<number | null>(null);
-  const [ageUnknown, setAgeUnknown] = useState(true);
   const [gender, setGender] = useState<Gender>("unknown");
   const [firstPersonPronoun, setFirstPersonPronoun] = useState("");
   const [ocean, setOcean] = useState<Ocean>({});
@@ -45,7 +44,6 @@ export function useCharacterSettings() {
       setProfile(persona.profile);
       setPersonality(persona.personality ?? "");
       setAge(persona.age ?? null);
-      setAgeUnknown(persona.age == null);
       setGender(persona.gender ?? "unknown");
       setFirstPersonPronoun(persona.firstPersonPronoun ?? "");
       setOcean(persona.ocean);
@@ -68,7 +66,7 @@ export function useCharacterSettings() {
     try {
       await vrm.setPersona({
         displayName: displayName || null,
-        age: ageUnknown ? null : age,
+        age,
         gender,
         firstPersonPronoun: firstPersonPronoun || null,
         profile,
@@ -89,7 +87,7 @@ export function useCharacterSettings() {
     } finally {
       setSaving(false);
     }
-  }, [vrm, entity, displayName, age, ageUnknown, gender, firstPersonPronoun, profile, personality, ocean, scale, saving]);
+  }, [vrm, entity, displayName, age, gender, firstPersonPronoun, profile, personality, ocean, scale, saving]);
 
   return {
     loading,
@@ -106,8 +104,6 @@ export function useCharacterSettings() {
     setPersonality,
     age,
     setAge,
-    ageUnknown,
-    setAgeUnknown,
     gender,
     setGender,
     firstPersonPronoun,

--- a/mods/character-settings/ui/src/hooks/useCharacterSettings.ts
+++ b/mods/character-settings/ui/src/hooks/useCharacterSettings.ts
@@ -8,6 +8,7 @@ export function useCharacterSettings() {
   const [entity, setEntity] = useState<number | null>(null);
   const [tab, setTab] = useState<Tab>("basic");
   const [name, setName] = useState("");
+  const [displayName, setDisplayName] = useState("");
   const [scale, setScale] = useState(1);
   const [profile, setProfile] = useState("");
   const [personality, setPersonality] = useState("");
@@ -35,6 +36,7 @@ export function useCharacterSettings() {
       if (cancelled) return;
 
       setName(vrmName);
+      setDisplayName(persona.displayName ?? "");
       setScale(transform.scale[0]);
       setProfile(persona.profile);
       setPersonality(persona.personality ?? "");
@@ -57,6 +59,7 @@ export function useCharacterSettings() {
     setSaving(true);
     try {
       await vrm.setPersona({
+        displayName: displayName || null,
         profile,
         personality: personality || null,
         ocean,
@@ -75,11 +78,13 @@ export function useCharacterSettings() {
     } finally {
       setSaving(false);
     }
-  }, [vrm, entity, profile, personality, ocean, scale, saving]);
+  }, [vrm, entity, displayName, profile, personality, ocean, scale, saving]);
 
   return {
     loading,
     name,
+    displayName,
+    setDisplayName,
     tab,
     setTab,
     scale,

--- a/mods/character-settings/ui/src/hooks/useCharacterSettings.ts
+++ b/mods/character-settings/ui/src/hooks/useCharacterSettings.ts
@@ -1,12 +1,12 @@
 import { useCallback, useEffect, useState } from "react";
 import { Webview, Vrm, entities, type Ocean, audio } from "@hmcs/sdk";
 
-export type Tab = "basic" | "persona" | "ocean";
+export type Tab = "persona" | "ocean" | "appearance";
 
 export function useCharacterSettings() {
   const [vrm, setVrm] = useState<Vrm | null>(null);
   const [entity, setEntity] = useState<number | null>(null);
-  const [tab, setTab] = useState<Tab>("basic");
+  const [tab, setTab] = useState<Tab>("persona");
   const [name, setName] = useState("");
   const [displayName, setDisplayName] = useState("");
   const [scale, setScale] = useState(1);

--- a/mods/character-settings/ui/src/hooks/useCharacterSettings.ts
+++ b/mods/character-settings/ui/src/hooks/useCharacterSettings.ts
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useState } from "react";
-import { Webview, Vrm, entities, type Ocean, audio } from "@hmcs/sdk";
+import { Webview, Vrm, entities, type Ocean, type Gender, audio } from "@hmcs/sdk";
 
 export type Tab = "persona" | "ocean" | "appearance";
 
@@ -12,6 +12,10 @@ export function useCharacterSettings() {
   const [scale, setScale] = useState(1);
   const [profile, setProfile] = useState("");
   const [personality, setPersonality] = useState("");
+  const [age, setAge] = useState<number | null>(null);
+  const [ageUnknown, setAgeUnknown] = useState(true);
+  const [gender, setGender] = useState<Gender>("unknown");
+  const [firstPersonPronoun, setFirstPersonPronoun] = useState("");
   const [ocean, setOcean] = useState<Ocean>({});
   const [saving, setSaving] = useState(false);
   const [saved, setSaved] = useState(false);
@@ -40,6 +44,10 @@ export function useCharacterSettings() {
       setScale(transform.scale[0]);
       setProfile(persona.profile);
       setPersonality(persona.personality ?? "");
+      setAge(persona.age ?? null);
+      setAgeUnknown(persona.age == null);
+      setGender(persona.gender ?? "unknown");
+      setFirstPersonPronoun(persona.firstPersonPronoun ?? "");
       setOcean(persona.ocean);
       setLoading(false);
     })();
@@ -60,6 +68,9 @@ export function useCharacterSettings() {
     try {
       await vrm.setPersona({
         displayName: displayName || null,
+        age: ageUnknown ? null : age,
+        gender,
+        firstPersonPronoun: firstPersonPronoun || null,
         profile,
         personality: personality || null,
         ocean,
@@ -78,7 +89,7 @@ export function useCharacterSettings() {
     } finally {
       setSaving(false);
     }
-  }, [vrm, entity, displayName, profile, personality, ocean, scale, saving]);
+  }, [vrm, entity, displayName, age, ageUnknown, gender, firstPersonPronoun, profile, personality, ocean, scale, saving]);
 
   return {
     loading,
@@ -93,6 +104,14 @@ export function useCharacterSettings() {
     setProfile,
     personality,
     setPersonality,
+    age,
+    setAge,
+    ageUnknown,
+    setAgeUnknown,
+    gender,
+    setGender,
+    firstPersonPronoun,
+    setFirstPersonPronoun,
     ocean,
     setOcean,
     saving,

--- a/mods/character-settings/ui/src/index.css
+++ b/mods/character-settings/ui/src/index.css
@@ -360,6 +360,177 @@ body {
   color: oklch(0.55 0.02 250 / 0.5);
 }
 
+/* ━━ Age Field — Segmented Control + Value Area ━━ */
+
+.settings-age-field {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.settings-age-legend {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
+.settings-age-segments {
+  display: flex;
+  gap: 2px;
+  background: oklch(0.12 0.01 250 / 0.8);
+  border: 1px solid oklch(0.72 0.14 192 / 0.2);
+  border-radius: 6px;
+  overflow: hidden;
+  height: 32px;
+}
+
+.settings-age-segments[data-mode="unknown"] {
+  border-color: oklch(0.65 0.18 285 / 0.2);
+}
+
+.settings-age-segment {
+  flex: 1;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 0.75rem;
+  font-weight: 500;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  cursor: pointer;
+  border: none;
+  background: transparent;
+  padding: 6px 0;
+  color: oklch(0.58 0.02 250);
+  transition: color 180ms ease, background 180ms ease, text-shadow 180ms ease,
+              border-color 180ms ease;
+  border-bottom: 2px solid transparent;
+  font-family: inherit;
+  outline: none;
+}
+
+.settings-age-segment:hover {
+  color: oklch(0.78 0.10 192);
+}
+
+.settings-age-segment[data-mode="unknown"]:hover {
+  color: oklch(0.72 0.14 285);
+}
+
+.settings-age-segment[data-state="checked"][data-mode="specify"] {
+  color: oklch(0.72 0.14 192);
+  border-bottom-color: oklch(0.72 0.14 192 / 0.8);
+  text-shadow: 0 0 12px oklch(0.72 0.14 192 / 0.3);
+  background: oklch(0.18 0.02 250 / 0.5);
+}
+
+.settings-age-segment[data-state="checked"][data-mode="unknown"] {
+  color: oklch(0.65 0.18 285);
+  border-bottom-color: oklch(0.65 0.18 285 / 0.8);
+  text-shadow: 0 0 12px oklch(0.65 0.18 285 / 0.3);
+  background: oklch(0.18 0.02 250 / 0.5);
+}
+
+.settings-age-segment:focus-visible {
+  outline: 2px solid oklch(0.72 0.14 192);
+  outline-offset: 2px;
+}
+
+.settings-age-value-area {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  height: 36px;
+  min-inline-size: 8ch;
+  background: oklch(0.12 0.01 250 / 0.8);
+  border: 1px solid oklch(0.72 0.14 192 / 0.2);
+  border-radius: 6px;
+  padding: 8px 12px;
+  transition: border-color 200ms ease-out, box-shadow 200ms ease-out;
+}
+
+.settings-age-value-area[data-mode="unknown"] {
+  border-color: oklch(0.65 0.18 285 / 0.2);
+}
+
+.settings-age-input {
+  width: 100%;
+  background: transparent;
+  border: none;
+  outline: none;
+  color: oklch(0.92 0.01 250);
+  font-family: monospace;
+  font-size: 0.95rem;
+  font-weight: 400;
+  text-align: center;
+  font-variant-numeric: tabular-nums;
+  padding: 0;
+}
+
+.settings-age-input::placeholder {
+  color: oklch(0.55 0.02 250 / 0.5);
+}
+
+.settings-age-input::-webkit-inner-spin-button,
+.settings-age-input::-webkit-outer-spin-button {
+  -webkit-appearance: none;
+  margin: 0;
+}
+
+.settings-age-suffix {
+  font-size: 0.75rem;
+  color: oklch(0.72 0.14 192 / 0.5);
+  margin-left: 2px;
+  font-family: monospace;
+}
+
+.settings-age-unknown-readout {
+  font-family: monospace;
+  font-size: 0.95rem;
+  font-weight: 400;
+  text-align: center;
+  color: oklch(0.65 0.18 285);
+  font-variant-numeric: tabular-nums;
+}
+
+.settings-age-value-area:focus-within {
+  border-color: oklch(0.72 0.14 192 / 0.5);
+  box-shadow: 0 0 8px oklch(0.72 0.14 192 / 0.15),
+              inset 0 0 4px oklch(0.72 0.14 192 / 0.05);
+}
+
+.settings-age-value-area[data-mode="unknown"]:focus-within {
+  border-color: oklch(0.65 0.18 285 / 0.5);
+  box-shadow: 0 0 8px oklch(0.65 0.18 285 / 0.15),
+              inset 0 0 4px oklch(0.65 0.18 285 / 0.05);
+}
+
+@media (forced-colors: active) {
+  .settings-age-segment {
+    color: GrayText;
+  }
+  .settings-age-segment[data-state="checked"] {
+    color: CanvasText;
+    border-bottom-color: CanvasText;
+  }
+  .settings-age-segment[data-state="checked"][data-mode="unknown"] {
+    color: LinkText;
+    border-bottom-color: LinkText;
+  }
+  .settings-age-unknown-readout {
+    color: LinkText;
+  }
+  .settings-age-suffix {
+    color: CanvasText;
+  }
+}
+
 /* ━━ Slider ━━ */
 
 .settings-slider-row {
@@ -634,5 +805,10 @@ body {
   .settings-loading-text {
     animation: none;
     opacity: 0.5;
+  }
+
+  .settings-age-segment,
+  .settings-age-value-area {
+    transition-duration: 0ms;
   }
 }

--- a/packages/sdk/src/vrm.ts
+++ b/packages/sdk/src/vrm.ts
@@ -35,6 +35,9 @@ export interface Ocean {
     neuroticism?: number;
 }
 
+/** Gender identity for a VRM character. */
+export type Gender = "male" | "female" | "other" | "unknown";
+
 /**
  * Persona data for a VRM character.
  *
@@ -42,6 +45,9 @@ export interface Ocean {
  * ```typescript
  * const persona: Persona = {
  *   displayName: "エルマー",
+ *   age: 25,
+ *   gender: "female",
+ *   firstPersonPronoun: "わたし",
  *   profile: "A cheerful virtual assistant",
  *   personality: "Friendly and helpful",
  *   ocean: { openness: 0.8, extraversion: 0.7 },
@@ -52,6 +58,12 @@ export interface Ocean {
 export interface Persona {
     /** Optional display name / nickname for the character. */
     displayName?: string | null;
+    /** Age of the character. null means age unknown. */
+    age?: number | null;
+    /** Gender identity. Defaults to "unknown". */
+    gender: Gender;
+    /** First-person pronoun (e.g. "わたし", "僕", "俺"). null means unset (AI infers). */
+    firstPersonPronoun?: string | null;
     /** Character profile/background description. */
     profile: string;
     /** Personality description in natural language. */

--- a/packages/sdk/src/vrm.ts
+++ b/packages/sdk/src/vrm.ts
@@ -41,6 +41,7 @@ export interface Ocean {
  * @example
  * ```typescript
  * const persona: Persona = {
+ *   displayName: "エルマー",
  *   profile: "A cheerful virtual assistant",
  *   personality: "Friendly and helpful",
  *   ocean: { openness: 0.8, extraversion: 0.7 },
@@ -49,6 +50,8 @@ export interface Ocean {
  * ```
  */
 export interface Persona {
+    /** Optional display name / nickname for the character. */
+    displayName?: string | null;
     /** Character profile/background description. */
     profile: string;
     /** Personality description in natural language. */

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -22,6 +22,7 @@ export * from "./components/ui/hover-card";
 export * from "./components/ui/input-otp";
 export * from "./components/ui/input";
 export * from "./components/ui/label";
+export * from "./components/ui/radio-group";
 export * from "./components/ui/select";
 export * from "./components/ui/separator";
 export * from "./components/ui/settings-card";

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -96,6 +96,9 @@ importers:
       '@hmcs/ui':
         specifier: workspace:*
         version: link:../../packages/ui
+      '@radix-ui/react-radio-group':
+        specifier: ^1.3.8
+        version: 1.3.8(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       react:
         specifier: ^19.2.4
         version: 19.2.4


### PR DESCRIPTION
## Problem

The character settings panel only allows editing profile text and personality — there is no way to set identity attributes like display name, age, gender, or first person pronoun. Users need to configure these fields to give their desktop mascot characters a concrete, distinct personality.

## Solution

### Data Model (engine + SDK)
- Add `display_name`, `age` (Option<u32>), `gender` (enum: unknown/male/female/other), and `first_person_pronoun` fields to the Rust `Persona` component
- Add corresponding TypeScript types to `@hmcs/sdk` (`Gender` enum, identity fields on `Persona` interface)
- Add HTTP round-trip tests for the new persona fields

### Character Settings UI (mods/character-settings)
- Add editable Display Name field with model-name placeholder
- Add Gender field using Radix Select (Unknown/Male/Female/Other)
- Add Age field with a custom RadioGroup segmented control ("Specify" / "Unknown") + fixed-height value display area — replacing the original number input + checkbox pattern for better UX and WCAG AA compliance
- Add First Person Pronoun text input
- Rename "Basic" tab to "Appearance" and reorder tabs (Persona first)
- Simplify component API from 4 age-related props to 2 (`value` + `onChange`)
- Unify all UI text to English

### Shared UI Library (packages/ui)
- Export `RadioGroup` and `RadioGroupItem` from `@hmcs/ui`

<details><summary>Screenshots</summary>

_UI changes affect mods/character-settings — screenshots to be added after visual verification._

</details>

## Documentation

- [ ] Included in this PR
- [ ] Will be added in a follow-up PR
- [x] Not needed

---

- [x] If HTTP endpoints changed: I ran `make gen-open-api` and `pnpm build`
- [ ] This PR includes breaking changes