### PR TITLE
feat: add GET /assets/file endpoint for serving asset content by ID

### DIFF
--- a/engine/Cargo.lock
+++ b/engine/Cargo.lock
@@ -4663,6 +4663,7 @@ dependencies = [
  "homunculus_screen",
  "homunculus_utils",
  "http-body-util",
+ "mime_guess",
  "reqwest",
  "rfd",
  "serde",
@@ -5686,6 +5687,16 @@ name = "mime"
 version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
+
+[[package]]
+name = "mime_guess"
+version = "2.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f7c44f8e672c00fe5308fa235f821cb4198414e1c77935c1ab6948d3fd78550e"
+dependencies = [
+ "mime",
+ "unicase",
+]
 
 [[package]]
 name = "minimal-lexical"
@@ -9050,6 +9061,12 @@ dependencies = [
  "tempfile",
  "windows-sys 0.61.2",
 ]
+
+[[package]]
+name = "unicase"
+version = "2.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dbc4bc3a9f746d862c45cb89d705aa10f187bb96c76001afab07a0d35ce60142"
 
 [[package]]
 name = "unicode-bidi"

--- a/engine/Cargo.toml
+++ b/engine/Cargo.toml
@@ -121,6 +121,7 @@ libc = "0.2"
 windows = "0.60"
 raw-window-handle = "0.6"
 num_cpus = "1"
+mime_guess = "2"
 
 [build-dependencies]
 embed-resource = "3"

--- a/engine/crates/homunculus_api/src/assets.rs
+++ b/engine/crates/homunculus_api/src/assets.rs
@@ -45,6 +45,26 @@ impl AssetsApi {
             })
             .await
     }
