### PR TITLE
feat(ui): add Precision Hologram design tokens to @hmcs/ui

### DIFF
--- a/mods/character-settings/ui/src/index.css
+++ b/mods/character-settings/ui/src/index.css
@@ -74,7 +74,7 @@ body {
   max-height: 100vh;
   display: flex;
   flex-direction: column;
-  gap: 16px;
+  gap: var(--hud-space-xl);
   animation: settings-in 400ms cubic-bezier(0.16, 1, 0.3, 1) both;
   box-sizing: border-box;
 }
@@ -234,7 +234,7 @@ body {
 }
 
 .settings-title {
-  font-size: 0.85rem;
+  font-size: var(--hud-font-size-base);
   letter-spacing: 0.15em;
   text-transform: uppercase;
   color: oklch(0.72 0.14 192 / 0.9);
@@ -243,7 +243,7 @@ body {
 }
 
 .settings-entity-name {
-  font-size: 0.75rem;
+  font-size: var(--hud-font-size-sm);
   color: oklch(0.72 0.14 192 / 0.5);
   font-family: monospace;
 }
@@ -253,7 +253,7 @@ body {
 .settings-tabs {
   display: flex;
   flex-direction: row;
-  gap: 4px;
+  gap: var(--hud-space-xs);
   position: relative;
   z-index: 7;
   border-bottom: 1px solid oklch(0.72 0.14 192 / 0.1);
@@ -265,12 +265,12 @@ body {
   border: none;
   border-bottom: 2px solid transparent;
   color: oklch(0.75 0.02 250 / 0.6);
-  font-size: 0.75rem;
+  font-size: var(--hud-font-size-sm);
   letter-spacing: 0.08em;
   text-transform: uppercase;
-  padding: 8px 16px;
+  padding: var(--hud-space-md) var(--hud-space-xl);
   cursor: pointer;
-  transition: color 180ms ease, border-color 180ms ease, text-shadow 180ms ease;
+  transition: color var(--hud-duration-content) ease, border-color var(--hud-duration-content) ease, text-shadow var(--hud-duration-content) ease;
   font-family: inherit;
 }
 
@@ -302,7 +302,7 @@ body {
 .settings-section {
   display: flex;
   flex-direction: column;
-  gap: 16px;
+  gap: var(--hud-space-xl);
 }
 
 /* ━━ Form Elements ━━ */
@@ -310,8 +310,8 @@ body {
 .settings-label {
   display: flex;
   flex-direction: column;
-  gap: 6px;
-  font-size: 0.8rem;
+  gap: var(--hud-space-sm);
+  font-size: var(--hud-font-size-sm);
   letter-spacing: 0.1em;
   text-transform: uppercase;
   color: oklch(0.72 0.14 192 / 0.7);
@@ -321,12 +321,12 @@ body {
   background: oklch(0.12 0.01 250 / 0.8);
   border: 1px solid oklch(0.72 0.14 192 / 0.2);
   border-radius: 6px;
-  padding: 8px 12px;
+  padding: var(--hud-space-md) var(--hud-space-lg);
   color: oklch(0.92 0.01 250);
-  font-size: 0.85rem;
+  font-size: var(--hud-font-size-base);
   font-family: inherit;
   outline: none;
-  transition: border-color 180ms ease, box-shadow 180ms ease;
+  transition: border-color var(--hud-duration-content) ease, box-shadow var(--hud-duration-content) ease;
 }
 
 .settings-input:focus {
@@ -339,14 +339,14 @@ body {
   background: oklch(0.12 0.01 250 / 0.8);
   border: 1px solid oklch(0.72 0.14 192 / 0.2);
   border-radius: 6px;
-  padding: 8px 12px;
+  padding: var(--hud-space-md) var(--hud-space-lg);
   color: oklch(0.92 0.01 250);
-  font-size: 0.85rem;
+  font-size: var(--hud-font-size-base);
   font-family: inherit;
   outline: none;
   resize: vertical;
   min-height: 60px;
-  transition: border-color 180ms ease, box-shadow 180ms ease;
+  transition: border-color var(--hud-duration-content) ease, box-shadow var(--hud-duration-content) ease;
 }
 
 .settings-textarea:focus {
@@ -365,7 +365,7 @@ body {
 .settings-age-field {
   display: flex;
   flex-direction: column;
-  gap: 6px;
+  gap: var(--hud-space-sm);
 }
 
 .settings-age-legend {
@@ -399,17 +399,17 @@ body {
   display: flex;
   align-items: center;
   justify-content: center;
-  font-size: 0.75rem;
+  font-size: var(--hud-font-size-sm);
   font-weight: 500;
   letter-spacing: 0.08em;
   text-transform: uppercase;
   cursor: pointer;
   border: none;
   background: transparent;
-  padding: 6px 0;
+  padding: var(--hud-space-sm) 0;
   color: oklch(0.58 0.02 250);
-  transition: color 180ms ease, background 180ms ease, text-shadow 180ms ease,
-              border-color 180ms ease;
+  transition: color var(--hud-duration-content) ease, background var(--hud-duration-content) ease, text-shadow var(--hud-duration-content) ease,
+              border-color var(--hud-duration-content) ease;
   border-bottom: 2px solid transparent;
   font-family: inherit;
   outline: none;
@@ -438,8 +438,8 @@ body {
 }
 
 .settings-age-segment:focus-visible {
-  outline: 2px solid oklch(0.72 0.14 192);
-  outline-offset: 2px;
+  outline: var(--hud-focus-ring-width) solid oklch(0.72 0.14 192);
+  outline-offset: var(--hud-focus-offset);
 }
 
 .settings-age-value-area {
@@ -451,8 +451,8 @@ body {
   background: oklch(0.12 0.01 250 / 0.8);
   border: 1px solid oklch(0.72 0.14 192 / 0.2);
   border-radius: 6px;
-  padding: 8px 12px;
-  transition: border-color 200ms ease-out, box-shadow 200ms ease-out;
+  padding: var(--hud-space-md) var(--hud-space-lg);
+  transition: border-color var(--hud-duration-content) ease-out, box-shadow var(--hud-duration-content) ease-out;
 }
 
 .settings-age-value-area[data-mode="unknown"] {
@@ -484,7 +484,7 @@ body {
 }
 
 .settings-age-suffix {
-  font-size: 0.75rem;
+  font-size: var(--hud-font-size-sm);
   color: oklch(0.72 0.14 192 / 0.5);
   margin-left: 2px;
   font-family: monospace;
@@ -537,7 +537,7 @@ body {
   display: flex;
   flex-direction: row;
   align-items: center;
-  gap: 12px;
+  gap: var(--hud-space-lg);
 }
 
 .settings-slider {
@@ -563,7 +563,7 @@ body {
   border: 2px solid oklch(0.72 0.14 192 / 0.5);
   box-shadow: 0 0 8px oklch(0.72 0.14 192 / 0.4);
   cursor: pointer;
-  transition: box-shadow 180ms ease, transform 120ms ease;
+  transition: box-shadow var(--hud-duration-content) ease, transform var(--hud-duration-micro) ease;
 }
 
 .settings-slider::-webkit-slider-thumb:hover {
@@ -603,7 +603,7 @@ body {
 
 .settings-slider-value {
   font-family: monospace;
-  font-size: 0.8rem;
+  font-size: var(--hud-font-size-sm);
   color: oklch(0.72 0.14 192);
   min-width: 3.5em;
   text-align: right;
@@ -635,7 +635,7 @@ body {
   flex-direction: row;
   justify-content: space-between;
   align-items: center;
-  margin-bottom: 6px;
+  margin-bottom: var(--hud-space-sm);
 }
 
 .settings-ocean-label {
@@ -647,7 +647,7 @@ body {
 
 .settings-ocean-value {
   font-family: monospace;
-  font-size: 0.75rem;
+  font-size: var(--hud-font-size-sm);
   color: oklch(0.72 0.14 192);
 }
 
@@ -687,8 +687,8 @@ body {
 .settings-footer {
   display: flex;
   justify-content: flex-end;
-  gap: 8px;
-  padding-top: 8px;
+  gap: var(--hud-space-md);
+  padding-top: var(--hud-space-md);
   position: relative;
   z-index: 7;
 }
@@ -699,14 +699,14 @@ body {
   background: transparent;
   border: 1px solid oklch(0.4 0.02 250 / 0.25);
   border-radius: 6px;
-  padding: 8px 24px;
+  padding: var(--hud-space-md) var(--hud-space-2xl);
   color: oklch(0.75 0.04 250 / 0.75);
-  font-size: 0.8rem;
+  font-size: var(--hud-font-size-sm);
   font-family: inherit;
   letter-spacing: 0.08em;
   text-transform: uppercase;
   cursor: pointer;
-  transition: color 180ms ease, border-color 180ms ease, text-shadow 180ms ease;
+  transition: color var(--hud-duration-content) ease, border-color var(--hud-duration-content) ease, text-shadow var(--hud-duration-content) ease;
 }
 
 .settings-close:hover {
@@ -725,15 +725,15 @@ body {
   background: oklch(0.72 0.14 192 / 0.15);
   border: 1px solid oklch(0.72 0.14 192 / 0.3);
   border-radius: 6px;
-  padding: 8px 24px;
+  padding: var(--hud-space-md) var(--hud-space-2xl);
   color: oklch(0.72 0.14 192);
-  font-size: 0.8rem;
+  font-size: var(--hud-font-size-sm);
   font-family: inherit;
   letter-spacing: 0.08em;
   text-transform: uppercase;
   cursor: pointer;
-  transition: background 180ms ease, border-color 180ms ease, box-shadow 180ms ease,
-              color 180ms ease;
+  transition: background var(--hud-duration-content) ease, border-color var(--hud-duration-content) ease, box-shadow var(--hud-duration-content) ease,
+              color var(--hud-duration-content) ease;
 }
 
 .settings-save:hover {
@@ -774,7 +774,7 @@ body {
 }
 
 .settings-loading-text {
-  font-size: 0.8rem;
+  font-size: var(--hud-font-size-sm);
   letter-spacing: 0.12em;
   text-transform: uppercase;
   color: oklch(0.72 0.14 192 / 0.5);

--- a/mods/menu/ui/src/index.css
+++ b/mods/menu/ui/src/index.css
@@ -97,7 +97,7 @@ body {
   scrollbar-gutter: stable;
   width: var(--menu-w);
   max-width: 340px;
-  padding: 6px 6px 6px 6px !important;
+  padding: var(--hud-space-sm) var(--hud-space-sm) var(--hud-space-sm) var(--hud-space-sm) !important;
   box-shadow: none !important;
   animation: orbital-float 4s ease-in-out infinite;
   animation-delay: 0.8s;
@@ -105,12 +105,12 @@ body {
 
 .menu-hud[data-state="open"] {
   animation:
-    orbital-hud-in 200ms cubic-bezier(0.16, 1, 0.3, 1) both,
+    orbital-hud-in var(--hud-duration-content) cubic-bezier(0.16, 1, 0.3, 1) both,
     orbital-float 4s ease-in-out infinite 0.8s;
 }
 
 .menu-hud[data-state="closed"] {
-  animation: orbital-hud-out 150ms cubic-bezier(0.4, 0, 1, 1) forwards;
+  animation: orbital-hud-out var(--hud-duration-micro) cubic-bezier(0.4, 0, 1, 1) forwards;
 }
 
 /* Noise texture — handled by shared .holo-noise class */
@@ -142,13 +142,13 @@ body {
   display: flex;
   align-items: center;
   justify-content: space-between;
-  padding: 4px 8px 6px;
+  padding: var(--hud-space-xs) var(--hud-space-md) var(--hud-space-sm);
   position: relative;
   z-index: 7;
 }
 
 .menu-status-name {
-  font-size: 12px;
+  font-size: var(--hud-font-size-sm);
   font-weight: 600;
   letter-spacing: 0.02em;
   color: oklch(0.93 0.03 var(--menu-accent-hue));
@@ -163,7 +163,7 @@ body {
 
 .menu-separator {
   height: 1px;
-  margin: 2px 6px 4px;
+  margin: 2px var(--hud-space-sm) var(--hud-space-xs);
   background: linear-gradient(
     90deg,
     transparent,
@@ -199,16 +199,16 @@ body {
   align-items: center;
   justify-content: center;
   min-height: 52px;
-  padding: 8px 10px;
+  padding: var(--hud-space-md) 10px;
   border-radius: 6px;
   border: 1px solid oklch(1 0 0 / 0.14);
   background: oklch(0.13 0.015 var(--menu-accent-hue) / 0.45);
   cursor: pointer;
   transition:
-    border-color 140ms cubic-bezier(0.4, 0, 0.2, 1),
-    background 140ms cubic-bezier(0.4, 0, 0.2, 1),
+    border-color var(--hud-duration-micro) cubic-bezier(0.4, 0, 0.2, 1),
+    background var(--hud-duration-micro) cubic-bezier(0.4, 0, 0.2, 1),
     transform 100ms cubic-bezier(0.4, 0, 0.2, 1),
-    color 140ms cubic-bezier(0.4, 0, 0.2, 1);
+    color var(--hud-duration-micro) cubic-bezier(0.4, 0, 0.2, 1);
 }
 
 .menu-card-label {
@@ -265,7 +265,7 @@ body {
 .menu-card-grid--list .menu-card {
   min-height: 40px;
   justify-content: flex-start;
-  padding: 6px 12px;
+  padding: var(--hud-space-sm) var(--hud-space-lg);
 }
 
 .menu-card-grid--list .menu-card-label {

--- a/mods/settings/ui/src/index.css
+++ b/mods/settings/ui/src/index.css
@@ -74,7 +74,7 @@ body {
   max-height: 100vh;
   display: flex;
   flex-direction: column;
-  gap: 16px;
+  gap: var(--hud-space-xl);
   animation: settings-in 400ms cubic-bezier(0.16, 1, 0.3, 1) both;
   box-sizing: border-box;
 }
@@ -234,7 +234,7 @@ body {
 }
 
 .settings-title {
-  font-size: 0.85rem;
+  font-size: var(--hud-font-size-base);
   letter-spacing: 0.15em;
   text-transform: uppercase;
   color: oklch(0.72 0.14 192 / 0.9);
@@ -260,7 +260,7 @@ body {
 .settings-section {
   display: flex;
   flex-direction: column;
-  gap: 16px;
+  gap: var(--hud-space-xl);
 }
 
 /* ━━ Form Elements ━━ */
@@ -268,8 +268,8 @@ body {
 .settings-label {
   display: flex;
   flex-direction: column;
-  gap: 6px;
-  font-size: 0.8rem;
+  gap: var(--hud-space-sm);
+  font-size: var(--hud-font-size-sm);
   letter-spacing: 0.1em;
   text-transform: uppercase;
   color: oklch(0.72 0.14 192 / 0.7);
@@ -281,7 +281,7 @@ body {
   display: flex;
   flex-direction: row;
   align-items: center;
-  gap: 12px;
+  gap: var(--hud-space-lg);
 }
 
 .settings-slider {
@@ -307,7 +307,7 @@ body {
   border: 2px solid oklch(0.72 0.14 192 / 0.5);
   box-shadow: 0 0 8px oklch(0.72 0.14 192 / 0.4);
   cursor: pointer;
-  transition: box-shadow 180ms ease, transform 120ms ease;
+  transition: box-shadow var(--hud-duration-content) ease, transform var(--hud-duration-micro) ease;
 }
 
 .settings-slider::-webkit-slider-thumb:hover {
@@ -347,7 +347,7 @@ body {
 
 .settings-slider-value {
   font-family: monospace;
-  font-size: 0.8rem;
+  font-size: var(--hud-font-size-sm);
   color: oklch(0.72 0.14 192);
   min-width: 3.5em;
   text-align: right;
@@ -368,8 +368,8 @@ body {
 .settings-footer {
   display: flex;
   justify-content: flex-end;
-  gap: 8px;
-  padding-top: 8px;
+  gap: var(--hud-space-md);
+  padding-top: var(--hud-space-md);
   position: relative;
   z-index: 7;
 }
@@ -380,14 +380,14 @@ body {
   background: transparent;
   border: 1px solid oklch(0.4 0.02 250 / 0.25);
   border-radius: 6px;
-  padding: 8px 24px;
+  padding: var(--hud-space-md) var(--hud-space-2xl);
   color: oklch(0.75 0.04 250 / 0.75);
-  font-size: 0.8rem;
+  font-size: var(--hud-font-size-sm);
   font-family: inherit;
   letter-spacing: 0.08em;
   text-transform: uppercase;
   cursor: pointer;
-  transition: color 180ms ease, border-color 180ms ease, text-shadow 180ms ease;
+  transition: color var(--hud-duration-content) ease, border-color var(--hud-duration-content) ease, text-shadow var(--hud-duration-content) ease;
 }
 
 .settings-close:hover {
@@ -406,15 +406,15 @@ body {
   background: oklch(0.72 0.14 192 / 0.15);
   border: 1px solid oklch(0.72 0.14 192 / 0.3);
   border-radius: 6px;
-  padding: 8px 24px;
+  padding: var(--hud-space-md) var(--hud-space-2xl);
   color: oklch(0.72 0.14 192);
-  font-size: 0.8rem;
+  font-size: var(--hud-font-size-sm);
   font-family: inherit;
   letter-spacing: 0.08em;
   text-transform: uppercase;
   cursor: pointer;
-  transition: background 180ms ease, border-color 180ms ease, box-shadow 180ms ease,
-              color 180ms ease;
+  transition: background var(--hud-duration-content) ease, border-color var(--hud-duration-content) ease, box-shadow var(--hud-duration-content) ease,
+              color var(--hud-duration-content) ease;
 }
 
 .settings-save:hover {
@@ -455,7 +455,7 @@ body {
 }
 
 .settings-loading-text {
-  font-size: 0.8rem;
+  font-size: var(--hud-font-size-sm);
   letter-spacing: 0.12em;
   text-transform: uppercase;
   color: oklch(0.72 0.14 192 / 0.5);

--- a/mods/stt/ui/src/index.css
+++ b/mods/stt/ui/src/index.css
@@ -74,7 +74,7 @@ body {
   max-height: 100vh;
   display: flex;
   flex-direction: column;
-  gap: 16px;
+  gap: var(--hud-space-xl);
   animation: settings-in 400ms cubic-bezier(0.16, 1, 0.3, 1) both;
   box-sizing: border-box;
 }
@@ -234,7 +234,7 @@ body {
 }
 
 .settings-title {
-  font-size: 0.85rem;
+  font-size: var(--hud-font-size-base);
   letter-spacing: 0.15em;
   text-transform: uppercase;
   color: oklch(0.72 0.14 192 / 0.9);
@@ -260,7 +260,7 @@ body {
 .settings-section {
   display: flex;
   flex-direction: column;
-  gap: 16px;
+  gap: var(--hud-space-xl);
 }
 
 /* ━━ Form Elements ━━ */
@@ -268,8 +268,8 @@ body {
 .settings-label {
   display: flex;
   flex-direction: column;
-  gap: 6px;
-  font-size: 0.8rem;
+  gap: var(--hud-space-sm);
+  font-size: var(--hud-font-size-sm);
   letter-spacing: 0.1em;
   text-transform: uppercase;
   color: oklch(0.72 0.14 192 / 0.7);
@@ -280,8 +280,8 @@ body {
 .settings-footer {
   display: flex;
   justify-content: flex-end;
-  gap: 8px;
-  padding-top: 8px;
+  gap: var(--hud-space-md);
+  padding-top: var(--hud-space-md);
   position: relative;
   z-index: 7;
 }
@@ -292,14 +292,14 @@ body {
   background: transparent;
   border: 1px solid oklch(0.4 0.02 250 / 0.25);
   border-radius: 6px;
-  padding: 8px 24px;
+  padding: var(--hud-space-md) var(--hud-space-2xl);
   color: oklch(0.75 0.04 250 / 0.75);
-  font-size: 0.8rem;
+  font-size: var(--hud-font-size-sm);
   font-family: inherit;
   letter-spacing: 0.08em;
   text-transform: uppercase;
   cursor: pointer;
-  transition: color 180ms ease, border-color 180ms ease, text-shadow 180ms ease;
+  transition: color var(--hud-duration-content) ease, border-color var(--hud-duration-content) ease, text-shadow var(--hud-duration-content) ease;
 }
 
 .settings-close:hover {
@@ -322,7 +322,7 @@ body {
 }
 
 .settings-loading-text {
-  font-size: 0.8rem;
+  font-size: var(--hud-font-size-sm);
   letter-spacing: 0.12em;
   text-transform: uppercase;
   color: oklch(0.72 0.14 192 / 0.5);
@@ -334,8 +334,8 @@ body {
 .stt-section-divider {
   display: flex;
   align-items: center;
-  gap: 8px;
-  margin-top: 4px;
+  gap: var(--hud-space-md);
+  margin-top: var(--hud-space-xs);
 }
 
 .stt-section-divider__label {
@@ -360,17 +360,17 @@ body {
 .stt-models-grid {
   display: grid;
   grid-template-columns: 1fr 1fr;
-  gap: 8px;
+  gap: var(--hud-space-md);
 }
 
 .stt-model-card {
   background: oklch(0.18 0.01 250 / 0.6);
   border: 1px solid oklch(0.4 0.02 250 / 0.25);
   border-radius: 8px;
-  padding: 12px;
+  padding: var(--hud-space-lg);
   display: flex;
   flex-direction: column;
-  gap: 6px;
+  gap: var(--hud-space-sm);
   text-align: left;
   font-family: inherit;
 }
@@ -406,14 +406,14 @@ body {
   background: oklch(0.72 0.14 192 / 0.1);
   border: 1px solid oklch(0.72 0.14 192 / 0.25);
   border-radius: 4px;
-  padding: 4px 8px;
+  padding: var(--hud-space-xs) var(--hud-space-md);
   color: oklch(0.72 0.14 192);
   font-size: 0.7rem;
   letter-spacing: 0.06em;
   text-transform: uppercase;
   cursor: pointer;
   font-family: inherit;
-  transition: background 180ms ease, border-color 180ms ease;
+  transition: background var(--hud-duration-content) ease, border-color var(--hud-duration-content) ease;
   display: inline-block;
 }
 
@@ -438,16 +438,16 @@ body {
     oklch(0.65 0.18 285)
   );
   border-radius: 2px;
-  transition: width 200ms ease;
+  transition: width var(--hud-duration-content) ease;
 }
 
 .stt-model-card__cancel {
   background: transparent;
   border: none;
   color: oklch(0.55 0.02 250 / 0.5);
-  font-size: 0.75rem;
+  font-size: var(--hud-font-size-sm);
   cursor: pointer;
-  padding: 2px 4px;
+  padding: 2px var(--hud-space-xs);
 }
 
 .stt-model-card__cancel:hover {
@@ -459,7 +459,7 @@ body {
 .stt-error {
   font-size: 0.7rem;
   color: oklch(0.7 0.18 25 / 0.8);
-  padding: 6px 0;
+  padding: var(--hud-space-sm) 0;
   letter-spacing: 0.04em;
 }
 

--- a/mods/voicevox/ui/src/index.css
+++ b/mods/voicevox/ui/src/index.css
@@ -74,7 +74,7 @@ body {
   max-height: 100vh;
   display: flex;
   flex-direction: column;
-  gap: 16px;
+  gap: var(--hud-space-xl);
   animation: settings-in 400ms cubic-bezier(0.16, 1, 0.3, 1) both;
   box-sizing: border-box;
 }
@@ -234,7 +234,7 @@ body {
 }
 
 .settings-title {
-  font-size: 0.85rem;
+  font-size: var(--hud-font-size-base);
   letter-spacing: 0.15em;
   text-transform: uppercase;
   color: oklch(0.72 0.14 192 / 0.9);
@@ -243,7 +243,7 @@ body {
 }
 
 .settings-entity-name {
-  font-size: 0.75rem;
+  font-size: var(--hud-font-size-sm);
   color: oklch(0.72 0.14 192 / 0.5);
   font-family: monospace;
 }
@@ -253,7 +253,7 @@ body {
 .settings-tabs {
   display: flex;
   flex-direction: row;
-  gap: 4px;
+  gap: var(--hud-space-xs);
   position: relative;
   z-index: 7;
   border-bottom: 1px solid oklch(0.72 0.14 192 / 0.1);
@@ -265,12 +265,12 @@ body {
   border: none;
   border-bottom: 2px solid transparent;
   color: oklch(0.75 0.02 250 / 0.6);
-  font-size: 0.75rem;
+  font-size: var(--hud-font-size-sm);
   letter-spacing: 0.08em;
   text-transform: uppercase;
-  padding: 8px 16px;
+  padding: var(--hud-space-md) var(--hud-space-xl);
   cursor: pointer;
-  transition: color 180ms ease, border-color 180ms ease, text-shadow 180ms ease;
+  transition: color var(--hud-duration-content) ease, border-color var(--hud-duration-content) ease, text-shadow var(--hud-duration-content) ease;
   font-family: inherit;
 }
 
@@ -302,7 +302,7 @@ body {
 .settings-section {
   display: flex;
   flex-direction: column;
-  gap: 16px;
+  gap: var(--hud-space-xl);
 }
 
 /* ━━ Form Elements ━━ */
@@ -310,8 +310,8 @@ body {
 .settings-label {
   display: flex;
   flex-direction: column;
-  gap: 6px;
-  font-size: 0.8rem;
+  gap: var(--hud-space-sm);
+  font-size: var(--hud-font-size-sm);
   letter-spacing: 0.1em;
   text-transform: uppercase;
   color: oklch(0.72 0.14 192 / 0.7);
@@ -321,12 +321,12 @@ body {
   background: oklch(0.12 0.01 250 / 0.8);
   border: 1px solid oklch(0.72 0.14 192 / 0.2);
   border-radius: 6px;
-  padding: 8px 12px;
+  padding: var(--hud-space-md) var(--hud-space-lg);
   color: oklch(0.92 0.01 250);
-  font-size: 0.85rem;
+  font-size: var(--hud-font-size-base);
   font-family: inherit;
   outline: none;
-  transition: border-color 180ms ease, box-shadow 180ms ease;
+  transition: border-color var(--hud-duration-content) ease, box-shadow var(--hud-duration-content) ease;
 }
 
 .settings-input:focus {
@@ -339,14 +339,14 @@ body {
   background: oklch(0.12 0.01 250 / 0.8);
   border: 1px solid oklch(0.72 0.14 192 / 0.2);
   border-radius: 6px;
-  padding: 8px 12px;
+  padding: var(--hud-space-md) var(--hud-space-lg);
   color: oklch(0.92 0.01 250);
-  font-size: 0.85rem;
+  font-size: var(--hud-font-size-base);
   font-family: inherit;
   outline: none;
   resize: vertical;
   min-height: 60px;
-  transition: border-color 180ms ease, box-shadow 180ms ease;
+  transition: border-color var(--hud-duration-content) ease, box-shadow var(--hud-duration-content) ease;
 }
 
 .settings-textarea:focus {
@@ -366,7 +366,7 @@ body {
   display: flex;
   flex-direction: row;
   align-items: center;
-  gap: 12px;
+  gap: var(--hud-space-lg);
 }
 
 .settings-slider {
@@ -392,7 +392,7 @@ body {
   border: 2px solid oklch(0.72 0.14 192 / 0.5);
   box-shadow: 0 0 8px oklch(0.72 0.14 192 / 0.4);
   cursor: pointer;
-  transition: box-shadow 180ms ease, transform 120ms ease;
+  transition: box-shadow var(--hud-duration-content) ease, transform var(--hud-duration-micro) ease;
 }
 
 .settings-slider::-webkit-slider-thumb:hover {
@@ -432,7 +432,7 @@ body {
 
 .settings-slider-value {
   font-family: monospace;
-  font-size: 0.8rem;
+  font-size: var(--hud-font-size-sm);
   color: oklch(0.72 0.14 192);
   min-width: 3.5em;
   text-align: right;
@@ -476,7 +476,7 @@ body {
 
 .settings-ocean-value {
   font-family: monospace;
-  font-size: 0.75rem;
+  font-size: var(--hud-font-size-sm);
   color: oklch(0.72 0.14 192);
 }
 
@@ -516,8 +516,8 @@ body {
 .settings-footer {
   display: flex;
   justify-content: flex-end;
-  gap: 8px;
-  padding-top: 8px;
+  gap: var(--hud-space-md);
+  padding-top: var(--hud-space-md);
   position: relative;
   z-index: 7;
 }
@@ -528,14 +528,14 @@ body {
   background: transparent;
   border: 1px solid oklch(0.4 0.02 250 / 0.25);
   border-radius: 6px;
-  padding: 8px 24px;
+  padding: var(--hud-space-md) var(--hud-space-2xl);
   color: oklch(0.75 0.04 250 / 0.75);
-  font-size: 0.8rem;
+  font-size: var(--hud-font-size-sm);
   font-family: inherit;
   letter-spacing: 0.08em;
   text-transform: uppercase;
   cursor: pointer;
-  transition: color 180ms ease, border-color 180ms ease, text-shadow 180ms ease;
+  transition: color var(--hud-duration-content) ease, border-color var(--hud-duration-content) ease, text-shadow var(--hud-duration-content) ease;
 }
 
 .settings-close:hover {
@@ -554,15 +554,15 @@ body {
   background: oklch(0.72 0.14 192 / 0.15);
   border: 1px solid oklch(0.72 0.14 192 / 0.3);
   border-radius: 6px;
-  padding: 8px 24px;
+  padding: var(--hud-space-md) var(--hud-space-2xl);
   color: oklch(0.72 0.14 192);
-  font-size: 0.8rem;
+  font-size: var(--hud-font-size-sm);
   font-family: inherit;
   letter-spacing: 0.08em;
   text-transform: uppercase;
   cursor: pointer;
-  transition: background 180ms ease, border-color 180ms ease, box-shadow 180ms ease,
-              color 180ms ease;
+  transition: background var(--hud-duration-content) ease, border-color var(--hud-duration-content) ease, box-shadow var(--hud-duration-content) ease,
+              color var(--hud-duration-content) ease;
 }
 
 .settings-save:hover {
@@ -603,7 +603,7 @@ body {
 }
 
 .settings-loading-text {
-  font-size: 0.8rem;
+  font-size: var(--hud-font-size-sm);
   letter-spacing: 0.12em;
   text-transform: uppercase;
   color: oklch(0.72 0.14 192 / 0.5);
@@ -642,9 +642,9 @@ body {
 .voicevox-status {
   display: inline-flex;
   align-items: center;
-  gap: 6px;
+  gap: var(--hud-space-sm);
   padding: 3px 10px;
-  font-size: 11px;
+  font-size: var(--hud-font-size-xs);
   border-radius: 20px;
   margin-left: auto;
 }
@@ -678,13 +678,13 @@ body {
 }
 
 .voicevox-param-desc {
-  font-size: 11px;
+  font-size: var(--hud-font-size-xs);
   color: oklch(0.72 0.14 192 / 0.4);
   margin-top: 2px;
 }
 
 .voicevox-section-title {
-  font-size: 12px;
+  font-size: var(--hud-font-size-sm);
   font-weight: 500;
   color: oklch(0.72 0.14 192 / 0.5);
   letter-spacing: 0.06em;
@@ -695,7 +695,7 @@ body {
 .voicevox-divider {
   height: 1px;
   background: oklch(0.72 0.14 192 / 0.1);
-  margin: 4px 0;
+  margin: var(--hud-space-xs) 0;
 }
 
 .voicevox-error {
@@ -703,18 +703,18 @@ body {
   flex-direction: column;
   align-items: center;
   justify-content: center;
-  gap: 16px;
-  padding: 40px 24px;
+  gap: var(--hud-space-xl);
+  padding: 40px var(--hud-space-2xl);
   text-align: center;
 }
 
 .voicevox-error-text {
-  font-size: 14px;
+  font-size: var(--hud-font-size-base);
   color: oklch(0.7 0.16 350 / 0.8);
 }
 
 .voicevox-error-retry {
-  padding: 8px 20px;
+  padding: var(--hud-space-md) 20px;
   font-size: 13px;
   font-weight: 500;
   border-radius: 6px;
@@ -722,7 +722,7 @@ body {
   color: oklch(0.72 0.14 192);
   border: 1px solid oklch(0.72 0.14 192 / 0.3);
   cursor: pointer;
-  transition: all 180ms ease;
+  transition: all var(--hud-duration-content) ease;
   position: relative;
   z-index: 7;
 }
@@ -732,8 +732,8 @@ body {
 }
 
 .voicevox-warning {
-  padding: 8px 12px;
-  font-size: 12px;
+  padding: var(--hud-space-md) var(--hud-space-lg);
+  font-size: var(--hud-font-size-sm);
   color: oklch(0.8 0.14 80 / 0.8);
   background: oklch(0.8 0.14 80 / 0.08);
   border: 1px solid oklch(0.8 0.14 80 / 0.2);

--- a/packages/ui/src/index.css
+++ b/packages/ui/src/index.css
@@ -183,6 +183,70 @@
   --fx-active-burst: var(--shadow-holo-intense);
   --fx-border-gradient: linear-gradient(135deg, var(--holo-cyan), oklch(from var(--holo-cyan) calc(l - 0.05) c h), var(--holo-cyan));
   --fx-text-glow: 0 0 8px var(--holo-cyan);
+
+  /* Precision Hologram — Text hierarchy */
+  --hud-text-primary: oklch(0.92 0 0);
+  --hud-text-secondary: oklch(0.80 0.02 250);
+  --hud-text-tertiary: oklch(0.73 0.02 250);
+  --hud-text-muted: oklch(0.58 0.02 250);
+  --hud-text-placeholder: oklch(0.65 0.03 250);
+
+  /* Precision Hologram — Semantic status */
+  --hud-status-error: oklch(0.78 0.14 15);
+  --hud-status-success: oklch(0.78 0.14 155);
+  --hud-status-warning: oklch(0.78 0.14 75);
+  --hud-status-info: oklch(0.78 0.14 192);
+  --hud-status-accent: oklch(0.78 0.14 30);
+
+  /* Precision Hologram — Surfaces (solid inner layers) */
+  --hud-surface-base: oklch(0.13 0.015 250 / 0.93);
+  --hud-surface-raised: oklch(0.15 0.015 250);
+  --hud-surface-input: oklch(0.14 0.018 250);
+  --hud-surface-dialog: oklch(0.11 0.015 250);
+  --hud-surface-user: oklch(0.16 0.03 30);
+
+  /* Precision Hologram — Borders */
+  --hud-border-decorative: oklch(0.72 0.14 192 / 0.18);
+  --hud-border-interactive: oklch(0.72 0.14 192 / 0.38);
+  --hud-border-hover: oklch(0.72 0.14 192 / 0.55);
+  --hud-border-focus: oklch(0.78 0.16 192 / 0.55);
+
+  /* Precision Hologram — Typography */
+  --hud-font-size-xs: 0.6875rem;
+  --hud-font-size-sm: 0.75rem;
+  --hud-font-size-base: 0.875rem;
+  --hud-line-height-tight: 1.3;
+  --hud-line-height-normal: 1.5;
+
+  /* Precision Hologram — Spacing (4px base) */
+  --hud-space-unit: 4px;
+  --hud-space-xs: 4px;
+  --hud-space-sm: 6px;
+  --hud-space-md: 8px;
+  --hud-space-lg: 12px;
+  --hud-space-xl: 16px;
+  --hud-space-2xl: 24px;
+
+  /* Precision Hologram — Motion */
+  --hud-duration-entry: 280ms;
+  --hud-easing-entry: cubic-bezier(0.16, 1, 0.3, 1);
+  --hud-duration-micro: 150ms;
+  --hud-easing-micro: ease-out;
+  --hud-duration-layout: 280ms;
+  --hud-easing-layout: cubic-bezier(0.16, 1, 0.3, 1);
+  --hud-duration-content: 200ms;
+  --hud-easing-content: ease-in-out;
+
+  /* Precision Hologram — Elevation */
+  --hud-shadow-glow-sm: 0 0 4px oklch(0.72 0.14 192 / 0.15);
+  --hud-shadow-glow-md: 0 0 8px oklch(0.72 0.14 192 / 0.2);
+  --hud-shadow-glow-lg: 0 0 12px oklch(0.72 0.14 192 / 0.3);
+
+  /* Precision Hologram — Focus */
+  --hud-focus-offset: 2px;
+  --hud-focus-ring-width: 2px;
+  --hud-focus-ring-color: oklch(0.78 0.16 192 / 0.55);
+  --hud-focus-glow: 0 0 6px oklch(0.72 0.14 192 / 0.35);
 }
 
 /* ━━ Keyframes ━━ */
@@ -416,6 +480,13 @@
     --animate-holo-color-shift: none;
   }
 
+  .dark {
+    --hud-duration-entry: 0ms;
+    --hud-duration-micro: 0ms;
+    --hud-duration-layout: 0ms;
+    --hud-duration-content: 0ms;
+  }
+
   .holo-shimmer::after {
     animation: none !important;
   }
@@ -430,5 +501,13 @@
     animation-duration: 0.01ms !important;
     animation-iteration-count: 1 !important;
     transition-duration: 0.01ms !important;
+  }
+}
+
+@media (prefers-contrast: more) {
+  .dark {
+    --hud-text-tertiary: oklch(0.82 0.02 250);
+    --hud-text-placeholder: oklch(0.78 0.03 250);
+    --hud-border-interactive: oklch(0.85 0.14 192 / 0.7);
   }
 }


### PR DESCRIPTION
## Problem

Each mod UI (settings, menu, character-settings, agent) independently hardcodes OKLCH color values, spacing, and motion parameters with no shared design token system. This makes it difficult to maintain visual consistency, verify WCAG AA compliance, and evolve the design language across the application.

## Solution

Add 46 `--hud-*` CSS custom properties to `@hmcs/ui`'s dark mode block, establishing a shared "Precision Hologram" design token system. This provides a single source of truth for:

- **Text hierarchy**: 5 tiers (primary/secondary/tertiary/muted/placeholder) with verified WCAG AA contrast ratios
- **Semantic status colors**: error/success/warning/info/accent at L≥0.78
- **Surface layers**: base/raised/input/dialog/user — solid inner surfaces eliminating opacity stacking
- **Border states**: decorative/interactive/hover/focus with WCAG 1.4.11 compliance
- **Typography**: 3-step font scale (xs/sm/base) + line heights
- **Spacing**: 4px base unit with 6 modular steps
- **Motion**: 4 categories with easings
- **Elevation**: 3-tier glow system
- **Focus ring**: offset gap + holographic glow

Includes `prefers-reduced-motion` (zero durations) and `prefers-contrast: more` (raised values) media query overrides.

**Affected area**: `packages/ui/` only. No mod UIs are modified in this PR — they can incrementally adopt the tokens in follow-up PRs.

## Documentation

- [ ] Included in this PR
- [ ] Will be added in a follow-up PR
- [x] Not needed

---

- [ ] If HTTP endpoints changed: I ran `make gen-open-api` and `pnpm build`
- [ ] This PR includes breaking changes