### PR TITLE
feat(tray): add position field for tray menu ordering

### DIFF
--- a/engine/crates/homunculus_tray/src/lib.rs
+++ b/engine/crates/homunculus_tray/src/lib.rs
@@ -407,10 +407,18 @@ mod tests {
 
         assert_eq!(
             texts,
-            vec!["@hmcs/settings", "@hmcs/agent", "@hmcs/voicevox", "@hmcs/app-exit"]
+            vec![
+                "@hmcs/settings",
+                "@hmcs/agent",
+                "@hmcs/voicevox",
+                "@hmcs/app-exit"
+            ]
         );
 
-        let separator_count = menu.iter().filter(|item| matches!(item, MenuItem::Separator)).count();
+        let separator_count = menu
+            .iter()
+            .filter(|item| matches!(item, MenuItem::Separator))
+            .count();
         assert_eq!(separator_count, 2);
     }
 
@@ -446,7 +454,10 @@ mod tests {
 
         let (menu, _) = build_menu(&mod_registry);
 
-        let separator_count = menu.iter().filter(|item| matches!(item, MenuItem::Separator)).count();
+        let separator_count = menu
+            .iter()
+            .filter(|item| matches!(item, MenuItem::Separator))
+            .count();
         assert_eq!(separator_count, 1);
 
         let texts: Vec<&str> = menu

--- a/engine/crates/homunculus_tray/src/lib.rs
+++ b/engine/crates/homunculus_tray/src/lib.rs
@@ -195,10 +195,10 @@ fn build_grouped_menu_items(
     let mut last_group: Option<u8> = None;
 
     for (group, mod_name, tray_item) in entries {
-        if let Some(prev) = last_group {
-            if *group != prev {
-                menu_items.push(MenuItem::separator());
-            }
+        if let Some(prev) = last_group
+            && *group != prev
+        {
+            menu_items.push(MenuItem::separator());
         }
         last_group = Some(*group);
 

--- a/engine/crates/homunculus_tray/src/lib.rs
+++ b/engine/crates/homunculus_tray/src/lib.rs
@@ -196,6 +196,7 @@ mod tests {
             text: "Settings".to_string(),
             command: Some("open-ui".to_string()),
             items: None,
+            position: None,
         };
         registry.register_item("my-mod", &item);
 
@@ -219,14 +220,17 @@ mod tests {
                     text: "Tool A".to_string(),
                     command: Some("run-a".to_string()),
                     items: None,
+                    position: None,
                 },
                 TrayMenuItem {
                     id: "tool-b".to_string(),
                     text: "Tool B".to_string(),
                     command: Some("run-b".to_string()),
                     items: None,
+                    position: None,
                 },
             ]),
+            position: None,
         };
         registry.register_item("my-mod", &item);
 
@@ -256,6 +260,7 @@ mod tests {
             text: "Open".to_string(),
             command: Some("do-open".to_string()),
             items: None,
+            position: None,
         };
         let bevy_item = to_bevy_menu_item("test-mod", &item);
         match bevy_item {
@@ -281,7 +286,9 @@ mod tests {
                 text: "Child".to_string(),
                 command: Some("run-child".to_string()),
                 items: None,
+                position: None,
             }]),
+            position: None,
         };
         let bevy_item = to_bevy_menu_item("test-mod", &item);
         match bevy_item {

--- a/engine/crates/homunculus_tray/src/lib.rs
+++ b/engine/crates/homunculus_tray/src/lib.rs
@@ -140,29 +140,73 @@ async fn execute_command(mods_dir: PathBuf, command: String) {
     }
 }
 
+/// Resolve the tray position string to a sort-order group index.
+///
+/// Returns 0 for `"top"`, 1 for `"middle"` (default), 2 for `"bottom"`.
+/// Unknown values are treated as `"middle"` with a warning log.
+fn resolve_position(position: Option<&str>, mod_name: &str) -> u8 {
+    match position {
+        Some("top") => 0,
+        Some("bottom") => 2,
+        Some("middle") | None => 1,
+        Some(unknown) => {
+            tracing::warn!(
+                "MOD {mod_name}: unknown tray position \"{unknown}\", falling back to \"middle\""
+            );
+            1
+        }
+    }
+}
+
 /// Build the tray menu and registry from all mods in the `ModRegistry`.
 ///