+
+    /// Resolves an asset ID to its absolute file path.
+    pub async fn get_file_path(&self, asset_id: String) -> ApiResult<std::path::PathBuf> {
+        self.0
+            .schedule(move |task| async move {
+                task.will(Update, once::run(resolve_file_path).with(asset_id))
+                    .await
+            })
+            .await?
+    }
+}
+
+fn resolve_file_path(
+    In(asset_id): In<String>,
+    registry: Res<AssetRegistry>,
+) -> ApiResult<std::path::PathBuf> {
+    let entry = registry
+        .get(&asset_id)
+        .ok_or_else(|| crate::error::ApiError::AssetNotFound(AssetId::new(&asset_id)))?;
+    Ok(entry.absolute_path.clone())
 }
 
 fn list_assets(In(filter): In<AssetFilter>, registry: Res<AssetRegistry>) -> Vec<AssetInfo> {

--- a/engine/crates/homunculus_http_server/Cargo.toml
+++ b/engine/crates/homunculus_http_server/Cargo.toml
@@ -10,7 +10,7 @@ publish.workspace = true
 [dependencies]
 bevy = { workspace = true }
 axum = { workspace = true, features = ["tokio", "macros"] }
-tokio = { version = "1", features = ["rt-multi-thread", "process", "io-util"] }
+tokio = { version = "1", features = ["rt-multi-thread", "process", "io-util", "fs"] }
 tokio-stream = "0.1"
 bevy_vrm1 = { workspace = true }
 homunculus_core = { workspace = true, features = ["openapi"] }
@@ -35,6 +35,7 @@ utoipa = { workspace = true }
 utoipa-axum = { workspace = true }
 rfd = { workspace = true }
 uuid = { workspace = true }
+mime_guess = { workspace = true }
 
 [dev-dependencies]
 serde_json = "1.0.140"

--- a/engine/crates/homunculus_http_server/src/lib.rs
+++ b/engine/crates/homunculus_http_server/src/lib.rs
@@ -944,9 +944,7 @@ mod tests {
             .unwrap();
         assert_eq!(content_type, "image/jpeg");
 
-        let body = block_on(response.into_body().collect())
-            .unwrap()
-            .to_bytes();
+        let body = block_on(response.into_body().collect()).unwrap().to_bytes();
         assert_eq!(&body[..], b"fake-jpg-data");
 
         std::fs::remove_file(&tmp).ok();
@@ -957,16 +955,16 @@ mod tests {
         let (mut app, router) = test_app();
 
         // Register asset with a path that does not exist on disk
-        app.world_mut()
-            .resource_mut::<AssetRegistry>()
-            .register(homunculus_core::prelude::AssetEntry {
+        app.world_mut().resource_mut::<AssetRegistry>().register(
+            homunculus_core::prelude::AssetEntry {
                 id: homunculus_utils::prelude::AssetId::new("test-mod:ghost"),
                 path: PathBuf::from("ghost.png"),
                 absolute_path: PathBuf::from("/tmp/does_not_exist_12345.png"),
                 asset_type: AssetType::Image,
                 description: None,
                 mod_name: "test-mod".to_string(),
-            });
+            },
+        );
 
         let request = Request::get("/assets/file?id=test-mod:ghost")
             .body(Body::empty())

--- a/engine/crates/homunculus_http_server/src/lib.rs
+++ b/engine/crates/homunculus_http_server/src/lib.rs
@@ -914,6 +914,68 @@ mod tests {
     }
 
     #[test]
+    fn test_get_asset_file_imported_asset() {
+        let (mut app, router) = test_app();
+
+        let tmp = std::env::temp_dir().join("test_imported_asset.jpg");
+        std::fs::write(&tmp, b"fake-jpg-data").unwrap();
+
+        // Use register_imported (same path as POST /assets/import)
+        app.world_mut()
+            .resource_mut::<AssetRegistry>()
+            .register_imported(homunculus_core::prelude::AssetEntry {
+                id: homunculus_utils::prelude::AssetId::new("vrm:local:my-persona"),
+                path: PathBuf::from("vrm_local_my-persona.jpg"),
+                absolute_path: tmp.clone(),
+                asset_type: AssetType::Image,
+                description: None,
+                mod_name: "local".to_string(),
+            });
+
+        let request = Request::get("/assets/file?id=vrm:local:my-persona")
+            .body(Body::empty())
+            .unwrap();
+        let response = block_on(call(&mut app, router, request));
+        let content_type = response
+            .headers()
+            .get("content-type")
+            .unwrap()
+            .to_str()
+            .unwrap();
+        assert_eq!(content_type, "image/jpeg");
+
+        let body = block_on(response.into_body().collect())
+            .unwrap()
+            .to_bytes();
+        assert_eq!(&body[..], b"fake-jpg-data");
+
+        std::fs::remove_file(&tmp).ok();
+    }
+
+    #[test]
+    fn test_get_asset_file_missing_file_on_disk() {
+        let (mut app, router) = test_app();
+
+        // Register asset with a path that does not exist on disk
+        app.world_mut()
+            .resource_mut::<AssetRegistry>()
+            .register(homunculus_core::prelude::AssetEntry {
+                id: homunculus_utils::prelude::AssetId::new("test-mod:ghost"),
+                path: PathBuf::from("ghost.png"),
+                absolute_path: PathBuf::from("/tmp/does_not_exist_12345.png"),
+                asset_type: AssetType::Image,
+                description: None,
+                mod_name: "test-mod".to_string(),
+            });
+
+        let request = Request::get("/assets/file?id=test-mod:ghost")
+            .body(Body::empty())
+            .unwrap();
+        let response = block_on(call_any_status(&mut app, router, request));
+        assert_eq!(response.status(), StatusCode::NOT_FOUND);
+    }
+
+    #[test]
     fn test_list_signals_with_channels() {
         let (mut app, router) = test_app();
 

--- a/engine/crates/homunculus_http_server/src/lib.rs
+++ b/engine/crates/homunculus_http_server/src/lib.rs
@@ -234,6 +234,7 @@ fn build_openapi_router() -> OpenApiRouter<HttpState> {
         .nest("/dialog", dialog_router())
         .routes(routes!(assets::list))
         .routes(routes!(assets::import))
+        .routes(routes!(assets::get_asset_file))
         .nest("/rpc", rpc_openapi_router())
 }
 
@@ -846,6 +847,70 @@ mod tests {
             request,
             vec![],
         ));
+    }
+
+    #[test]
+    fn test_get_asset_file_returns_file_content() {
+        let (mut app, router) = test_app();
+
+        // Create a temp file with known content
+        let tmp = std::env::temp_dir().join("test_asset_file.png");
+        std::fs::write(&tmp, b"fake-png-content").unwrap();
+
+        // Register an asset pointing to the temp file
+        app.world_mut().resource_mut::<AssetRegistry>().register(
+            homunculus_core::prelude::AssetEntry {
+                id: homunculus_utils::prelude::AssetId::new("test-mod:my-image"),
+                path: PathBuf::from("my-image.png"),
+                absolute_path: tmp.clone(),
+                asset_type: AssetType::Image,
+                description: None,
+                mod_name: "test-mod".to_string(),
+            },
+        );
+
+        let request = Request::get("/assets/file?id=test-mod:my-image")
+            .body(Body::empty())
+            .unwrap();
+        let response = block_on(call(&mut app, router, request));
+        let content_type = response
+            .headers()
+            .get("content-type")
+            .unwrap()
+            .to_str()
+            .unwrap();
+        assert_eq!(content_type, "image/png");
+
+        let nosniff = response
+            .headers()
+            .get("x-content-type-options")
+            .unwrap()
+            .to_str()
+            .unwrap();
+        assert_eq!(nosniff, "nosniff");
+
+        let body = block_on(response.into_body().collect()).unwrap().to_bytes();
+        assert_eq!(&body[..], b"fake-png-content");
+
+        std::fs::remove_file(&tmp).ok();
+    }
+
+    #[test]
+    fn test_get_asset_file_not_found() {
+        let (mut app, router) = test_app();
+        let request = Request::get("/assets/file?id=nonexistent:asset")
+            .body(Body::empty())
+            .unwrap();
+        let response = block_on(call_any_status(&mut app, router, request));
+        assert_eq!(response.status(), StatusCode::NOT_FOUND);
+    }
+
+    #[test]
+    fn test_get_asset_file_missing_id() {
+        let (mut app, router) = test_app();
+        let request = Request::get("/assets/file").body(Body::empty()).unwrap();
+        let response = block_on(call_any_status(&mut app, router, request));
+        assert_eq!(response.status(), StatusCode::BAD_REQUEST);
     }
 
     #[test]

--- a/engine/crates/homunculus_http_server/src/route/assets.rs
+++ b/engine/crates/homunculus_http_server/src/route/assets.rs
@@ -1,7 +1,10 @@
 use axum::Json;
 use axum::extract::{Query, State};
+use axum::response::{IntoResponse, Response};
 use homunculus_api::assets::{AssetFilter, AssetInfo, AssetsApi, ImportAsset, ImportAssetResponse};
+use homunculus_api::prelude::ApiError;
 use homunculus_api::prelude::axum::{HttpResult, IntoHttpResult};
+use serde::Deserialize;
 
 /// List available assets, optionally filtered by type or mod name.
 #[utoipa::path(
@@ -42,4 +45,73 @@ pub async fn import(
     Json(body): Json<ImportAsset>,
 ) -> HttpResult<ImportAssetResponse> {
     api.import(body).await.into_http_result()
+}
+
+/// Query parameters for the asset file endpoint.
+#[derive(Deserialize)]
+pub struct AssetFileQuery {
+    pub id: Option<String>,
+}
+
+/// Get the raw file content of an asset by its ID.
+///
+/// Returns the file bytes with a `Content-Type` header inferred from
+/// the file extension. Unknown extensions fall back to
+/// `application/octet-stream`.
+#[utoipa::path(
+    get,
+    path = "/assets/file",
+    tag = "assets",
+    params(
+        ("id" = String, Query, description = "Asset ID (e.g. '@hmcs/elmer:thumbnail')"),
+    ),
+    responses(
+        (status = 200, description = "Raw file content", content_type = "application/octet-stream"),
+        (status = 400, description = "Missing id parameter"),
+        (status = 404, description = "Asset not found or file missing"),
+        (status = 500, description = "IO error"),
+    ),
+)]
+pub async fn get_asset_file(
+    State(api): State<AssetsApi>,
+    Query(query): Query<AssetFileQuery>,
+) -> Result<Response, ApiError> {
+    let asset_id = query
+        .id
+        .ok_or_else(|| ApiError::InvalidInput("Missing required query parameter: id".into()))?;
+
+    let path = api.get_file_path(asset_id).await?;
+    read_and_respond(&path).await
+}
+
+/// Reads the file at `path` and builds an HTTP response with inferred MIME type.
+async fn read_and_respond(path: &std::path::Path) -> Result<Response, ApiError> {
+    let bytes = std::fs::read(path).map_err(|e| map_io_error(e, path))?;
+    let mime = mime_guess::from_path(path)
+        .first_raw()
+        .unwrap_or("application/octet-stream");
+
+    Ok((
+        [
+            (axum::http::header::CONTENT_TYPE, mime),
+            (
+                axum::http::header::HeaderName::from_static("x-content-type-options"),
+                "nosniff",
+            ),
+        ],
+        bytes,
+    )
+        .into_response())
+}
+
+/// Maps a `std::io::Error` to an `ApiError`.
+///
+/// `NotFound` maps to `AssetNotFound` (404), all other IO errors map
+/// to `InvalidInput` which falls through to the 500 catch-all.
+fn map_io_error(err: std::io::Error, path: &std::path::Path) -> ApiError {
+    if err.kind() == std::io::ErrorKind::NotFound {
+        ApiError::AssetNotFound(path.display().to_string().into())
+    } else {
+        ApiError::InvalidInput(format!("Failed to read file {}: {err}", path.display()))
+    }
 }

