### PR TITLE
feat(agent): add session log persistence and restoration per persona and git branch

### DIFF
--- a/mods/agent/lib/claude-agent-runtime.ts
+++ b/mods/agent/lib/claude-agent-runtime.ts
@@ -8,8 +8,7 @@ import type {
 } from "@anthropic-ai/claude-agent-sdk";
 import type { AgentRuntime, AgentEvent, AgentResponse } from "./agent-runtime.ts";
 import { AsyncQueue, Deferred } from "./async-queue.ts";
-import type { AgentSettings, Persona } from "./types.ts";
-import { buildCharacterPrompt, type WorktreeContext } from "./prompt.ts";
+import type { AgentSettings } from "./types.ts";
 
 /** Item enqueued by canUseTool; awaited by mergeStreams. */
 interface PermissionQueueItem {
@@ -37,11 +36,10 @@ type RaceResult =
  */
 export class ClaudeAgentRuntime implements AgentRuntime {
   constructor(
-    private readonly persona: Persona,
+    private readonly prompt: string,
     private readonly settings: AgentSettings,
     private readonly apiKey: string,
     private readonly workDir: string,
-    private readonly worktree?: WorktreeContext,
   ) {}
 
   async *execute(
@@ -51,7 +49,7 @@ export class ClaudeAgentRuntime implements AgentRuntime {
   ): AsyncGenerator<AgentEvent, void, AgentResponse | undefined> {
     const permQueue = new AsyncQueue<PermissionQueueItem>();
     const canUseTool = createCanUseToolHandler(permQueue);
-    const options = buildQueryOptions(this.persona, this.settings, this.apiKey, this.workDir, sessionId, canUseTool, this.worktree);
+    const options = buildQueryOptions(this.prompt, this.settings, this.apiKey, this.workDir, sessionId, canUseTool);
     const handle = query({ prompt: text, options });
 
     const onAbort = () => handle.close();
@@ -221,16 +219,15 @@ function mapResultMessage(msg: { subtype: string; session_id: string; is_error: 
 
 /** Constructs the SDK Options for a query call. */
 function buildQueryOptions(
-  persona: Persona,
+  prompt: string,
   settings: AgentSettings,
   apiKey: string,
   workDir: string,
   sessionId: string | null,
   canUseTool: Options["canUseTool"],
-  worktree?: WorktreeContext,
 ): Options {
   const options: Options = {
-    systemPrompt: buildCharacterPrompt(persona, worktree),
+    systemPrompt: prompt,
     cwd: workDir,
     mcpServers: {
       homunculus: { type: "http", url: "http://localhost:3100/mcp" },

--- a/mods/agent/lib/codex-appserver-runtime.ts
+++ b/mods/agent/lib/codex-appserver-runtime.ts
@@ -37,8 +37,7 @@ import type {
   ToolRequestUserInputParams,
   ErrorNotification,
 } from "./codex-appserver-types.ts";
-import { buildCharacterPrompt, type WorktreeContext } from "./prompt.ts";
-import type { AgentSettings, Persona } from "./types.ts";
+import type { AgentSettings } from "./types.ts";
 
 /** Internal message pushed into the event queue by the ThreadHandler. */
 type QueueMessage =
@@ -55,24 +54,21 @@ type QueueMessage =
  * {@link AgentEvent} values yielded through an AsyncGenerator.
  */
 export class CodexAppServerRuntime implements AgentRuntime {
-  private readonly persona: Persona;
+  private readonly prompt: string;
   private readonly settings: AgentSettings;
   private readonly workDir: string;
   private readonly process: CodexAppServerProcess;
-  private readonly worktree?: WorktreeContext;
 
   constructor(
-    persona: Persona,
+    prompt: string,
     settings: AgentSettings,
     workDir: string,
     process: CodexAppServerProcess,
-    worktree?: WorktreeContext,
   ) {
-    this.persona = persona;
+    this.prompt = prompt;
     this.settings = settings;
     this.workDir = workDir;
     this.process = process;
-    this.worktree = worktree;
   }
 
   /**
@@ -130,7 +126,7 @@ export class CodexAppServerRuntime implements AgentRuntime {
   private async startThread(): Promise<string> {
     const params: ThreadStartParams = {
       cwd: this.workDir,
-      baseInstructions: buildCharacterPrompt(this.persona, this.worktree),
+      baseInstructions: this.prompt,
       personality: "none",
       sandbox: "workspace-write",
       experimentalRawEvents: false,
@@ -159,7 +155,7 @@ export class CodexAppServerRuntime implements AgentRuntime {
     const params: ThreadResumeParams = {
       threadId: sessionId,
       cwd: this.workDir,
-      baseInstructions: buildCharacterPrompt(this.persona, this.worktree),
+      baseInstructions: this.prompt,
       personality: "none",
       sandbox: "workspace-write",
       persistExtendedHistory: false,

--- a/mods/agent/lib/prompt.test.ts
+++ b/mods/agent/lib/prompt.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { buildCharacterPrompt } from "./prompt.ts";
+import { buildPersonaPrompt } from "./prompt.ts";
 import type { Persona } from "./types.ts";
 
 const basePersona: Persona = {
@@ -11,35 +11,35 @@ const basePersona: Persona = {
   personality: null,
 };
 
-describe("buildCharacterPrompt", () => {
+describe("buildPersonaPrompt", () => {
   describe("basic persona fields", () => {
     it("includes character name", () => {
-      const prompt = buildCharacterPrompt(basePersona);
+      const prompt = buildPersonaPrompt(basePersona);
       expect(prompt).toContain('"TestChar"');
     });
 
     it("includes age", () => {
-      const prompt = buildCharacterPrompt(basePersona);
+      const prompt = buildPersonaPrompt(basePersona);
       expect(prompt).toContain("Age: 25");
     });
 
     it("shows Unknown when age is null", () => {
-      const prompt = buildCharacterPrompt({ ...basePersona, age: null });
+      const prompt = buildPersonaPrompt({ ...basePersona, age: null });
       expect(prompt).toContain("Age: Unknown");
     });
 
     it("includes gender label", () => {
-      const prompt = buildCharacterPrompt(basePersona);
+      const prompt = buildPersonaPrompt(basePersona);
       expect(prompt).toContain("Gender: Female");
     });
 
     it("includes first-person pronoun instruction", () => {
-      const prompt = buildCharacterPrompt(basePersona);
+      const prompt = buildPersonaPrompt(basePersona);
       expect(prompt).toContain('"watashi"');
     });
 
     it("omits pronoun line when null", () => {
-      const prompt = buildCharacterPrompt({
+      const prompt = buildPersonaPrompt({
         ...basePersona,
         firstPersonPronoun: null,
       });
@@ -49,7 +49,7 @@ describe("buildCharacterPrompt", () => {
 
   describe("profile", () => {
     it("includes profile when non-empty", () => {
-      const prompt = buildCharacterPrompt({
+      const prompt = buildPersonaPrompt({
         ...basePersona,
         profile: "A cheerful girl",
       });
@@ -57,30 +57,30 @@ describe("buildCharacterPrompt", () => {
     });
 
     it("omits profile when empty string", () => {
-      const prompt = buildCharacterPrompt({ ...basePersona, profile: "" });
+      const prompt = buildPersonaPrompt({ ...basePersona, profile: "" });
       expect(prompt).not.toContain("Profile:");
     });
   });
 
   describe("personality section", () => {
     it("omits section when personality is null", () => {
-      const prompt = buildCharacterPrompt({ ...basePersona, personality: null });
+      const prompt = buildPersonaPrompt({ ...basePersona, personality: null });
       expect(prompt).not.toContain("## Personality");
     });
 
     it("omits section when personality is empty string", () => {
-      const prompt = buildCharacterPrompt({ ...basePersona, personality: "" });
+      const prompt = buildPersonaPrompt({ ...basePersona, personality: "" });
       expect(prompt).not.toContain("## Personality");
     });
 
     it("omits section when personality is undefined", () => {
       const { personality: _, ...withoutPersonality } = basePersona;
-      const prompt = buildCharacterPrompt(withoutPersonality as Persona);
+      const prompt = buildPersonaPrompt(withoutPersonality as Persona);
       expect(prompt).not.toContain("## Personality");
     });
 
     it("includes personality text under ## Personality header", () => {
-      const prompt = buildCharacterPrompt({
+      const prompt = buildPersonaPrompt({
         ...basePersona,
         personality: "Sarcastic but caring",
       });
@@ -89,7 +89,7 @@ describe("buildCharacterPrompt", () => {
     });
 
     it("places personality before response style section", () => {
-      const prompt = buildCharacterPrompt({
+      const prompt = buildPersonaPrompt({
         ...basePersona,
         personality: "Cheerful and bright",
       });
@@ -99,7 +99,7 @@ describe("buildCharacterPrompt", () => {
     });
 
     it("places profile before personality", () => {
-      const prompt = buildCharacterPrompt({
+      const prompt = buildPersonaPrompt({
         ...basePersona,
         profile: "An apprentice wizard",
         personality: "Curious and talkative",
@@ -112,17 +112,17 @@ describe("buildCharacterPrompt", () => {
 
   describe("existing sections", () => {
     it("includes response style section", () => {
-      const prompt = buildCharacterPrompt(basePersona);
+      const prompt = buildPersonaPrompt(basePersona);
       expect(prompt).toContain("## Response Style");
     });
 
     it("includes response examples section", () => {
-      const prompt = buildCharacterPrompt(basePersona);
+      const prompt = buildPersonaPrompt(basePersona);
       expect(prompt).toContain("## Response Examples");
     });
 
     it("includes webview section", () => {
-      const prompt = buildCharacterPrompt(basePersona);
+      const prompt = buildPersonaPrompt(basePersona);
       expect(prompt).toContain("open_webview");
     });
   });

--- a/mods/agent/lib/prompt.ts
+++ b/mods/agent/lib/prompt.ts
@@ -27,7 +27,11 @@ export function buildWorktreeSection(ctx: WorktreeContext): string {
 }
 
 /** Builds the system prompt with spoken-style instructions and personality description. */
-export function buildCharacterPrompt(persona: Persona, worktree?: WorktreeContext): string {
+export function buildPersonaPrompt(
+  persona: Persona,
+  worktree?: WorktreeContext,
+  sessionContext?: string,
+): string {
   const lines = [
     buildNameLine(persona.name),
     buildAgeLine(persona.age),
@@ -43,6 +47,9 @@ export function buildCharacterPrompt(persona: Persona, worktree?: WorktreeContex
   ];
   if (worktree) {
     lines.push(buildWorktreeSection(worktree));
+  }
+  if (sessionContext) {
+    lines.push(sessionContext);
   }
   return lines.filter(Boolean).join("\n");
 }
@@ -129,3 +136,55 @@ function buildWebviewSection(): string {
     'Verbally, just say something brief like "I put it up on screen, take a look."',
   ].join("\n");
 }
+
+const SESSION_CONTEXT_BUDGET = 8000;
+
+/** Extract a structured summary from session log entries for prompt injection. */
+export function buildSessionContext(
+  entries: { type: string; message: string; timestamp: number; source?: string }[],
+): string {
+  const conversationLines: string[] = [];
+  const toolCounts: Record<string, number> = {};
+
+  for (const entry of entries) {
+    if (entry.type === "user" || entry.type === "assistant") {
+      const prefix = entry.type === "user" ? "User" : "Assistant";
+      conversationLines.push(`${prefix}: ${entry.message}`);
+    } else if (["read", "edit", "run", "tool"].includes(entry.type)) {
+      toolCounts[entry.type] = (toolCounts[entry.type] ?? 0) + 1;
+    }
+  }
+
+  const toolSummaryParts: string[] = [];
+  if (toolCounts.read || toolCounts.edit) {
+    toolSummaryParts.push(`${(toolCounts.read ?? 0) + (toolCounts.edit ?? 0)} file operations`);
+  }
+  if (toolCounts.run) {
+    toolSummaryParts.push(`${toolCounts.run} commands executed`);
+  }
+  if (toolCounts.tool) {
+    toolSummaryParts.push(`${toolCounts.tool} tool calls`);
+  }
+
+  let body = "";
+  if (toolSummaryParts.length > 0) {
+    body += `Tool activity: ${toolSummaryParts.join(", ")}\n\n`;
+  }
+
+  body += "Conversation:\n";
+  body += conversationLines.join("\n");
+
+  // Truncate oldest entries first to stay within budget
+  if (body.length > SESSION_CONTEXT_BUDGET) {
+    body = body.slice(body.length - SESSION_CONTEXT_BUDGET);
+    const firstNewline = body.indexOf("\n");
+    if (firstNewline > 0) {
+      body = "…" + body.slice(firstNewline);
+    }
+  }
+
+  return `## Prior Session Context\n\n${body}`;
+}
+
+/** @deprecated Use buildPersonaPrompt instead. */
+export const buildCharacterPrompt = buildPersonaPrompt;

--- a/mods/agent/lib/prompt.ts
+++ b/mods/agent/lib/prompt.ts
@@ -185,6 +185,3 @@ export function buildSessionContext(
 
   return `## Prior Session Context\n\n${body}`;
 }
-
-/** @deprecated Use buildPersonaPrompt instead. */
-export const buildCharacterPrompt = buildPersonaPrompt;

--- a/mods/agent/lib/prompt.ts
+++ b/mods/agent/lib/prompt.ts
@@ -139,7 +139,10 @@ function buildWebviewSection(): string {
 
 const SESSION_CONTEXT_BUDGET = 8000;
 
-/** Extract a structured summary from session log entries for prompt injection. */
+/** Extract a structured summary from session log entries for prompt injection.
+ *
+ * TODO: For large sessions, consider adding compression (e.g., LLM-based summarization)
+ * to stay within the token budget more intelligently than simple truncation. */
 export function buildSessionContext(
   entries: { type: string; message: string; timestamp: number; source?: string }[],
 ): string {

--- a/mods/agent/lib/session-persistence.ts
+++ b/mods/agent/lib/session-persistence.ts
@@ -52,8 +52,14 @@ export class SessionPersistence {
   /** Pending write chains per file path — guarantees append ordering. */
   private _pendingWrites = new Map<string, Promise<void>>();
 
+  /** Tracks file paths that received at least one user-type entry. */
+  private _hasUserEntries = new Set<string>();
+
   /** Append a log entry. Non-blocking but ordered via promise chaining. */
   append(handle: SessionHandle, entry: PersistLogEntry): void {
+    if (entry.type === "user") {
+      this._hasUserEntries.add(handle.filePath);
+    }
     const line = JSON.stringify(entry) + "\n";
     const prev = this._pendingWrites.get(handle.filePath) ?? Promise.resolve();
     const next = prev.then(() => appendFile(handle.filePath, line, "utf-8")).catch((err) => {
@@ -62,14 +68,21 @@ export class SessionPersistence {
     this._pendingWrites.set(handle.filePath, next);
   }
 
-  /** Close a session. Awaits pending appends, then writes footer. Idempotent. */
+  /** Close a session. Awaits pending appends, then writes footer or deletes if empty. Idempotent. */
   async close(handle: SessionHandle): Promise<void> {
     const pending = this._pendingWrites.get(handle.filePath);
     if (!pending) return;
     await pending;
-    const footer = JSON.stringify({ _meta: "footer", endedAt: Date.now() });
-    await appendFile(handle.filePath, footer + "\n", "utf-8");
+
+    if (this._hasUserEntries.has(handle.filePath)) {
+      const footer = JSON.stringify({ _meta: "footer", endedAt: Date.now() });
+      await appendFile(handle.filePath, footer + "\n", "utf-8");
+    } else {
+      await rm(handle.filePath).catch(() => {});
+    }
+
     this._pendingWrites.delete(handle.filePath);
+    this._hasUserEntries.delete(handle.filePath);
   }
 
   /** List sessions in the scoped directory, sorted by startedAt desc. */

--- a/mods/agent/lib/session-persistence.ts
+++ b/mods/agent/lib/session-persistence.ts
@@ -1,4 +1,4 @@
-import { mkdir, writeFile, appendFile } from "node:fs/promises";
+import { mkdir, writeFile, appendFile, readdir, readFile } from "node:fs/promises";
 import { join } from "node:path";
 import { randomUUID } from "node:crypto";
 
@@ -69,4 +69,105 @@ export class SessionPersistence {
     await appendFile(handle.filePath, footer + "\n", "utf-8");
     this._pendingWrites.delete(handle.filePath);
   }
+
+  /** List sessions in the scoped directory, sorted by startedAt desc. */
+  async list(workspacePath: string, personaId: string, branchName: string): Promise<SessionMeta[]> {
+    const dir = this.sessionDir(workspacePath, personaId, branchName);
+    let files: string[];
+    try {
+      files = (await readdir(dir)).filter((f) => f.endsWith(".jsonl"));
+    } catch {
+      return [];
+    }
+
+    const metas: SessionMeta[] = [];
+    for (const file of files) {
+      const meta = await this.readSessionMeta(join(dir, file));
+      if (meta) metas.push(meta);
+    }
+
+    return metas.sort((a, b) => b.startedAt - a.startedAt);
+  }
+
+  /** Read a full session log, returning entries (skipping _meta lines). */
+  async read(
+    workspacePath: string,
+    personaId: string,
+    branchName: string,
+    uuid: string,
+  ): Promise<PersistLogEntry[]> {
+    const filePath = join(this.sessionDir(workspacePath, personaId, branchName), `${uuid}.jsonl`);
+    let content: string;
+    try {
+      content = await readFile(filePath, "utf-8");
+    } catch {
+      return [];
+    }
+    return parseLogEntries(content);
+  }
+
+  /** Find the UUID of the most recent session. */
+  async findLatestSessionUuid(
+    workspacePath: string,
+    personaId: string,
+    branchName: string,
+  ): Promise<string | null> {
+    const sessions = await this.list(workspacePath, personaId, branchName);
+    return sessions.length > 0 ? sessions[0].uuid : null;
+  }
+
+  /** Read header + scan for first user message as preview. */
+  private async readSessionMeta(filePath: string): Promise<SessionMeta | null> {
+    let content: string;
+    try {
+      content = await readFile(filePath, "utf-8");
+    } catch {
+      return null;
+    }
+
+    const lines = content.split("\n").filter((l) => l.trim());
+    if (lines.length === 0) return null;
+
+    let header: { _meta: string; startedAt: number };
+    try {
+      header = JSON.parse(lines[0]);
+    } catch {
+      return null;
+    }
+    if (header._meta !== "header" || typeof header.startedAt !== "number") return null;
+
+    const uuid = filePath.split("/").pop()!.replace(".jsonl", "");
+
+    let preview: string | null = null;
+    for (let i = 1; i < Math.min(lines.length, 10); i++) {
+      try {
+        const entry = JSON.parse(lines[i]);
+        if (entry.type === "user" && entry.message) {
+          preview = entry.message.length > 100
+            ? entry.message.slice(0, 100) + "\u2026"
+            : entry.message;
+          break;
+        }
+      } catch {
+        continue;
+      }
+    }
+
+    return { uuid, startedAt: header.startedAt, preview };
+  }
+}
+
+function parseLogEntries(content: string): PersistLogEntry[] {
+  const entries: PersistLogEntry[] = [];
+  for (const line of content.split("\n")) {
+    if (!line.trim()) continue;
+    try {
+      const parsed = JSON.parse(line);
+      if (parsed._meta) continue;
+      entries.push(parsed as PersistLogEntry);
+    } catch {
+      continue;
+    }
+  }
+  return entries;
 }

--- a/mods/agent/lib/session-persistence.ts
+++ b/mods/agent/lib/session-persistence.ts
@@ -1,4 +1,4 @@
-import { mkdir, writeFile, appendFile, readdir, readFile } from "node:fs/promises";
+import { mkdir, writeFile, appendFile, readdir, readFile, rm } from "node:fs/promises";
 import { join } from "node:path";
 import { randomUUID } from "node:crypto";
 
@@ -114,6 +114,61 @@ export class SessionPersistence {
   ): Promise<string | null> {
     const sessions = await this.list(workspacePath, personaId, branchName);
     return sessions.length > 0 ? sessions[0].uuid : null;
+  }
+
+  /** Delete session files older than ttlDays. Walks persona dirs recursively. */
+  async cleanup(workspacePath: string, personaId: string, ttlDays: number = SESSION_TTL_DAYS): Promise<void> {
+    const personaDir = join(workspacePath, ".hmcs", "sessions", personaId);
+    try {
+      await this.cleanupDir(personaDir, ttlDays);
+    } catch {
+      // personaDir may not exist yet — that's fine
+    }
+  }
+
+  private async cleanupDir(dir: string, ttlDays: number): Promise<void> {
+    let entries: import("node:fs").Dirent[];
+    try {
+      entries = await readdir(dir, { withFileTypes: true });
+    } catch {
+      return;
+    }
+
+    const cutoff = Date.now() - ttlDays * 24 * 60 * 60 * 1000;
+
+    for (const entry of entries) {
+      const fullPath = join(dir, entry.name);
+      if (entry.isDirectory()) {
+        await this.cleanupDir(fullPath, ttlDays);
+        await this.removeIfEmpty(fullPath);
+      } else if (entry.name.endsWith(".jsonl")) {
+        await this.removeIfExpired(fullPath, cutoff);
+      }
+    }
+  }
+
+  private async removeIfExpired(filePath: string, cutoff: number): Promise<void> {
+    try {
+      const content = await readFile(filePath, "utf-8");
+      const firstLine = content.split("\n")[0];
+      const header = JSON.parse(firstLine);
+      if (header._meta === "header" && header.startedAt < cutoff) {
+        await rm(filePath);
+      }
+    } catch {
+      // corrupt file or read error — skip
+    }
+  }
+
+  private async removeIfEmpty(dir: string): Promise<void> {
+    try {
+      const entries = await readdir(dir);
+      if (entries.length === 0) {
+        await rm(dir, { recursive: true });
+      }
+    } catch {
+      // skip
+    }
   }
 
   /** Read header + scan for first user message as preview. */

--- a/mods/agent/lib/session-persistence.ts
+++ b/mods/agent/lib/session-persistence.ts
@@ -26,10 +26,11 @@ export interface PersistLogEntry {
 const SESSION_TTL_DAYS = 90;
 
 export class SessionPersistence {
-  /** Resolve the directory for a given persona + branch scope. */
-  private sessionDir(workspacePath: string, personaId: string, branchName: string): string {
-    return join(workspacePath, ".hmcs", "sessions", personaId, branchName);
-  }
+  /** Pending write chains per file path — guarantees append ordering. */
+  private _pendingWrites = new Map<string, Promise<void>>();
+
+  /** Tracks file paths that received at least one user-type entry. */
+  private _hasUserEntries = new Set<string>();
 
   /** Create a new session file and write the JSONL header. */
   async create(params: {
@@ -48,12 +49,6 @@ export class SessionPersistence {
     this._pendingWrites.set(filePath, Promise.resolve());
     return { uuid, filePath };
   }
-
-  /** Pending write chains per file path — guarantees append ordering. */
-  private _pendingWrites = new Map<string, Promise<void>>();
-
-  /** Tracks file paths that received at least one user-type entry. */
-  private _hasUserEntries = new Set<string>();
 
   /** Append a log entry. Non-blocking but ordered via promise chaining. */
   append(handle: SessionHandle, entry: PersistLogEntry): void {
@@ -139,6 +134,11 @@ export class SessionPersistence {
     } catch {
       // personaDir may not exist yet — that's fine
     }
+  }
+
+  /** Resolve the directory for a given persona + branch scope. */
+  private sessionDir(workspacePath: string, personaId: string, branchName: string): string {
+    return join(workspacePath, ".hmcs", "sessions", personaId, branchName);
   }
 
   private async cleanupDir(dir: string, ttlDays: number): Promise<void> {

--- a/mods/agent/lib/session-persistence.ts
+++ b/mods/agent/lib/session-persistence.ts
@@ -1,0 +1,72 @@
+import { mkdir, writeFile, appendFile } from "node:fs/promises";
+import { join } from "node:path";
+import { randomUUID } from "node:crypto";
+
+/** Opaque handle to an active session file. */
+export interface SessionHandle {
+  uuid: string;
+  filePath: string;
+}
+
+/** Metadata for a session, derived from its JSONL header + preview scan. */
+export interface SessionMeta {
+  uuid: string;
+  startedAt: number;
+  preview: string | null;
+}
+
+/** A single log entry persisted to JSONL. Wider than LogEntry to allow any type string. */
+export interface PersistLogEntry {
+  type: string;
+  message: string;
+  timestamp: number;
+  source?: string;
+}
+
+const SESSION_TTL_DAYS = 90;
+
+export class SessionPersistence {
+  /** Resolve the directory for a given persona + branch scope. */
+  private sessionDir(workspacePath: string, personaId: string, branchName: string): string {
+    return join(workspacePath, ".hmcs", "sessions", personaId, branchName);
+  }
+
+  /** Create a new session file and write the JSONL header. */
+  async create(params: {
+    workspacePath: string;
+    personaId: string;
+    branchName: string;
+  }): Promise<SessionHandle> {
+    const dir = this.sessionDir(params.workspacePath, params.personaId, params.branchName);
+    await mkdir(dir, { recursive: true });
+
+    const uuid = randomUUID();
+    const filePath = join(dir, `${uuid}.jsonl`);
+    const header = JSON.stringify({ _meta: "header", startedAt: Date.now() });
+    await writeFile(filePath, header + "\n", "utf-8");
+
+    this._pendingWrites.set(filePath, Promise.resolve());
+    return { uuid, filePath };
+  }
+
+  /** Pending write chains per file path — guarantees append ordering. */
+  private _pendingWrites = new Map<string, Promise<void>>();
+
+  /** Append a log entry. Non-blocking but ordered via promise chaining. */
+  append(handle: SessionHandle, entry: PersistLogEntry): void {
+    const line = JSON.stringify(entry) + "\n";
+    const prev = this._pendingWrites.get(handle.filePath) ?? Promise.resolve();
+    const next = prev.then(() => appendFile(handle.filePath, line, "utf-8")).catch((err) => {
+      console.error(`[session-persistence] append failed: ${err}`);
+    });
+    this._pendingWrites.set(handle.filePath, next);
+  }
+
+  /** Close a session. Awaits pending appends, then writes footer. */
+  async close(handle: SessionHandle): Promise<void> {
+    await this._pendingWrites.get(handle.filePath);
+    const footer = JSON.stringify({ _meta: "footer", endedAt: Date.now() });
+    await appendFile(handle.filePath, footer + "\n", "utf-8");
+    this._pendingWrites.delete(handle.filePath);
+  }
+}

--- a/mods/agent/lib/session-persistence.ts
+++ b/mods/agent/lib/session-persistence.ts
@@ -1,5 +1,5 @@
 import { mkdir, writeFile, appendFile, readdir, readFile, rm } from "node:fs/promises";
-import { join } from "node:path";
+import { join, basename } from "node:path";
 import { randomUUID } from "node:crypto";
 
 /** Opaque handle to an active session file. */
@@ -62,9 +62,11 @@ export class SessionPersistence {
     this._pendingWrites.set(handle.filePath, next);
   }
 
-  /** Close a session. Awaits pending appends, then writes footer. */
+  /** Close a session. Awaits pending appends, then writes footer. Idempotent. */
   async close(handle: SessionHandle): Promise<void> {
-    await this._pendingWrites.get(handle.filePath);
+    const pending = this._pendingWrites.get(handle.filePath);
+    if (!pending) return;
+    await pending;
     const footer = JSON.stringify({ _meta: "footer", endedAt: Date.now() });
     await appendFile(handle.filePath, footer + "\n", "utf-8");
     this._pendingWrites.delete(handle.filePath);
@@ -191,7 +193,7 @@ export class SessionPersistence {
     }
     if (header._meta !== "header" || typeof header.startedAt !== "number") return null;
 
-    const uuid = filePath.split("/").pop()!.replace(".jsonl", "");
+    const uuid = basename(filePath, ".jsonl");
 
     let preview: string | null = null;
     for (let i = 1; i < Math.min(lines.length, 10); i++) {

--- a/mods/agent/lib/session-persistence.ts
+++ b/mods/agent/lib/session-persistence.ts
@@ -131,8 +131,8 @@ export class SessionPersistence {
     const personaDir = join(workspacePath, ".hmcs", "sessions", personaId);
     try {
       await this.cleanupDir(personaDir, ttlDays);
-    } catch {
-      // personaDir may not exist yet — that's fine
+    } catch (e) {
+      console.error(`[session-persistence] cleanup failed for ${personaDir}:`, e);
     }
   }
 
@@ -170,8 +170,8 @@ export class SessionPersistence {
       if (header._meta === "header" && header.startedAt < cutoff) {
         await rm(filePath);
       }
-    } catch {
-      // corrupt file or read error — skip
+    } catch (e) {
+      console.error(`[session-persistence] removeIfExpired failed for ${filePath}:`, e);
     }
   }
 
@@ -188,43 +188,55 @@ export class SessionPersistence {
 
   /** Read header + scan for first user message as preview. */
   private async readSessionMeta(filePath: string): Promise<SessionMeta | null> {
-    let content: string;
-    try {
-      content = await readFile(filePath, "utf-8");
-    } catch {
-      return null;
-    }
+    const lines = await readNonEmptyLines(filePath);
+    if (!lines) return null;
 
-    const lines = content.split("\n").filter((l) => l.trim());
-    if (lines.length === 0) return null;
-
-    let header: { _meta: string; startedAt: number };
-    try {
-      header = JSON.parse(lines[0]);
-    } catch {
-      return null;
-    }
-    if (header._meta !== "header" || typeof header.startedAt !== "number") return null;
+    const header = parseSessionHeader(lines[0]);
+    if (!header) return null;
 
     const uuid = basename(filePath, ".jsonl");
-
-    let preview: string | null = null;
-    for (let i = 1; i < Math.min(lines.length, 10); i++) {
-      try {
-        const entry = JSON.parse(lines[i]);
-        if (entry.type === "user" && entry.message) {
-          preview = entry.message.length > 100
-            ? entry.message.slice(0, 100) + "\u2026"
-            : entry.message;
-          break;
-        }
-      } catch {
-        continue;
-      }
-    }
-
+    const preview = findFirstUserPreview(lines);
     return { uuid, startedAt: header.startedAt, preview };
   }
+}
+
+async function readNonEmptyLines(filePath: string): Promise<string[] | null> {
+  let content: string;
+  try {
+    content = await readFile(filePath, "utf-8");
+  } catch {
+    return null;
+  }
+  const lines = content.split("\n").filter((l) => l.trim());
+  return lines.length > 0 ? lines : null;
+}
+
+function parseSessionHeader(line: string): { startedAt: number } | null {
+  try {
+    const header = JSON.parse(line);
+    if (header._meta === "header" && typeof header.startedAt === "number") {
+      return { startedAt: header.startedAt };
+    }
+    return null;
+  } catch {
+    return null;
+  }
+}
+
+function findFirstUserPreview(lines: string[]): string | null {
+  for (let i = 1; i < Math.min(lines.length, 10); i++) {
+    try {
+      const entry = JSON.parse(lines[i]);
+      if (entry.type === "user" && entry.message) {
+        return entry.message.length > 100
+          ? entry.message.slice(0, 100) + "\u2026"
+          : entry.message;
+      }
+    } catch {
+      continue;
+    }
+  }
+  return null;
 }
 
 function parseLogEntries(content: string): PersistLogEntry[] {

--- a/mods/agent/service.ts
+++ b/mods/agent/service.ts
@@ -15,7 +15,7 @@ import {
   type Persona,
   DEFAULT_SETTINGS,
 } from "./lib/types.ts";
-import { buildPersonaPrompt, type WorktreeContext } from "./lib/prompt.ts";
+import { buildPersonaPrompt, buildSessionContext, type WorktreeContext } from "./lib/prompt.ts";
 import { WorktreeManager, WORKTREE_NAME_PATTERN } from "./lib/worktree-manager.ts";
 import { gitExec, isGitRepo, currentBranch, listBranches } from "./lib/git.ts";
 import { sanitizeForTts } from "./lib/tts.ts";
@@ -128,7 +128,7 @@ async function scanOrphanedWorktrees(): Promise<void> {
   }
 }
 
-async function startSession(personaId: string): Promise<void> {
+async function startSession(personaId: string, contextSessionUuid?: string): Promise<void> {
   const settings = await loadPersonaSettings(personaId);
   assertCanStartSession(personaId, settings);
 
@@ -148,13 +148,27 @@ async function startSession(personaId: string): Promise<void> {
   }
 
   const worktreeCtx = await buildWorktreeContext(settings, workDir);
-  const prompt = buildPersonaPrompt(persona, worktreeCtx);
-  const runtime = createRuntime(settings, prompt, currentApiKey, workDir);
 
   const basePath = settings.workspaces.paths[selection.workspaceIndex];
   const branchName = basePath
     ? await resolveCurrentBranch(basePath, selection.worktreeName)
     : null;
+
+  // Read previous session context for prompt injection
+  let sessionContext: string | undefined;
+  if (basePath && branchName) {
+    const contextUuid = contextSessionUuid
+      ?? await persistence.findLatestSessionUuid(basePath, personaId, branchName);
+    if (contextUuid) {
+      const entries = await persistence.read(basePath, personaId, branchName, contextUuid);
+      if (entries.length > 0) {
+        sessionContext = buildSessionContext(entries);
+      }
+    }
+  }
+
+  const prompt = buildPersonaPrompt(persona, worktreeCtx, sessionContext);
+  const runtime = createRuntime(settings, prompt, currentApiKey, workDir);
 
   if (basePath && branchName) {
     const handle = await persistence.create({
@@ -560,7 +574,7 @@ async function handleAgentEvent(
     case "elicitation_request":
       return await handleElicitationRequest(personaId, event, signal);
     case "completed":
-      return handleCompleted(personaId, event.sessionId, settings);
+      return handleCompleted(personaId, event.sessionId);
     case "error":
       return handleError(personaId, event.message, settings);
   }
@@ -604,9 +618,7 @@ async function handleElicitationRequest(
 function handleCompleted(
   personaId: string,
   sessionId: string,
-  settings: AgentSettings,
 ): undefined {
-  saveSession(personaId, settings.runtime, sessionId);
   return undefined;
 }
 

--- a/mods/agent/service.ts
+++ b/mods/agent/service.ts
@@ -19,7 +19,7 @@ import { buildPersonaPrompt, buildSessionContext, type WorktreeContext } from ".
 import { WorktreeManager, WORKTREE_NAME_PATTERN } from "./lib/worktree-manager.ts";
 import { gitExec, isGitRepo, currentBranch, listBranches } from "./lib/git.ts";
 import { sanitizeForTts } from "./lib/tts.ts";
-import { SessionPersistence, type SessionHandle } from "./lib/session-persistence.ts";
+import { SessionPersistence, type SessionHandle, type PersistLogEntry } from "./lib/session-persistence.ts";
 import { mkdirSync } from "node:fs";
 import { homedir } from "node:os";
 import path from "node:path";
@@ -128,7 +128,7 @@ async function scanOrphanedWorktrees(): Promise<void> {
   }
 }
 
-async function startSession(personaId: string, contextSessionUuid?: string): Promise<void> {
+async function startSession(personaId: string, contextSessionUuid?: string): Promise<PersistLogEntry[]> {
   const settings = await loadPersonaSettings(personaId);
   assertCanStartSession(personaId, settings);
 
@@ -156,6 +156,7 @@ async function startSession(personaId: string, contextSessionUuid?: string): Pro
 
   // Read previous session context for prompt injection
   let sessionContext: string | undefined;
+  let replayEntries: PersistLogEntry[] = [];
   if (basePath && branchName) {
     const contextUuid = contextSessionUuid
       ?? await persistence.findLatestSessionUuid(basePath, personaId, branchName);
@@ -163,9 +164,7 @@ async function startSession(personaId: string, contextSessionUuid?: string): Pro
       const entries = await persistence.read(basePath, personaId, branchName, contextUuid);
       if (entries.length > 0) {
         sessionContext = buildSessionContext(entries);
-        // Replay previous entries to UI as a batch for visual continuity.
-        // Uses a dedicated signal (not emitLog) to avoid persisting to new JSONL.
-        signals.send("agent:session-replay", { personaId, entries });
+        replayEntries = entries;
       }
     }
   }
@@ -188,6 +187,7 @@ async function startSession(personaId: string, contextSessionUuid?: string): Pro
   textQueues.set(personaId, new AsyncQueue<string>());
 
   launchSessionLoop(personaId, runtime, sessionAbort, settings, resolvedKey);
+  return replayEntries;
 }
 
 function assertCanStartSession(
@@ -954,9 +954,9 @@ function buildRpcMethods() {
         contextSessionUuid: z.string().optional(),
       }),
       handler: async ({ personaId, text, contextSessionUuid }) => {
+        let replayEntries: PersistLogEntry[] = [];
         if (!activeSessions.has(personaId)) {
-          // Auto-start session with optional context
-          await startSession(personaId, contextSessionUuid);
+          replayEntries = await startSession(personaId, contextSessionUuid);
         }
         const queue = textQueues.get(personaId);
         if (!queue) {
@@ -965,7 +965,7 @@ function buildRpcMethods() {
         await interruptSession(personaId);
         queue.clear();
         queue.push(text);
-        return { success: true as const };
+        return { success: true as const, replayEntries };
       },
     }),
     "set-text-focus": rpc.method({
@@ -1005,8 +1005,8 @@ function buildRpcMethods() {
       description: "Manually start an agent session for a persona",
       input: z.object({ personaId: z.string() }),
       handler: async ({ personaId }) => {
-        await startSession(personaId);
-        return { success: true as const };
+        const replayEntries = await startSession(personaId);
+        return { success: true as const, replayEntries };
       },
     }),
     "stop-session": rpc.method({

--- a/mods/agent/service.ts
+++ b/mods/agent/service.ts
@@ -15,7 +15,7 @@ import {
   type Persona,
   DEFAULT_SETTINGS,
 } from "./lib/types.ts";
-import type { WorktreeContext } from "./lib/prompt.ts";
+import { buildPersonaPrompt, type WorktreeContext } from "./lib/prompt.ts";
 import { WorktreeManager, WORKTREE_NAME_PATTERN } from "./lib/worktree-manager.ts";
 import { gitExec, isGitRepo, currentBranch, listBranches } from "./lib/git.ts";
 import { sanitizeForTts } from "./lib/tts.ts";
@@ -144,7 +144,8 @@ async function startSession(personaId: string): Promise<void> {
   }
 
   const worktreeCtx = await buildWorktreeContext(settings, workDir);
-  const runtime = createRuntime(settings, persona, currentApiKey, workDir, worktreeCtx);
+  const prompt = buildPersonaPrompt(persona, worktreeCtx);
+  const runtime = createRuntime(settings, prompt, currentApiKey, workDir);
 
   const sessionAbort = new AbortController();
   activeSessions.set(personaId, sessionAbort);
@@ -253,16 +254,15 @@ async function readWorktreeBaseBranch(worktreePath: string): Promise<string> {
 
 function createRuntime(
   settings: AgentSettings,
-  persona: Persona,
+  prompt: string,
   apiKey: string | null,
   workDir: string,
-  worktree?: WorktreeContext,
 ): AgentRuntime {
   switch (settings.runtime) {
     case "codex":
-      return new CodexAppServerRuntime(persona, settings, workDir, getAppServerProcess(), worktree);
+      return new CodexAppServerRuntime(prompt, settings, workDir, getAppServerProcess());
     case "sdk":
-      return new ClaudeAgentRuntime(persona, settings, apiKey!, workDir, worktree);
+      return new ClaudeAgentRuntime(prompt, settings, apiKey!, workDir);
     default:
       throw new Error(`Runtime "${settings.runtime}" is not yet implemented.`);
   }

--- a/mods/agent/service.ts
+++ b/mods/agent/service.ts
@@ -401,9 +401,7 @@ async function runSession(
 
     const handle = activeSessionHandles.get(personaId);
     if (handle) {
-      if (!signal.aborted) {
-        await persistence.close(handle).catch(() => {});
-      }
+      await persistence.close(handle).catch(() => {});
       activeSessionHandles.delete(personaId);
     }
 

--- a/mods/agent/service.ts
+++ b/mods/agent/service.ts
@@ -351,30 +351,6 @@ async function interruptSession(personaId: string): Promise<void> {
   }
 }
 
-const SESSION_PREF_PREFIX = "agent::session::";
-
-async function loadSavedSession(
-  personaId: string,
-  runtime: AgentSettings["runtime"],
-): Promise<string | null> {
-  return (
-    (await preferences.load<string>(
-      `${SESSION_PREF_PREFIX}${runtime}::${personaId}`,
-    )) ?? null
-  );
-}
-
-function saveSession(
-  personaId: string,
-  runtime: AgentSettings["runtime"],
-  sessionId: string | null,
-): void {
-  preferences.save(
-    `${SESSION_PREF_PREFIX}${runtime}::${personaId}`,
-    sessionId,
-  );
-}
-
 interface UserInput {
   text: string;
   source: "voice" | "text";
@@ -387,7 +363,7 @@ async function runSession(
   settings: AgentSettings,
   resolvedKey: ResolvedPttKey | null,
 ): Promise<void> {
-  let sessionId = await loadSavedSession(personaId, settings.runtime);
+  let sessionId: string | null = null;
   const signal = sessionAbort.signal;
 
   try {

--- a/mods/agent/service.ts
+++ b/mods/agent/service.ts
@@ -19,6 +19,7 @@ import { buildPersonaPrompt, type WorktreeContext } from "./lib/prompt.ts";
 import { WorktreeManager, WORKTREE_NAME_PATTERN } from "./lib/worktree-manager.ts";
 import { gitExec, isGitRepo, currentBranch, listBranches } from "./lib/git.ts";
 import { sanitizeForTts } from "./lib/tts.ts";
+import { SessionPersistence, type SessionHandle } from "./lib/session-persistence.ts";
 import { mkdirSync } from "node:fs";
 import { homedir } from "node:os";
 import path from "node:path";
@@ -31,6 +32,9 @@ const pendingQuestions = new Map<string, Deferred<Record<string, string>>>();
 const pendingInterrupts = new Map<string, Deferred<void>>();
 const textQueues = new Map<string, AsyncQueue<string>>();
 const textFocusedPersonas = new Set<string>();
+
+const persistence = new SessionPersistence();
+const activeSessionHandles = new Map<string, SessionHandle>();
 
 let appServerProcess: CodexAppServerProcess | null = null;
 
@@ -147,6 +151,21 @@ async function startSession(personaId: string): Promise<void> {
   const prompt = buildPersonaPrompt(persona, worktreeCtx);
   const runtime = createRuntime(settings, prompt, currentApiKey, workDir);
 
+  const basePath = settings.workspaces.paths[selection.workspaceIndex];
+  const branchName = basePath
+    ? await resolveCurrentBranch(basePath, selection.worktreeName)
+    : null;
+
+  if (basePath && branchName) {
+    const handle = await persistence.create({
+      workspacePath: basePath,
+      personaId,
+      branchName,
+    });
+    activeSessionHandles.set(personaId, handle);
+    persistence.cleanup(basePath, personaId).catch(() => {});
+  }
+
   const sessionAbort = new AbortController();
   activeSessions.set(personaId, sessionAbort);
   textQueues.set(personaId, new AsyncQueue<string>());
@@ -252,6 +271,24 @@ async function readWorktreeBaseBranch(worktreePath: string): Promise<string> {
   }
 }
 
+/** Resolve the current git branch for session scoping. */
+async function resolveCurrentBranch(
+  workspacePath: string,
+  worktreeName: string | null,
+): Promise<string | null> {
+  try {
+    if (worktreeName) {
+      const manager = new WorktreeManager(workspacePath);
+      const worktrees = await manager.list();
+      const wt = worktrees.find((w) => w.name === worktreeName);
+      return wt?.branch ?? null;
+    }
+    return await currentBranch(workspacePath);
+  } catch {
+    return null;
+  }
+}
+
 function createRuntime(
   settings: AgentSettings,
   prompt: string,
@@ -271,6 +308,13 @@ function createRuntime(
 async function stopSession(personaId: string): Promise<void> {
   const controller = activeSessions.get(personaId);
   if (!controller) return;
+
+  const handle = activeSessionHandles.get(personaId);
+  if (handle) {
+    await persistence.close(handle).catch(() => {});
+    activeSessionHandles.delete(personaId);
+  }
+
   controller.abort();
   const queue = textQueues.get(personaId);
   if (queue) {
@@ -356,6 +400,15 @@ async function runSession(
   } finally {
     activeSessions.delete(personaId);
     textFocusedPersonas.delete(personaId);
+
+    const handle = activeSessionHandles.get(personaId);
+    if (handle) {
+      if (!signal.aborted) {
+        await persistence.close(handle).catch(() => {});
+      }
+      activeSessionHandles.delete(personaId);
+    }
+
     emitStatus(personaId, "idle", "session-ended");
   }
 }
@@ -832,22 +885,19 @@ function emitStatus(personaId: string, state: AgentStatus, reason?: string): voi
 }
 
 function emitLog(personaId: string, type: string, message: string): void {
-  signals.send("agent:log", {
-    personaId,
-    type,
-    message,
-    timestamp: Date.now(),
-  });
+  const entry = { type, message, timestamp: Date.now() };
+  signals.send("agent:log", { personaId, ...entry });
+
+  const handle = activeSessionHandles.get(personaId);
+  if (handle) persistence.append(handle, entry);
 }
 
 function emitUserLog(personaId: string, text: string, source: "voice" | "text"): void {
-  signals.send("agent:log", {
-    personaId,
-    type: "user",
-    message: text,
-    source,
-    timestamp: Date.now(),
-  });
+  const entry = { type: "user" as const, message: text, timestamp: Date.now(), source };
+  signals.send("agent:log", { personaId, ...entry });
+
+  const handle = activeSessionHandles.get(personaId);
+  if (handle) persistence.append(handle, entry);
 }
 
 function emitInterruptLog(personaId: string): void {

--- a/mods/agent/service.ts
+++ b/mods/agent/service.ts
@@ -222,6 +222,11 @@ function handleSessionCrash(
     console.error(`[agent] Session error for ${personaId}:`, err);
     emitLog(personaId, "error", extractErrorMessage(err));
   }
+  const handle = activeSessionHandles.get(personaId);
+  if (handle) {
+    persistence.close(handle).catch(() => {});
+    activeSessionHandles.delete(personaId);
+  }
   const queue = textQueues.get(personaId);
   if (queue) {
     queue.rejectAll(new DOMException("Session crashed", "AbortError"));

--- a/mods/agent/service.ts
+++ b/mods/agent/service.ts
@@ -163,6 +163,9 @@ async function startSession(personaId: string, contextSessionUuid?: string): Pro
       const entries = await persistence.read(basePath, personaId, branchName, contextUuid);
       if (entries.length > 0) {
         sessionContext = buildSessionContext(entries);
+        // Replay previous entries to UI as a batch for visual continuity.
+        // Uses a dedicated signal (not emitLog) to avoid persisting to new JSONL.
+        signals.send("agent:session-replay", { personaId, entries });
       }
     }
   }

--- a/mods/agent/service.ts
+++ b/mods/agent/service.ts
@@ -924,10 +924,10 @@ function buildRpcMethods() {
       handler: async ({ requestId, approved, decision }) => {
         const deferred = pendingApprovals.get(requestId);
         if (!deferred) {
-          return { success: false as const, error: "No pending approval for this request" };
+          throw new Error("No pending approval for this request");
         }
         deferred.resolve({ approved, decision });
-        return { success: true as const };
+        return {};
       },
     }),
     "answer-question": rpc.method({
@@ -941,7 +941,7 @@ function buildRpcMethods() {
         if (deferred) {
           deferred.resolve(answers);
         }
-        return { success: true as const };
+        return {};
       },
     }),
     "send-message": rpc.method({
@@ -958,12 +958,12 @@ function buildRpcMethods() {
         }
         const queue = textQueues.get(personaId);
         if (!queue) {
-          return { success: false as const, error: "No active session" };
+          throw new Error("No active session");
         }
         await interruptSession(personaId);
         queue.clear();
         queue.push(text);
-        return { success: true as const, replayEntries };
+        return { replayEntries };
       },
     }),
     "set-text-focus": rpc.method({
@@ -978,7 +978,7 @@ function buildRpcMethods() {
         } else {
           textFocusedPersonas.delete(personaId);
         }
-        return { success: true as const };
+        return {};
       },
     }),
     status: rpc.method({
@@ -1004,7 +1004,7 @@ function buildRpcMethods() {
       input: z.object({ personaId: z.string() }),
       handler: async ({ personaId }) => {
         const replayEntries = await startSession(personaId);
-        return { success: true as const, replayEntries };
+        return { replayEntries };
       },
     }),
     "stop-session": rpc.method({
@@ -1012,7 +1012,7 @@ function buildRpcMethods() {
       input: z.object({ personaId: z.string() }),
       handler: async ({ personaId }) => {
         await stopSession(personaId);
-        return { success: true as const };
+        return {};
       },
     }),
     "interrupt-session": rpc.method({
@@ -1020,7 +1020,7 @@ function buildRpcMethods() {
       input: z.object({ personaId: z.string() }),
       handler: async ({ personaId }) => {
         await interruptSession(personaId);
-        return { success: true as const };
+        return {};
       },
     }),
     "list-worktrees": rpc.method({
@@ -1063,12 +1063,12 @@ function buildRpcMethods() {
         if (action === "merge") {
           const result = await manager.merge(name);
           if (!result.success) {
-            return { success: false, error: result.error };
+            throw new Error(result.error);
           }
-          return { success: true };
+          return {};
         }
         await manager.remove(name);
-        return { success: true };
+        return {};
       },
     }),
     "list-branches": rpc.method({
@@ -1097,9 +1097,9 @@ function buildRpcMethods() {
       handler: async ({ workspacePath, worktreeName }) => {
         const branchName = await resolveCurrentBranch(workspacePath, worktreeName);
         if (!branchName) {
-          return { success: false as const, error: "Not a git repository or branch could not be resolved" };
+          throw new Error("Not a git repository or branch could not be resolved");
         }
-        return { success: true as const, branchName };
+        return { branchName };
       },
     }),
     "list-sessions": rpc.method({
@@ -1111,7 +1111,7 @@ function buildRpcMethods() {
       }),
       handler: async ({ workspacePath, personaId, branchName }) => {
         const sessions = await persistence.list(workspacePath, personaId, branchName);
-        return { success: true as const, sessions };
+        return { sessions };
       },
     }),
     "get-session-logs": rpc.method({
@@ -1124,7 +1124,7 @@ function buildRpcMethods() {
       }),
       handler: async ({ workspacePath, personaId, branchName, uuid }) => {
         const entries = await persistence.read(workspacePath, personaId, branchName, uuid);
-        return { success: true as const, entries };
+        return { entries };
       },
     }),
   };

--- a/mods/agent/service.ts
+++ b/mods/agent/service.ts
@@ -943,10 +943,12 @@ function buildRpcMethods() {
       input: z.object({
         personaId: z.string(),
         text: z.string().min(1),
+        contextSessionUuid: z.string().optional(),
       }),
-      handler: async ({ personaId, text }) => {
+      handler: async ({ personaId, text, contextSessionUuid }) => {
         if (!activeSessions.has(personaId)) {
-          return { success: false as const, error: "No active session" };
+          // Auto-start session with optional context
+          await startSession(personaId, contextSessionUuid);
         }
         const queue = textQueues.get(personaId);
         if (!queue) {
@@ -1078,6 +1080,45 @@ function buildRpcMethods() {
       handler: async ({ workspacePath, name }) => {
         const manager = new WorktreeManager(workspacePath);
         return await manager.status(name);
+      },
+    }),
+    "get-current-branch": rpc.method({
+      description: "Resolve the current git branch for a workspace",
+      input: z.object({
+        workspacePath: z.string(),
+        worktreeName: z.string().nullable(),
+      }),
+      handler: async ({ workspacePath, worktreeName }) => {
+        const branchName = await resolveCurrentBranch(workspacePath, worktreeName);
+        if (!branchName) {
+          return { success: false as const, error: "Not a git repository or branch could not be resolved" };
+        }
+        return { success: true as const, branchName };
+      },
+    }),
+    "list-sessions": rpc.method({
+      description: "List past sessions for a persona on a branch",
+      input: z.object({
+        workspacePath: z.string(),
+        personaId: z.string(),
+        branchName: z.string(),
+      }),
+      handler: async ({ workspacePath, personaId, branchName }) => {
+        const sessions = await persistence.list(workspacePath, personaId, branchName);
+        return { success: true as const, sessions };
+      },
+    }),
+    "get-session-logs": rpc.method({
+      description: "Read the full log entries for a past session",
+      input: z.object({
+        workspacePath: z.string(),
+        personaId: z.string(),
+        branchName: z.string(),
+        uuid: z.string(),
+      }),
+      handler: async ({ workspacePath, personaId, branchName, uuid }) => {
+        const entries = await persistence.read(workspacePath, personaId, branchName, uuid);
+        return { success: true as const, entries };
       },
     }),
   };

--- a/mods/agent/ui/session/src/UnifiedView.tsx
+++ b/mods/agent/ui/session/src/UnifiedView.tsx
@@ -1,8 +1,8 @@
 import { useState, useEffect, useCallback, useRef } from "react";
 import { audio, dialog, Webview } from "@hmcs/sdk";
-import { rpc } from "@hmcs/sdk/rpc";
 import { useAgentSession } from "./hooks/useAgentSession";
 import { useWebviewMode } from "./hooks/useWebviewMode";
+import { useCurrentBranch } from "./hooks/useCurrentBranch";
 import { useSettingsDraft } from "./settings/hooks/useSettingsDraft";
 import type { WorkspaceSelection, PttKey } from "./settings/hooks/useSettingsDraft";
 import { formatPttKeyName } from "./utils/format-ptt-key";
@@ -32,31 +32,10 @@ export function UnifiedView() {
   const [mounted, setMounted] = useState(false);
   const dragRef = useRef<{ startX: number; startWidth: number } | null>(null);
 
-  const [currentBranch, setCurrentBranch] = useState<string | null>(null);
-
   const paths = draft.settings.workspaces.paths;
   const selection = draft.settings.workspaces.selection;
   const workspacePath = paths[selection.workspaceIndex] ?? null;
-
-  useEffect(() => {
-    if (!workspacePath) return;
-    let cancelled = false;
-    (async () => {
-      try {
-        const result = await rpc.call({
-          modName: "@hmcs/agent",
-          method: "get-current-branch",
-          body: { workspacePath, worktreeName: selection.worktreeName },
-        }) as { success: boolean; branchName?: string };
-        if (!cancelled && result.success && result.branchName) {
-          setCurrentBranch(result.branchName);
-        }
-      } catch {
-        if (!cancelled) setCurrentBranch(null);
-      }
-    })();
-    return () => { cancelled = true; };
-  }, [workspacePath, selection.worktreeName]);
+  const currentBranch = useCurrentBranch(workspacePath, selection.worktreeName);
 
   // Geometry management
   const geometryMode = sidebarOpen ? "expanded" : "collapsed";

--- a/mods/agent/ui/session/src/UnifiedView.tsx
+++ b/mods/agent/ui/session/src/UnifiedView.tsx
@@ -154,7 +154,7 @@ export function UnifiedView() {
     }
     updateSelection(newSelection);
     setActiveCategory(null);
-    setBodyContent({ kind: "sessionLog" });
+    setBodyContent({ kind: "sessionHistory" });
   }
 
   function updateSelection(newSelection: WorkspaceSelection) {

--- a/mods/agent/ui/session/src/UnifiedView.tsx
+++ b/mods/agent/ui/session/src/UnifiedView.tsx
@@ -9,6 +9,8 @@ import { formatPttKeyName } from "./utils/format-ptt-key";
 import { Sidebar } from "./settings/components/Sidebar";
 import { SettingsFormView } from "./settings/components/SettingsFormView";
 import { ActivityLog } from "./components/ActivityLog";
+import { SessionHistory } from "./components/SessionHistory";
+import { PastSessionView } from "./components/PastSessionView";
 import { PermissionDialog } from "./components/PermissionDialog";
 import { QuestionDialog } from "./components/QuestionDialog";
 import { TextInput } from "./components/TextInput";
@@ -30,9 +32,31 @@ export function UnifiedView() {
   const [mounted, setMounted] = useState(false);
   const dragRef = useRef<{ startX: number; startWidth: number } | null>(null);
 
+  const [currentBranch, setCurrentBranch] = useState<string | null>(null);
+
   const paths = draft.settings.workspaces.paths;
   const selection = draft.settings.workspaces.selection;
   const workspacePath = paths[selection.workspaceIndex] ?? null;
+
+  useEffect(() => {
+    if (!workspacePath) return;
+    let cancelled = false;
+    (async () => {
+      try {
+        const result = await rpc.call({
+          modName: "@hmcs/agent",
+          method: "get-current-branch",
+          body: { workspacePath, worktreeName: selection.worktreeName },
+        }) as { success: boolean; branchName?: string };
+        if (!cancelled && result.success && result.branchName) {
+          setCurrentBranch(result.branchName);
+        }
+      } catch {
+        if (!cancelled) setCurrentBranch(null);
+      }
+    })();
+    return () => { cancelled = true; };
+  }, [workspacePath, selection.worktreeName]);
 
   // Geometry management
   const geometryMode = sidebarOpen ? "expanded" : "collapsed";
@@ -47,9 +71,12 @@ export function UnifiedView() {
     }
     if (!isActive && prevActive) {
       setSidebarOpen(true);
+      if (workspacePath) {
+        setBodyContent({ kind: "sessionHistory" });
+      }
     }
     setPrevActive(isActive);
-  }, [isActive, prevActive]);
+  }, [isActive, prevActive, workspacePath]);
 
   // Focus reporting for PTT
   useEffect(() => {
@@ -84,12 +111,14 @@ export function UnifiedView() {
     };
   }, [session.personaId]);
 
-  // Empty state when no workspaces
+  // Empty state when no workspaces, or session history when idle with workspaces
   useEffect(() => {
     if (!draft.loading && paths.length === 0) {
       setBodyContent({ kind: "empty" });
+    } else if (!draft.loading && paths.length > 0 && !isActive) {
+      setBodyContent({ kind: "sessionHistory" });
     }
-  }, [draft.loading, paths.length]);
+  }, [draft.loading, paths.length, isActive]);
 
   // Auto-restore when permission or question dialog arrives
   useEffect(() => {
@@ -281,6 +310,10 @@ export function UnifiedView() {
             isActive={isActive}
             onBack={handleBack}
             onAddWorkspace={handleAddWorkspaceFromPanel}
+            workspacePath={workspacePath}
+            branchName={currentBranch}
+            onSelectSession={(uuid) => setBodyContent({ kind: "pastSession", uuid })}
+            onBodyContentChange={setBodyContent}
           />
         </div>
       </div>
@@ -295,6 +328,10 @@ function BodyPanel({
   isActive,
   onBack,
   onAddWorkspace,
+  workspacePath,
+  branchName,
+  onSelectSession,
+  onBodyContentChange,
 }: {
   content: BodyContent;
   session: ReturnType<typeof useAgentSession>;
@@ -302,6 +339,10 @@ function BodyPanel({
   isActive: boolean;
   onBack: () => void;
   onAddWorkspace: () => void;
+  workspacePath: string | null;
+  branchName: string | null;
+  onSelectSession: (uuid: string) => void;
+  onBodyContentChange: (content: BodyContent) => void;
 }) {
   if (content.kind === "empty") {
     return (
@@ -341,6 +382,41 @@ function BodyPanel({
           />
         </div>
       </div>
+    );
+  }
+
+  if (content.kind === "sessionHistory") {
+    return (
+      <div className="uv-session">
+        {workspacePath && session.personaId && (
+          <SessionHistory
+            workspacePath={workspacePath}
+            personaId={session.personaId}
+            branchName={branchName}
+            onSelectSession={onSelectSession}
+          />
+        )}
+        <TextInput
+          onSend={session.sendMessage}
+          isInterruptible={false}
+          onInterrupt={session.interruptSession}
+        />
+      </div>
+    );
+  }
+
+  if (content.kind === "pastSession") {
+    return (
+      <PastSessionView
+        workspacePath={workspacePath ?? ""}
+        personaId={session.personaId}
+        branchName={branchName}
+        uuid={content.uuid}
+        onBack={() => onBodyContentChange({ kind: "sessionHistory" })}
+        onSendMessage={async (text, contextUuid) => {
+          await session.sendMessage(text, contextUuid);
+        }}
+      />
     );
   }
 

--- a/mods/agent/ui/session/src/components/PastSessionView.tsx
+++ b/mods/agent/ui/session/src/components/PastSessionView.tsx
@@ -37,8 +37,8 @@ export function PastSessionView({
           modName: "@hmcs/agent",
           method: "get-session-logs",
           body: { workspacePath, personaId, branchName, uuid },
-        }) as { success: boolean; entries?: Array<{ type: string; message: string; timestamp: number; source?: string }> };
-        if (!cancelled && result.success && result.entries) {
+        }) as { entries?: Array<{ type: string; message: string; timestamp: number; source?: string }> };
+        if (!cancelled && result.entries) {
           const mapped = mapEntries(result.entries);
           setEntries(mapped);
           if (mapped.length > 0) {

--- a/mods/agent/ui/session/src/components/PastSessionView.tsx
+++ b/mods/agent/ui/session/src/components/PastSessionView.tsx
@@ -1,0 +1,120 @@
+import { useState, useEffect } from "react";
+import { rpc } from "@hmcs/sdk/rpc";
+import { ActivityLog } from "./ActivityLog";
+import { TextInput } from "./TextInput";
+import type { LogEntry } from "../hooks/useAgentSession";
+
+interface PastSessionViewProps {
+  workspacePath: string;
+  personaId: string;
+  branchName: string | null;
+  uuid: string;
+  onBack: () => void;
+  onSendMessage: (text: string, contextUuid: string) => Promise<void>;
+}
+
+export function PastSessionView({
+  workspacePath,
+  personaId,
+  branchName,
+  uuid,
+  onBack,
+  onSendMessage,
+}: PastSessionViewProps) {
+  const [entries, setEntries] = useState<LogEntry[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [sessionDate, setSessionDate] = useState("");
+
+  useEffect(() => {
+    if (!branchName) {
+      setLoading(false);
+      return;
+    }
+    let cancelled = false;
+    (async () => {
+      try {
+        const result = await rpc.call({
+          modName: "@hmcs/agent",
+          method: "get-session-logs",
+          body: { workspacePath, personaId, branchName, uuid },
+        }) as { success: boolean; entries?: Array<{ type: string; message: string; timestamp: number; source?: string }> };
+        if (!cancelled && result.success && result.entries) {
+          const mapped = mapEntries(result.entries);
+          setEntries(mapped);
+          if (mapped.length > 0) {
+            setSessionDate(formatDateTime(mapped[0].timestamp));
+          }
+        }
+      } catch {
+        // silently fail
+      }
+      if (!cancelled) setLoading(false);
+    })();
+    return () => { cancelled = true; };
+  }, [workspacePath, personaId, branchName, uuid]);
+
+  if (loading) return null;
+
+  return (
+    <div className="uv-session">
+      <PastSessionHeader date={sessionDate} onBack={onBack} />
+      <ActivityLog entries={entries} />
+      <TextInput
+        onSend={(text) => onSendMessage(text, uuid)}
+        isInterruptible={false}
+        onInterrupt={() => {}}
+      />
+    </div>
+  );
+}
+
+function PastSessionHeader({ date, onBack }: { date: string; onBack: () => void }) {
+  return (
+    <div style={{
+      display: "flex",
+      alignItems: "center",
+      gap: "8px",
+      padding: "8px 12px",
+      borderBottom: "1px solid rgba(255,255,255,0.1)",
+    }}>
+      <button
+        type="button"
+        onClick={onBack}
+        style={{
+          background: "none",
+          border: "none",
+          color: "#7c8da6",
+          cursor: "pointer",
+          fontSize: "14px",
+          padding: "4px",
+        }}
+      >
+        &larr;
+      </button>
+      <span style={{ color: "#aaa", fontSize: "11px" }}>{date}</span>
+      <span style={{ color: "#555", fontSize: "10px", fontStyle: "italic" }}>read-only</span>
+    </div>
+  );
+}
+
+function mapEntries(
+  raw: Array<{ type: string; message: string; timestamp: number; source?: string }>,
+): LogEntry[] {
+  return raw.map((e, i) => ({
+    id: `past-${i}`,
+    type: e.type as LogEntry["type"],
+    message: e.message,
+    timestamp: e.timestamp,
+    source: e.source as LogEntry["source"],
+  }));
+}
+
+function formatDateTime(ts: number): string {
+  return new Date(ts).toLocaleString("en-US", {
+    month: "short",
+    day: "numeric",
+    hour: "2-digit",
+    minute: "2-digit",
+    hour12: false,
+  });
+}

--- a/mods/agent/ui/session/src/components/SessionHistory.tsx
+++ b/mods/agent/ui/session/src/components/SessionHistory.tsx
@@ -1,0 +1,125 @@
+import { useState, useEffect } from "react";
+import { rpc } from "@hmcs/sdk/rpc";
+
+interface SessionMeta {
+  uuid: string;
+  startedAt: number;
+  preview: string | null;
+}
+
+interface SessionHistoryProps {
+  workspacePath: string;
+  personaId: string;
+  branchName: string | null;
+  onSelectSession: (uuid: string) => void;
+}
+
+export function SessionHistory({ workspacePath, personaId, branchName, onSelectSession }: SessionHistoryProps) {
+  const [sessions, setSessions] = useState<SessionMeta[]>([]);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    if (!branchName) {
+      setLoading(false);
+      return;
+    }
+    let cancelled = false;
+    (async () => {
+      try {
+        const result = await rpc.call({
+          modName: "@hmcs/agent",
+          method: "list-sessions",
+          body: { workspacePath, personaId, branchName },
+        }) as { success: boolean; sessions?: SessionMeta[] };
+        if (!cancelled && result.success && result.sessions) {
+          setSessions(result.sessions);
+        }
+      } catch {
+        // silently fail
+      }
+      if (!cancelled) setLoading(false);
+    })();
+    return () => { cancelled = true; };
+  }, [workspacePath, personaId, branchName]);
+
+  if (loading) return null;
+
+  const groups = groupByDate(sessions);
+
+  return (
+    <div className="hud-log" style={{ flex: 1, overflowY: "auto" }}>
+      {sessions.length === 0 ? (
+        <div className="hud-log-empty">No previous sessions</div>
+      ) : (
+        groups.map(([label, items]) => (
+          <div key={label}>
+            <div style={{
+              color: "#6c7a89",
+              fontSize: "10px",
+              fontWeight: "bold",
+              textTransform: "uppercase",
+              letterSpacing: "1px",
+              margin: "12px 0 4px",
+              padding: "0 8px",
+            }}>
+              {label}
+            </div>
+            {items.map((s) => (
+              <button
+                key={s.uuid}
+                type="button"
+                onClick={() => onSelectSession(s.uuid)}
+                style={{
+                  display: "flex",
+                  justifyContent: "space-between",
+                  width: "100%",
+                  background: "rgba(255,255,255,0.05)",
+                  border: "1px solid rgba(255,255,255,0.1)",
+                  borderRadius: "6px",
+                  padding: "8px 10px",
+                  marginBottom: "6px",
+                  cursor: "pointer",
+                  textAlign: "left",
+                  color: "#e0e0e0",
+                  fontSize: "12px",
+                }}
+              >
+                <span style={{ flex: 1, overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}>
+                  {s.preview ?? "Empty session"}
+                </span>
+                <span style={{ color: "#666", fontSize: "10px", marginLeft: "8px", flexShrink: 0 }}>
+                  {formatTime(s.startedAt)}
+                </span>
+              </button>
+            ))}
+          </div>
+        ))
+      )}
+    </div>
+  );
+}
+
+function groupByDate(sessions: SessionMeta[]): [string, SessionMeta[]][] {
+  const groups = new Map<string, SessionMeta[]>();
+  const now = new Date();
+  const today = new Date(now.getFullYear(), now.getMonth(), now.getDate()).getTime();
+  const yesterday = today - 86400000;
+
+  for (const s of sessions) {
+    const label = dateLabel(s.startedAt, today, yesterday);
+    if (!groups.has(label)) groups.set(label, []);
+    groups.get(label)!.push(s);
+  }
+
+  return [...groups.entries()];
+}
+
+function dateLabel(startedAt: number, today: number, yesterday: number): string {
+  if (startedAt >= today) return "Today";
+  if (startedAt >= yesterday) return "Yesterday";
+  return new Date(startedAt).toLocaleDateString("en-US", { month: "short", day: "numeric" });
+}
+
+function formatTime(ts: number): string {
+  return new Date(ts).toLocaleTimeString("en-US", { hour: "2-digit", minute: "2-digit", hour12: false });
+}

--- a/mods/agent/ui/session/src/components/SessionHistory.tsx
+++ b/mods/agent/ui/session/src/components/SessionHistory.tsx
@@ -1,11 +1,5 @@
-import { useState, useEffect } from "react";
-import { rpc } from "@hmcs/sdk/rpc";
-
-interface SessionMeta {
-  uuid: string;
-  startedAt: number;
-  preview: string | null;
-}
+import { useSessionList } from "../hooks/useSessionList";
+import type { SessionMeta } from "../hooks/useSessionList";
 
 interface SessionHistoryProps {
   workspacePath: string;
@@ -15,32 +9,7 @@ interface SessionHistoryProps {
 }
 
 export function SessionHistory({ workspacePath, personaId, branchName, onSelectSession }: SessionHistoryProps) {
-  const [sessions, setSessions] = useState<SessionMeta[]>([]);
-  const [loading, setLoading] = useState(true);
-
-  useEffect(() => {
-    if (!branchName) {
-      setLoading(false);
-      return;
-    }
-    let cancelled = false;
-    (async () => {
-      try {
-        const result = await rpc.call({
-          modName: "@hmcs/agent",
-          method: "list-sessions",
-          body: { workspacePath, personaId, branchName },
-        }) as { success: boolean; sessions?: SessionMeta[] };
-        if (!cancelled && result.success && result.sessions) {
-          setSessions(result.sessions);
-        }
-      } catch {
-        // silently fail
-      }
-      if (!cancelled) setLoading(false);
-    })();
-    return () => { cancelled = true; };
-  }, [workspacePath, personaId, branchName]);
+  const { sessions, loading } = useSessionList(workspacePath, personaId, branchName);
 
   if (loading) return null;
 

--- a/mods/agent/ui/session/src/hooks/useAgentSession.ts
+++ b/mods/agent/ui/session/src/hooks/useAgentSession.ts
@@ -93,6 +93,16 @@ export function useAgentSession() {
       }),
       subscribeToRecording(personaId, setIsRecording),
       subscribeToWorktree(personaId, setWorktreeInfo),
+      subscribeToSessionReplay(personaId, (replayEntries) => {
+        const mapped = replayEntries.map((e: { type: string; message: string; timestamp: number; source?: string }, i: number) => ({
+          id: `replay-${i}`,
+          type: e.type as LogType,
+          message: e.message,
+          timestamp: e.timestamp,
+          source: e.source as "voice" | "text" | undefined,
+        }));
+        setEntries(mapped.slice(-100));
+      }),
     ];
     return () => sources.forEach((s) => s.close());
   }, [personaId]);
@@ -149,6 +159,9 @@ export function useAgentSession() {
 
   const sendMessage = useCallback(async (text: string, contextSessionUuid?: string) => {
     if (!personaId || !text.trim()) return;
+    if (state === "idle") {
+      setEntries([]); // Clear stale entries before session starts
+    }
     try {
       await callRpc("send-message", {
         personaId,
@@ -158,7 +171,7 @@ export function useAgentSession() {
     } catch (e) {
       setError(e instanceof Error ? e.message : String(e));
     }
-  }, [personaId]);
+  }, [personaId, state]);
 
   const closePanel = useCallback(async () => {
     if (personaId && state !== "idle") {
@@ -249,6 +262,20 @@ function subscribeToRecording(id: string, onRecording: (recording: boolean) => v
   return signals.stream<{ personaId: string; recording: boolean }>(
     "agent:recording",
     (p) => { if (p.personaId === id) onRecording(p.recording); },
+  );
+}
+
+interface ReplayEntry {
+  type: string;
+  message: string;
+  timestamp: number;
+  source?: string;
+}
+
+function subscribeToSessionReplay(id: string, onReplay: (entries: ReplayEntry[]) => void) {
+  return signals.stream<{ personaId: string; entries: ReplayEntry[] }>(
+    "agent:session-replay",
+    (p) => { if (p.personaId === id) onReplay(p.entries); },
   );
 }
 

--- a/mods/agent/ui/session/src/hooks/useAgentSession.ts
+++ b/mods/agent/ui/session/src/hooks/useAgentSession.ts
@@ -132,7 +132,6 @@ export function useAgentSession() {
     setEntries([]);
     try {
       const result = await callRpc("start-session", { personaId }) as {
-        success: boolean;
         replayEntries?: Array<{ type: string; message: string; timestamp: number; source?: string }>;
       };
       if (result.replayEntries && result.replayEntries.length > 0) {
@@ -166,7 +165,7 @@ export function useAgentSession() {
         personaId,
         text: text.trim(),
         ...(contextSessionUuid && { contextSessionUuid }),
-      }) as { success: boolean; replayEntries?: Array<{ type: string; message: string; timestamp: number; source?: string }> };
+      }) as { replayEntries?: Array<{ type: string; message: string; timestamp: number; source?: string }> };
       if (result.replayEntries && result.replayEntries.length > 0) {
         setEntries(result.replayEntries.map((e, i) => ({
           id: `replay-${i}`,

--- a/mods/agent/ui/session/src/hooks/useAgentSession.ts
+++ b/mods/agent/ui/session/src/hooks/useAgentSession.ts
@@ -147,13 +147,17 @@ export function useAgentSession() {
     }
   }, [personaId]);
 
-  const sendMessage = useCallback(async (text: string) => {
+  const sendMessage = useCallback(async (text: string, contextSessionUuid?: string) => {
     if (!personaId || !text.trim()) return;
     try {
       if (state === "idle") {
         await callRpc("start-session", { personaId });
       }
-      await callRpc("send-message", { personaId, text: text.trim() });
+      await callRpc("send-message", {
+        personaId,
+        text: text.trim(),
+        ...(contextSessionUuid && { contextSessionUuid }),
+      });
     } catch (e) {
       setError(e instanceof Error ? e.message : String(e));
     }

--- a/mods/agent/ui/session/src/hooks/useAgentSession.ts
+++ b/mods/agent/ui/session/src/hooks/useAgentSession.ts
@@ -93,16 +93,6 @@ export function useAgentSession() {
       }),
       subscribeToRecording(personaId, setIsRecording),
       subscribeToWorktree(personaId, setWorktreeInfo),
-      subscribeToSessionReplay(personaId, (replayEntries) => {
-        const mapped = replayEntries.map((e: { type: string; message: string; timestamp: number; source?: string }, i: number) => ({
-          id: `replay-${i}`,
-          type: e.type as LogType,
-          message: e.message,
-          timestamp: e.timestamp,
-          source: e.source as "voice" | "text" | undefined,
-        }));
-        setEntries(mapped.slice(-100));
-      }),
     ];
     return () => sources.forEach((s) => s.close());
   }, [personaId]);
@@ -159,19 +149,26 @@ export function useAgentSession() {
 
   const sendMessage = useCallback(async (text: string, contextSessionUuid?: string) => {
     if (!personaId || !text.trim()) return;
-    if (state === "idle") {
-      setEntries([]); // Clear stale entries before session starts
-    }
+    setEntries([]);
     try {
-      await callRpc("send-message", {
+      const result = await callRpc("send-message", {
         personaId,
         text: text.trim(),
         ...(contextSessionUuid && { contextSessionUuid }),
-      });
+      }) as { success: boolean; replayEntries?: Array<{ type: string; message: string; timestamp: number; source?: string }> };
+      if (result.replayEntries && result.replayEntries.length > 0) {
+        setEntries(result.replayEntries.map((e, i) => ({
+          id: `replay-${i}`,
+          type: e.type as LogType,
+          message: e.message,
+          timestamp: e.timestamp,
+          source: e.source as "voice" | "text" | undefined,
+        })).slice(-100));
+      }
     } catch (e) {
       setError(e instanceof Error ? e.message : String(e));
     }
-  }, [personaId, state]);
+  }, [personaId]);
 
   const closePanel = useCallback(async () => {
     if (personaId && state !== "idle") {
@@ -262,20 +259,6 @@ function subscribeToRecording(id: string, onRecording: (recording: boolean) => v
   return signals.stream<{ personaId: string; recording: boolean }>(
     "agent:recording",
     (p) => { if (p.personaId === id) onRecording(p.recording); },
-  );
-}
-
-interface ReplayEntry {
-  type: string;
-  message: string;
-  timestamp: number;
-  source?: string;
-}
-
-function subscribeToSessionReplay(id: string, onReplay: (entries: ReplayEntry[]) => void) {
-  return signals.stream<{ personaId: string; entries: ReplayEntry[] }>(
-    "agent:session-replay",
-    (p) => { if (p.personaId === id) onReplay(p.entries); },
   );
 }
 

--- a/mods/agent/ui/session/src/hooks/useAgentSession.ts
+++ b/mods/agent/ui/session/src/hooks/useAgentSession.ts
@@ -131,7 +131,19 @@ export function useAgentSession() {
     setError(null);
     setEntries([]);
     try {
-      await callRpc("start-session", { personaId });
+      const result = await callRpc("start-session", { personaId }) as {
+        success: boolean;
+        replayEntries?: Array<{ type: string; message: string; timestamp: number; source?: string }>;
+      };
+      if (result.replayEntries && result.replayEntries.length > 0) {
+        setEntries(result.replayEntries.map((e, i) => ({
+          id: `replay-${i}`,
+          type: e.type as LogType,
+          message: e.message,
+          timestamp: e.timestamp,
+          source: e.source as "voice" | "text" | undefined,
+        })).slice(-100));
+      }
     } catch (e) {
       setError(e instanceof Error ? e.message : String(e));
     }
@@ -149,7 +161,6 @@ export function useAgentSession() {
 
   const sendMessage = useCallback(async (text: string, contextSessionUuid?: string) => {
     if (!personaId || !text.trim()) return;
-    setEntries([]);
     try {
       const result = await callRpc("send-message", {
         personaId,

--- a/mods/agent/ui/session/src/hooks/useAgentSession.ts
+++ b/mods/agent/ui/session/src/hooks/useAgentSession.ts
@@ -150,9 +150,6 @@ export function useAgentSession() {
   const sendMessage = useCallback(async (text: string, contextSessionUuid?: string) => {
     if (!personaId || !text.trim()) return;
     try {
-      if (state === "idle") {
-        await callRpc("start-session", { personaId });
-      }
       await callRpc("send-message", {
         personaId,
         text: text.trim(),
@@ -161,7 +158,7 @@ export function useAgentSession() {
     } catch (e) {
       setError(e instanceof Error ? e.message : String(e));
     }
-  }, [personaId, state]);
+  }, [personaId]);
 
   const closePanel = useCallback(async () => {
     if (personaId && state !== "idle") {

--- a/mods/agent/ui/session/src/hooks/useCurrentBranch.ts
+++ b/mods/agent/ui/session/src/hooks/useCurrentBranch.ts
@@ -1,0 +1,29 @@
+import { useState, useEffect } from "react";
+import { rpc } from "@hmcs/sdk/rpc";
+
+/** Resolve the current git branch for a workspace via the get-current-branch RPC. */
+export function useCurrentBranch(workspacePath: string | null, worktreeName: string | null): string | null {
+  const [branch, setBranch] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!workspacePath) return;
+    let cancelled = false;
+    (async () => {
+      try {
+        const result = await rpc.call({
+          modName: "@hmcs/agent",
+          method: "get-current-branch",
+          body: { workspacePath, worktreeName },
+        }) as { branchName?: string };
+        if (!cancelled && result.branchName) {
+          setBranch(result.branchName);
+        }
+      } catch {
+        if (!cancelled) setBranch(null);
+      }
+    })();
+    return () => { cancelled = true; };
+  }, [workspacePath, worktreeName]);
+
+  return branch;
+}

--- a/mods/agent/ui/session/src/hooks/useSessionList.ts
+++ b/mods/agent/ui/session/src/hooks/useSessionList.ts
@@ -28,8 +28,8 @@ export function useSessionList(
           modName: "@hmcs/agent",
           method: "list-sessions",
           body: { workspacePath, personaId, branchName },
-        }) as { success: boolean; sessions?: SessionMeta[] };
-        if (!cancelled && result.success && result.sessions) {
+        }) as { sessions?: SessionMeta[] };
+        if (!cancelled && result.sessions) {
           setSessions(result.sessions);
         }
       } catch {

--- a/mods/agent/ui/session/src/hooks/useSessionList.ts
+++ b/mods/agent/ui/session/src/hooks/useSessionList.ts
@@ -1,0 +1,44 @@
+import { useState, useEffect } from "react";
+import { rpc } from "@hmcs/sdk/rpc";
+
+export interface SessionMeta {
+  uuid: string;
+  startedAt: number;
+  preview: string | null;
+}
+
+/** Fetch session history for a persona on a specific branch. */
+export function useSessionList(
+  workspacePath: string,
+  personaId: string,
+  branchName: string | null,
+): { sessions: SessionMeta[]; loading: boolean } {
+  const [sessions, setSessions] = useState<SessionMeta[]>([]);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    if (!branchName) {
+      setLoading(false);
+      return;
+    }
+    let cancelled = false;
+    (async () => {
+      try {
+        const result = await rpc.call({
+          modName: "@hmcs/agent",
+          method: "list-sessions",
+          body: { workspacePath, personaId, branchName },
+        }) as { success: boolean; sessions?: SessionMeta[] };
+        if (!cancelled && result.success && result.sessions) {
+          setSessions(result.sessions);
+        }
+      } catch {
+        // silently fail
+      }
+      if (!cancelled) setLoading(false);
+    })();
+    return () => { cancelled = true; };
+  }, [workspacePath, personaId, branchName]);
+
+  return { sessions, loading };
+}

--- a/mods/agent/ui/session/src/settings/components/RemoveWorktreeDialog.tsx
+++ b/mods/agent/ui/session/src/settings/components/RemoveWorktreeDialog.tsx
@@ -40,18 +40,14 @@ export function RemoveWorktreeDialog({
     setBusy(true);
     setError(null);
     try {
-      const result = await rpc.call<{ success: boolean; error?: string }>({
+      await rpc.call({
         modName: "@hmcs/agent",
         method: "remove-worktree",
         body: { workspacePath, name: worktree.name, action },
       });
-      if (!result.success) {
-        setError(result.error ?? "Operation failed");
-        return;
-      }
       onRemoved();
-    } catch (err) {
-      setError(err instanceof Error ? err.message : String(err));
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "Operation failed");
     } finally {
       setBusy(false);
     }

--- a/mods/agent/ui/session/src/settings/types.ts
+++ b/mods/agent/ui/session/src/settings/types.ts
@@ -3,4 +3,6 @@ export type SettingsCategory = "phrases" | "permissions" | "backend";
 export type BodyContent =
   | { kind: "sessionLog" }
   | { kind: "settingsForm"; category: SettingsCategory }
-  | { kind: "empty" };
+  | { kind: "empty" }
+  | { kind: "sessionHistory" }
+  | { kind: "pastSession"; uuid: string };


### PR DESCRIPTION
## Problem

Closes #115

`@hmcs/agent` has no persistent session log storage. All session history exists only in-memory (max 100 entries in the UI). When the app restarts or a session ends, the entire observable history is lost. There is no way to resume a previous session's context or view past session activity.

## Solution

Add JSONL-based session log persistence scoped by **PersonaId + git branch**, with session context injection for cross-session continuity.

### Storage

- Session logs stored as JSONL files at `{workspace}/.hmcs/sessions/{personaId}/{branchName}/{uuid}.jsonl`
- Directory structure encodes scoping — no metadata needed for session discovery
- Branch names containing `/` (e.g., `feature/auth`) naturally create nested directories
- 90-day TTL cleanup runs on session start

### Write Path

- `SessionPersistence` module (`session-persistence.ts`) handles all JSONL I/O: create, append (non-blocking ordered writes via promise chaining), close, list, read, cleanup
- `emitLog()` and `emitUserLog()` in `service.ts` persist entries alongside signal emission
- Session files created on session start, closed with footer on normal end, left without footer on crash

### Restoration

- On session start, previous session's entries are read and key context (user/assistant messages + tool activity summary) is extracted via `buildSessionContext()`
- Context injected into the system prompt via `buildPersonaPrompt()` as a `## Prior Session Context` section
- Fully runtime-agnostic — same logs carry over regardless of Codex/Claude SDK switch

### Prompt Architecture Change

- Renamed `buildCharacterPrompt()` → `buildPersonaPrompt()` with optional `sessionContext` parameter
- Moved prompt building from runtime internals to `service.ts` — runtimes now receive a `prompt: string` instead of `persona` + `worktree`

### Read Path

- Three new RPCs: `list-sessions`, `get-session-logs`, `get-current-branch`
- `send-message` RPC gains optional `contextSessionUuid` parameter and returns `replayEntries` for UI display

### UI

- **SessionHistory** component: date-grouped list of past sessions (Today/Yesterday/date), shown when idle with a configured workspace
- **PastSessionView** component: read-only past session log viewer with TextInput for starting a new session from any past session's context
- Auto-transition to `sessionHistory` on session stop and workspace/worktree change
- Replay entries from previous sessions displayed in ActivityLog via RPC response

### Migration

- Old `agent::session::{runtime}::{personaId}` preference keys superseded; `SESSION_PREF_PREFIX`, `loadSavedSession()`, `saveSession()` removed

### Affected areas

- **mods**: `@hmcs/agent` (service, runtimes, prompt, UI)
- New file: `mods/agent/lib/session-persistence.ts` (243 lines)
- New files: `SessionHistory.tsx`, `PastSessionView.tsx`
- Modified: `service.ts`, `prompt.ts`, runtime files, `UnifiedView.tsx`, `useAgentSession.ts`

## Documentation

- [ ] Included in this PR
- [ ] Will be added in a follow-up PR
- [x] Not needed

---

- [ ] If HTTP endpoints changed: I ran `make gen-open-api` and `pnpm build`
- [ ] This PR includes breaking changes