-/// Each mod that declares a `tray` field contributes one top-level item
-/// (or submenu). Mods are separated by `MenuItem::Separator`.
+/// Items are grouped by position (`top` → `middle` → `bottom`) and sorted
+/// alphabetically by mod name within each group. Groups are separated by
+/// `MenuItem::Separator`.
 fn build_menu(mod_registry: &ModRegistry) -> (Menu, TrayMenuRegistry) {
-    let mut menu_items: Vec<MenuItem> = Vec::new();
     let mut registry = TrayMenuRegistry::default();
-    let mut first = true;
-    for mod_info in mod_registry.all() {
-        let Some(ref tray_item) = mod_info.tray else {
-            continue;
-        };
 
-        if !first {
-            menu_items.push(MenuItem::separator());
+    let mut entries = collect_tray_entries(mod_registry);
+    entries.sort_by(|a, b| a.0.cmp(&b.0).then_with(|| a.1.cmp(&b.1)));
+
+    let menu_items = build_grouped_menu_items(&entries, &mut registry);
+    (Menu::new(menu_items), registry)
+}
+
+/// Collect (position_key, mod_name, tray_item) tuples from all mods.
+fn collect_tray_entries(mod_registry: &ModRegistry) -> Vec<(u8, String, TrayMenuItem)> {
+    mod_registry
+        .all()
+        .iter()
+        .filter_map(|mod_info| {
+            let tray_item = mod_info.tray.as_ref()?;
+            let pos = resolve_position(tray_item.position.as_deref(), &mod_info.name);
+            Some((pos, mod_info.name.clone(), tray_item.clone()))
+        })
+        .collect()
+}
+
+/// Build the flat `Vec<MenuItem>` with separators between position groups.
+fn build_grouped_menu_items(
+    entries: &[(u8, String, TrayMenuItem)],
+    registry: &mut TrayMenuRegistry,
+) -> Vec<MenuItem> {
+    let mut menu_items: Vec<MenuItem> = Vec::new();
+    let mut last_group: Option<u8> = None;
+
+    for (group, mod_name, tray_item) in entries {
+        if let Some(prev) = last_group {
+            if *group != prev {
+                menu_items.push(MenuItem::separator());
+            }
         }
-        first = false;
+        last_group = Some(*group);
 
-        menu_items.push(to_bevy_menu_item(&mod_info.name, tray_item));
-        registry.register_item(&mod_info.name, tray_item);
+        menu_items.push(to_bevy_menu_item(mod_name, tray_item));
+        registry.register_item(mod_name, tray_item);
     }
 
-    (Menu::new(menu_items), registry)
+    menu_items
 }
 
 /// Convert a `TrayMenuItem` to a `bevy_tray_icon` `MenuItem`.
@@ -312,5 +356,106 @@ mod tests {
             }
             other => panic!("expected SubMenu, got {other:?}"),
         }
+    }
+
+    #[test]
+    fn build_menu_orders_by_position_then_mod_name() {
+        use homunculus_core::prelude::ModInfo;
+        use std::collections::HashMap;
+        use std::path::PathBuf;
+
+        let mut mod_registry = ModRegistry::default();
+
+        let mods = vec![
+            ("@hmcs/voicevox", Some("middle")),
+            ("@hmcs/app-exit", Some("bottom")),
+            ("@hmcs/settings", Some("top")),
+            ("@hmcs/agent", None),
+        ];
+        for (name, position) in mods {
+            mod_registry.register(ModInfo {
+                name: name.to_string(),
+                version: "0.1.0".to_string(),
+                description: None,
+                author: None,
+                license: None,
+                service_script_path: None,
+                commands: vec![],
+                assets: HashMap::new(),
+                menus: vec![],
+                tray: Some(TrayMenuItem {
+                    id: format!("{name}-tray"),
+                    text: name.to_string(),
+                    command: Some(format!("{name}-cmd")),
+                    items: None,
+                    position: position.map(|s| s.to_string()),
+                }),
+                mod_dir: PathBuf::from("/tmp"),
+            });
+        }
+
+        let (menu, _registry) = build_menu(&mod_registry);
+
+        let texts: Vec<&str> = menu
+            .iter()
+            .filter_map(|item| match item {
+                MenuItem::Common { text, .. } => Some(text.as_str()),
+                MenuItem::SubMenu { text, .. } => Some(text.as_str()),
+                _ => None,
+            })
+            .collect();
+
+        assert_eq!(
+            texts,
+            vec!["@hmcs/settings", "@hmcs/agent", "@hmcs/voicevox", "@hmcs/app-exit"]
+        );
+
+        let separator_count = menu.iter().filter(|item| matches!(item, MenuItem::Separator)).count();
+        assert_eq!(separator_count, 2);
+    }
+
+    #[test]
+    fn build_menu_skips_separator_for_empty_groups() {
+        use homunculus_core::prelude::ModInfo;
+        use std::collections::HashMap;
+        use std::path::PathBuf;
+
+        let mut mod_registry = ModRegistry::default();
+
+        for (name, position) in [("@hmcs/settings", "top"), ("@hmcs/app-exit", "bottom")] {
+            mod_registry.register(ModInfo {
+                name: name.to_string(),
+                version: "0.1.0".to_string(),
+                description: None,
+                author: None,
+                license: None,
+                service_script_path: None,
+                commands: vec![],
+                assets: HashMap::new(),
+                menus: vec![],
+                tray: Some(TrayMenuItem {
+                    id: format!("{name}-tray"),
+                    text: name.to_string(),
+                    command: Some(format!("{name}-cmd")),
+                    items: None,
+                    position: Some(position.to_string()),
+                }),
+                mod_dir: PathBuf::from("/tmp"),
+            });
+        }
+
+        let (menu, _) = build_menu(&mod_registry);
+
+        let separator_count = menu.iter().filter(|item| matches!(item, MenuItem::Separator)).count();
+        assert_eq!(separator_count, 1);
+
+        let texts: Vec<&str> = menu
+            .iter()
+            .filter_map(|item| match item {
+                MenuItem::Common { text, .. } => Some(text.as_str()),
+                _ => None,
+            })
+            .collect();
+        assert_eq!(texts, vec!["@hmcs/settings", "@hmcs/app-exit"]);
     }
 }