--- a/engine/crates/homunculus_http_server/src/route/assets.rs
+++ b/engine/crates/homunculus_http_server/src/route/assets.rs
@@ -50,7 +50,7 @@ pub async fn import(
 /// Query parameters for the asset file endpoint.
 #[derive(Deserialize)]
 pub struct AssetFileQuery {
-    pub id: Option<String>,
+    pub id: String,
 }
 
 /// Get the raw file content of an asset by its ID.
@@ -76,11 +76,7 @@ pub async fn get_asset_file(
     State(api): State<AssetsApi>,
     Query(query): Query<AssetFileQuery>,
 ) -> Result<Response, ApiError> {
-    let asset_id = query
-        .id
-        .ok_or_else(|| ApiError::InvalidInput("Missing required query parameter: id".into()))?;
-
-    let path = api.get_file_path(asset_id).await?;
+    let path = api.get_file_path(query.id).await?;
     read_and_respond(&path).await
 }
 


### PR DESCRIPTION
## Problem

PR #123 (Persona Management UI) identified a follow-up need: an endpoint to serve raw asset file content by asset ID. This is required for features like custom persona thumbnail selection, where WebView UIs need to display images by referencing asset IDs directly without knowing filesystem paths.

## Solution

Added `GET /assets/file?id={asset_id}` endpoint following the existing Core → API → HTTP three-layer pattern.

- **API layer** (`engine/crates/homunculus_api/src/assets.rs`): Added `AssetsApi::get_file_path()` method that resolves an asset ID to its absolute file path via `AssetRegistry`
- **HTTP layer** (`engine/crates/homunculus_http_server/src/route/assets.rs`): Added `get_asset_file` handler that reads the file and returns raw bytes with `Content-Type` inferred from file extension using `mime_guess`
- Works for both MOD-declared assets and user-imported assets (via `POST /assets/import`)
- Error handling: 400 for missing `id` param, 404 for unknown asset ID or missing file on disk, 500 for other IO errors

5 tests added covering: success case with Content-Type/nosniff headers, not-found asset, missing query param, imported asset resolution, and file-missing-on-disk.

## Documentation

- [ ] Included in this PR
- [x] Will be added in a follow-up PR
- [ ] Not needed

---

- [x] If HTTP endpoints changed: I ran `make gen-open-api` and `pnpm build`
- [ ] This PR includes breaking changes