--- a/engine/crates/homunculus_utils/src/schema/mods.rs
+++ b/engine/crates/homunculus_utils/src/schema/mods.rs
@@ -137,7 +137,8 @@ mod tests {
 
     #[test]
     fn deserialize_tray_item_with_position() {
-        let json = r#"{"id":"open-settings","text":"Settings","command":"open-ui","position":"top"}"#;
+        let json =
+            r#"{"id":"open-settings","text":"Settings","command":"open-ui","position":"top"}"#;
         let item: TrayMenuItem = serde_json::from_str(json).unwrap();
         assert_eq!(item.position, Some("top".to_string()));
     }

--- a/engine/crates/homunculus_utils/src/schema/mods.rs
+++ b/engine/crates/homunculus_utils/src/schema/mods.rs
@@ -88,6 +88,10 @@ pub struct TrayMenuItem {
     pub command: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub items: Option<Vec<TrayMenuItem>>,
+    /// Display position in the tray menu: `"top"`, `"middle"`, or `"bottom"`.
+    /// Defaults to `"middle"` when omitted or invalid.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub position: Option<String>,
 }
 
 #[cfg(test)]
@@ -129,5 +133,26 @@ mod tests {
         let json = r#"{}"#;
         let manifest: ModManifest = serde_json::from_str(json).unwrap();
         assert!(manifest.tray.is_none());
+    }
+
+    #[test]
+    fn deserialize_tray_item_with_position() {
+        let json = r#"{"id":"open-settings","text":"Settings","command":"open-ui","position":"top"}"#;
+        let item: TrayMenuItem = serde_json::from_str(json).unwrap();
+        assert_eq!(item.position, Some("top".to_string()));
+    }
+
+    #[test]
+    fn deserialize_tray_item_without_position() {
+        let json = r#"{"id":"x","text":"X","command":"do-x"}"#;
+        let item: TrayMenuItem = serde_json::from_str(json).unwrap();
+        assert_eq!(item.position, None);
+    }
+
+    #[test]
+    fn deserialize_tray_item_with_unknown_position() {
+        let json = r#"{"id":"x","text":"X","command":"do-x","position":"invalid"}"#;
+        let item: TrayMenuItem = serde_json::from_str(json).unwrap();
+        assert_eq!(item.position, Some("invalid".to_string()));
     }
 }

--- a/mods/app-exit/package.json
+++ b/mods/app-exit/package.json
@@ -10,7 +10,8 @@
     "tray": {
       "id": "exit-app",
       "text": "Exit",
-      "command": "app-exit"
+      "command": "app-exit",
+      "position": "bottom"
     }
   },
   "bin": {

--- a/mods/settings/package.json
+++ b/mods/settings/package.json
@@ -13,7 +13,8 @@
     "tray": {
       "id": "open-settings",
       "text": "Settings",
-      "command": "settings-open-ui"
+      "command": "settings-open-ui",
+      "position": "top"
     },
     "assets": {
       "settings:ui": {


### PR DESCRIPTION
## Problem

The tray menu item order currently depends on `pnpm ls` output (dependency/installation order), giving MOD developers no control over where their items appear. This can result in "Exit" appearing above "Settings" or items shifting position when mods are reinstalled.

## Solution

Add a `position` field (`"top"` / `"middle"` / `"bottom"`) to `TrayMenuItem` in `package.json`, allowing MOD developers to declare where their tray item should appear.

**Engine changes:**
- `homunculus_utils`: Added `position: Option<String>` to `TrayMenuItem` schema with serde default
- `homunculus_tray`: Rewrote `build_menu()` to group items by position (top → middle → bottom) with separators between groups. Items within the same group are sorted alphabetically by mod name for deterministic ordering. Invalid position values fall back to `"middle"` with a warning log.

**MOD changes:**
- `@hmcs/settings`: Set `"position": "top"`
- `@hmcs/app-exit`: Set `"position": "bottom"`

## Documentation

- [ ] Included in this PR
- [x] Will be added in a follow-up PR
- [ ] Not needed

---

- [ ] If HTTP endpoints changed: I ran `make gen-open-api` and `pnpm build`
- [ ] This PR includes breaking changes