### PR TITLE
feat: replace WebviewOffset with Transform-based positioning and swing-twist constraints

### DIFF
--- a/engine/crates/homunculus_api/src/webview.rs
+++ b/engine/crates/homunculus_api/src/webview.rs
@@ -1,4 +1,5 @@
 mod close;
+pub(crate) mod constraint;
 mod get;
 mod is_closed;
 mod linked_persona;
@@ -17,6 +18,6 @@ pub struct WebviewApiPlugin;
 
 impl Plugin for WebviewApiPlugin {
     fn build(&self, app: &mut App) {
-        app.add_plugins(open::WebviewOpenPlugin);
+        app.add_plugins((open::WebviewOpenPlugin, constraint::ConstraintPlugin));
     }
 }

--- a/engine/crates/homunculus_api/src/webview/constraint.rs
+++ b/engine/crates/homunculus_api/src/webview/constraint.rs
@@ -36,7 +36,9 @@ fn auto_insert_constraints(
     }
 }
 
-/// Overrides the propagated `GlobalTransform` of constrained child entities.
+/// Corrects the propagated `GlobalTransform` of constrained child entities.
+///
+/// Preserves the propagated translation and only overrides rotation and scale.
 fn apply_transform_constraints(
     mut children: Query<(&ChildOf, &TransformConstraint, &mut GlobalTransform)>,
     parents: Query<&GlobalTransform, Without<TransformConstraint>>,
@@ -45,50 +47,27 @@ fn apply_transform_constraints(
         let Ok(parent_global) = parents.get(child_of.parent()) else {
             continue;
         };
-        *global = compute_constrained_global(parent_global, constraint);
+        let propagated_translation = global.translation();
+        let parent_rot = parent_global.rotation();
+        let parent_scale = parent_global.scale();
+
+        let rotation = compute_constrained_rotation(
+            parent_rot,
+            constraint.rotation_follow,
+            constraint.max_tilt_degrees,
+        );
+        let scale = if constraint.lock_scale {
+            Vec3::ONE
+        } else {
+            parent_scale
+        };
+
+        *global = GlobalTransform::from(Transform {
+            translation: propagated_translation,
+            rotation,
+            scale,
+        });
     }
-}
-
-// ---------------------------------------------------------------------------
-// Math helpers
-// ---------------------------------------------------------------------------
-
-/// Builds a `GlobalTransform` that honours the given constraint relative to a parent.
-///
-/// The pipeline:
-/// 1. Fast-path: `rotation_follow == 0` and `max_tilt_degrees == 0` → identity rotation.
-/// 2. Slerp from identity toward the parent rotation by `rotation_follow`.
-/// 3. Decompose into swing (tilt from Y-up) and twist (yaw around Y).
-/// 4. Clamp swing to `max_tilt_degrees`, discard twist.
-/// 5. Compute translation as `parent_T + constrained_R * intended_offset`.
-/// 6. Scale is `Vec3::ONE` when `lock_scale` is true.
-pub fn compute_constrained_global(
-    parent_global: &GlobalTransform,
-    constraint: &TransformConstraint,
-) -> GlobalTransform {
-    let parent_rot = parent_global.rotation();
-    let parent_translation = parent_global.translation();
-    let parent_scale = parent_global.scale();
-
-    let rotation = compute_constrained_rotation(
-        parent_rot,
-        constraint.rotation_follow,
-        constraint.max_tilt_degrees,
-    );
-
-    let scale = if constraint.lock_scale {
-        Vec3::ONE
-    } else {
-        parent_scale
-    };
-
-    let translation = parent_translation + rotation * constraint.intended_offset;
-
-    GlobalTransform::from(Transform {
-        translation,
-        rotation,
-        scale,
-    })
 }
 
 /// Computes the constrained rotation from a parent rotation.
@@ -252,92 +231,58 @@ mod tests {
     }
 
     // -----------------------------------------------------------------------
-    // compute_constrained_global
+    // compute_constrained_rotation (via apply_transform_constraints)
     // -----------------------------------------------------------------------
 
     #[test]
     fn billboard_mode_no_rotation() {
         // follow=0, lock_scale=true, parent rotated + scaled
-        let parent = GlobalTransform::from(Transform {
-            translation: Vec3::new(1.0, 2.0, 3.0),
-            rotation: Quat::from_rotation_y(PI / 3.0),
-            scale: Vec3::splat(2.0),
-        });
         let constraint = TransformConstraint {
             rotation_follow: 0.0,
             max_tilt_degrees: 0.0,
             lock_scale: true,
-            intended_offset: Vec3::new(0.0, 1.0, 0.0),
         };
+        let parent_rot = Quat::from_rotation_y(PI / 3.0);
 
-        let result = compute_constrained_global(&parent, &constraint);
-        let t = result.compute_transform();
-
-        assert_near_identity(t.rotation, "rotation");
-        assert!(
-            (t.scale - Vec3::ONE).length() < EPSILON,
-            "scale should be ONE, got {:?}",
-            t.scale
-        );
-        // Translation = parent_T + IDENTITY * offset = (1,2,3) + (0,1,0) = (1,3,3)
-        let expected_t = Vec3::new(1.0, 3.0, 3.0);
-        assert!(
-            (t.translation - expected_t).length() < EPSILON,
-            "expected translation {expected_t:?}, got {:?}",
-            t.translation
-        );
+        let rotation =
+            compute_constrained_rotation(parent_rot, constraint.rotation_follow, constraint.max_tilt_degrees);
+        assert_near_identity(rotation, "rotation");
     }
 
     #[test]
     fn scale_locked_ignores_parent_scale() {
-        let parent = GlobalTransform::from(Transform {
-            translation: Vec3::ZERO,
-            rotation: Quat::IDENTITY,
-            scale: Vec3::splat(3.0),
-        });
         let constraint = TransformConstraint {
             rotation_follow: 0.0,
             max_tilt_degrees: 0.0,
             lock_scale: true,
-            intended_offset: Vec3::new(1.0, 0.0, 0.0),
         };
+        let parent_scale = Vec3::splat(3.0);
 
-        let result = compute_constrained_global(&parent, &constraint);
-        let t = result.compute_transform();
-
+        let scale = if constraint.lock_scale {
+            Vec3::ONE
+        } else {
+            parent_scale
+        };
         assert!(
-            (t.scale - Vec3::ONE).length() < EPSILON,
+            (scale - Vec3::ONE).length() < EPSILON,
             "scale should be ONE, got {:?}",
-            t.scale
-        );
-        // Offset should NOT be multiplied by parent scale
-        let expected_t = Vec3::new(1.0, 0.0, 0.0);
-        assert!(
-            (t.translation - expected_t).length() < EPSILON,
-            "expected translation {expected_t:?}, got {:?}",
-            t.translation
+            scale
         );
     }
 
     #[test]
     fn partial_follow_with_clamp() {
         // follow=1.0, maxTilt=10°, parent tilted 60° around X
-        let parent = GlobalTransform::from(Transform {
-            translation: Vec3::ZERO,
-            rotation: Quat::from_rotation_x(60f32.to_radians()),
-            scale: Vec3::ONE,
-        });
         let constraint = TransformConstraint {
             rotation_follow: 1.0,
             max_tilt_degrees: 10.0,
             lock_scale: true,
-            intended_offset: Vec3::ZERO,
         };
+        let parent_rot = Quat::from_rotation_x(60f32.to_radians());
 
-        let result = compute_constrained_global(&parent, &constraint);
-        let t = result.compute_transform();
-
-        let tilt_deg = t.rotation.angle_between(Quat::IDENTITY).to_degrees();
+        let rotation =
+            compute_constrained_rotation(parent_rot, constraint.rotation_follow, constraint.max_tilt_degrees);
+        let tilt_deg = rotation.angle_between(Quat::IDENTITY).to_degrees();
         assert!(tilt_deg <= 10.5, "expected tilt <= ~10°, got {tilt_deg}°");
     }
 }

--- a/engine/crates/homunculus_api/src/webview/constraint.rs
+++ b/engine/crates/homunculus_api/src/webview/constraint.rs
@@ -25,7 +25,10 @@ impl Plugin for ConstraintPlugin {
 }
 
 /// Inserts a default `TransformConstraint` on every entity that just received `LinkedPersona`.
-fn auto_insert_constraints(mut commands: Commands, query: Query<Entity, Added<LinkedPersona>>) {
+fn auto_insert_constraints(
+    mut commands: Commands,
+    query: Query<Entity, (Added<LinkedPersona>, Without<TransformConstraint>)>,
+) {
     for entity in &query {
         commands
             .entity(entity)

--- a/engine/crates/homunculus_api/src/webview/constraint.rs
+++ b/engine/crates/homunculus_api/src/webview/constraint.rs
@@ -38,16 +38,17 @@ fn auto_insert_constraints(
 
 /// Corrects the propagated `GlobalTransform` of constrained child entities.
 ///
-/// Preserves the propagated translation and only overrides rotation and scale.
+/// Overrides rotation and scale. When `lock_scale` is true, translation is
+/// recomputed without parent scale (using `parent_rot * local_T` instead of
+/// `parent_scale * parent_rot * local_T`).
 fn apply_transform_constraints(
-    mut children: Query<(&ChildOf, &TransformConstraint, &mut GlobalTransform)>,
+    mut children: Query<(&ChildOf, &TransformConstraint, &Transform, &mut GlobalTransform)>,
     parents: Query<&GlobalTransform, Without<TransformConstraint>>,
 ) {
-    for (child_of, constraint, mut global) in &mut children {
+    for (child_of, constraint, local_transform, mut global) in &mut children {
         let Ok(parent_global) = parents.get(child_of.parent()) else {
             continue;
         };
-        let propagated_translation = global.translation();
         let parent_rot = parent_global.rotation();
         let parent_scale = parent_global.scale();
 
@@ -61,9 +62,14 @@ fn apply_transform_constraints(
         } else {
             parent_scale
         };
+        let translation = if constraint.lock_scale {
+            parent_global.translation() + parent_rot * local_transform.translation
+        } else {
+            global.translation()
+        };
 
         *global = GlobalTransform::from(Transform {
-            translation: propagated_translation,
+            translation,
             rotation,
             scale,
         });

--- a/engine/crates/homunculus_api/src/webview/constraint.rs
+++ b/engine/crates/homunculus_api/src/webview/constraint.rs
@@ -42,7 +42,12 @@ fn auto_insert_constraints(
 /// recomputed without parent scale (using `parent_rot * local_T` instead of
 /// `parent_scale * parent_rot * local_T`).
 fn apply_transform_constraints(
-    mut children: Query<(&ChildOf, &TransformConstraint, &Transform, &mut GlobalTransform)>,
+    mut children: Query<(
+        &ChildOf,
+        &TransformConstraint,
+        &Transform,
+        &mut GlobalTransform,
+    )>,
     parents: Query<&GlobalTransform, Without<TransformConstraint>>,
 ) {
     for (child_of, constraint, local_transform, mut global) in &mut children {
@@ -250,8 +255,11 @@ mod tests {
         };
         let parent_rot = Quat::from_rotation_y(PI / 3.0);
 
-        let rotation =
-            compute_constrained_rotation(parent_rot, constraint.rotation_follow, constraint.max_tilt_degrees);
+        let rotation = compute_constrained_rotation(
+            parent_rot,
+            constraint.rotation_follow,
+            constraint.max_tilt_degrees,
+        );
         assert_near_identity(rotation, "rotation");
     }
 
@@ -286,8 +294,11 @@ mod tests {
         };
         let parent_rot = Quat::from_rotation_x(60f32.to_radians());
 
-        let rotation =
-            compute_constrained_rotation(parent_rot, constraint.rotation_follow, constraint.max_tilt_degrees);
+        let rotation = compute_constrained_rotation(
+            parent_rot,
+            constraint.rotation_follow,
+            constraint.max_tilt_degrees,
+        );
         let tilt_deg = rotation.angle_between(Quat::IDENTITY).to_degrees();
         assert!(tilt_deg <= 10.5, "expected tilt <= ~10°, got {tilt_deg}°");
     }

--- a/engine/crates/homunculus_api/src/webview/constraint.rs
+++ b/engine/crates/homunculus_api/src/webview/constraint.rs
@@ -1,0 +1,349 @@
+//! PostUpdate constraint system that corrects webview `GlobalTransform`s
+//! after Bevy's standard transform propagation.
+//!
+//! Webviews are children of persona entities but should remain upright
+//! (billboard-style) or only partially follow the parent's rotation.
+//! This module provides the math (swing-twist decomposition) and the
+//! Bevy systems that enforce those constraints every frame.
+
+use bevy::prelude::*;
+use bevy::transform::TransformSystems;
+use homunculus_core::prelude::{LinkedPersona, TransformConstraint};
+
+/// Bevy plugin that registers the PostUpdate constraint systems.
+pub struct ConstraintPlugin;
+
+impl Plugin for ConstraintPlugin {
+    fn build(&self, app: &mut App) {
+        app.add_systems(
+            PostUpdate,
+            (auto_insert_constraints, apply_transform_constraints)
+                .chain()
+                .after(TransformSystems::Propagate),
+        );
+    }
+}
+
+/// Inserts a default `TransformConstraint` on every entity that just received `LinkedPersona`.
+fn auto_insert_constraints(
+    mut commands: Commands,
+    query: Query<Entity, Added<LinkedPersona>>,
+) {
+    for entity in &query {
+        commands
+            .entity(entity)
+            .try_insert(TransformConstraint::default());
+    }
+}
+
+/// Overrides the propagated `GlobalTransform` of constrained child entities.
+fn apply_transform_constraints(
+    mut children: Query<(&ChildOf, &TransformConstraint, &mut GlobalTransform)>,
+    parents: Query<&GlobalTransform, Without<TransformConstraint>>,
+) {
+    for (child_of, constraint, mut global) in &mut children {
+        let Ok(parent_global) = parents.get(child_of.parent()) else {
+            continue;
+        };
+        *global = compute_constrained_global(parent_global, constraint);
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Math helpers
+// ---------------------------------------------------------------------------
+
+/// Builds a `GlobalTransform` that honours the given constraint relative to a parent.
+///
+/// The pipeline:
+/// 1. Fast-path: `rotation_follow == 0` and `max_tilt_degrees == 0` → identity rotation.
+/// 2. Slerp from identity toward the parent rotation by `rotation_follow`.
+/// 3. Decompose into swing (tilt from Y-up) and twist (yaw around Y).
+/// 4. Clamp swing to `max_tilt_degrees`, discard twist.
+/// 5. Compute translation as `parent_T + constrained_R * intended_offset`.
+/// 6. Scale is `Vec3::ONE` when `lock_scale` is true.
+pub fn compute_constrained_global(
+    parent_global: &GlobalTransform,
+    constraint: &TransformConstraint,
+) -> GlobalTransform {
+    let parent_rot = parent_global.rotation();
+    let parent_translation = parent_global.translation();
+    let parent_scale = parent_global.scale();
+
+    let rotation = compute_constrained_rotation(
+        parent_rot,
+        constraint.rotation_follow,
+        constraint.max_tilt_degrees,
+    );
+
+    let scale = if constraint.lock_scale {
+        Vec3::ONE
+    } else {
+        parent_scale
+    };
+
+    let translation = parent_translation + rotation * constraint.intended_offset;
+
+    GlobalTransform::from(Transform {
+        translation,
+        rotation,
+        scale,
+    })
+}
+
+/// Computes the constrained rotation from a parent rotation.
+fn compute_constrained_rotation(parent_rot: Quat, follow: f32, max_tilt_degrees: f32) -> Quat {
+    if follow == 0.0 && max_tilt_degrees == 0.0 {
+        return Quat::IDENTITY;
+    }
+
+    let blended = Quat::IDENTITY.slerp(parent_rot, follow.clamp(0.0, 1.0));
+    let (swing, _twist) = swing_twist_y(blended);
+    clamp_swing(swing, max_tilt_degrees)
+}
+
+/// Decomposes a quaternion into swing (tilt away from Y-up) and twist (yaw around Y).
+///
+/// Given `q`, we factor it as `q = swing * twist` where `twist` is a pure Y-axis rotation
+/// and `swing` contains the remaining tilt.
+///
+/// # Near-perpendicular guard
+///
+/// When the rotation is close to 90° from Y (i.e. the Y component is near zero),
+/// the twist extraction becomes numerically unstable.
+/// In that case we return `(q, Quat::IDENTITY)` — all rotation is treated as swing.
+pub fn swing_twist_y(q: Quat) -> (Quat, Quat) {
+    // The twist around Y is extracted from the (w, y) components.
+    if q.y.abs() < 1e-5 && q.w.abs() < 1e-5 {
+        // Near-perpendicular: cannot reliably separate twist.
+        return (q, Quat::IDENTITY);
+    }
+
+    let twist = Quat::from_xyzw(0.0, q.y, 0.0, q.w).normalize();
+    let swing = q * twist.inverse();
+
+    (swing, twist)
+}
+
+/// Clamps the swing angle to at most `max_degrees`.
+///
+/// Returns `Quat::IDENTITY` if `max_degrees <= 0.0` (no tilt allowed).
+/// If the swing angle is already within limits, returns it unchanged.
+pub fn clamp_swing(swing: Quat, max_degrees: f32) -> Quat {
+    if max_degrees <= 0.0 {
+        return Quat::IDENTITY;
+    }
+
+    let (axis, angle) = swing.to_axis_angle();
+    let max_radians = max_degrees.to_radians();
+
+    if angle <= max_radians {
+        swing
+    } else {
+        Quat::from_axis_angle(axis, max_radians)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::f32::consts::{FRAC_PI_2, PI};
+
+    const EPSILON: f32 = 1e-4;
+    /// Looser tolerance for numerically sensitive decompositions.
+    const LOOSE_EPSILON: f32 = 1e-2;
+
+    /// Helper: angle in degrees between two quaternions.
+    fn angle_between_deg(a: Quat, b: Quat) -> f32 {
+        a.angle_between(b).to_degrees()
+    }
+
+    /// Helper: checks that a quaternion is approximately identity.
+    fn assert_near_identity(q: Quat, label: &str) {
+        assert_near_identity_eps(q, EPSILON, label);
+    }
+
+    /// Helper with configurable tolerance.
+    fn assert_near_identity_eps(q: Quat, eps: f32, label: &str) {
+        let angle = q.angle_between(Quat::IDENTITY);
+        assert!(
+            angle < eps,
+            "{label}: expected near-identity, got angle {angle} rad ({} deg)",
+            angle.to_degrees()
+        );
+    }
+
+    // -----------------------------------------------------------------------
+    // swing_twist_y
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn swing_twist_identity() {
+        let (swing, twist) = swing_twist_y(Quat::IDENTITY);
+        assert_near_identity(swing, "swing");
+        assert_near_identity(twist, "twist");
+    }
+
+    #[test]
+    fn swing_twist_pure_yaw() {
+        // 45° rotation around Y → all twist, no swing
+        let yaw = Quat::from_rotation_y(PI / 4.0);
+        let (swing, twist) = swing_twist_y(yaw);
+        assert_near_identity(swing, "swing");
+        assert!(
+            angle_between_deg(twist, yaw) < 0.1,
+            "twist should equal input yaw"
+        );
+    }
+
+    #[test]
+    fn swing_twist_pure_tilt() {
+        // 30° rotation around X → pure swing, near-zero twist
+        let tilt = Quat::from_rotation_x(PI / 6.0);
+        let (swing, twist) = swing_twist_y(tilt);
+        assert_near_identity(twist, "twist");
+        assert!(
+            angle_between_deg(swing, tilt) < 0.1,
+            "swing should equal input tilt"
+        );
+    }
+
+    #[test]
+    fn swing_twist_near_perpendicular_guard() {
+        // 90° rotation around X → twist extraction is numerically unstable.
+        // The guard fires when both q.y and q.w are near zero; for a pure
+        // X rotation q.y==0 so twist normalises to identity with small error.
+        let tilt_90 = Quat::from_rotation_x(FRAC_PI_2);
+        let (swing, twist) = swing_twist_y(tilt_90);
+        assert_near_identity_eps(twist, LOOSE_EPSILON, "twist (near-perpendicular)");
+        assert!(
+            angle_between_deg(swing, tilt_90) < 0.1,
+            "swing should capture all rotation"
+        );
+    }
+
+    // -----------------------------------------------------------------------
+    // clamp_swing
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn clamp_swing_within_limit() {
+        let swing = Quat::from_rotation_x(5f32.to_radians());
+        let clamped = clamp_swing(swing, 10.0);
+        assert!(
+            angle_between_deg(clamped, swing) < 0.1,
+            "should be unchanged"
+        );
+    }
+
+    #[test]
+    fn clamp_swing_exceeds_limit() {
+        let swing = Quat::from_rotation_x(30f32.to_radians());
+        let clamped = clamp_swing(swing, 10.0);
+        let angle = clamped.angle_between(Quat::IDENTITY).to_degrees();
+        assert!(
+            (angle - 10.0).abs() < 0.5,
+            "expected ~10°, got {angle}°"
+        );
+    }
+
+    #[test]
+    fn clamp_swing_zero_degrees_returns_identity() {
+        let swing = Quat::from_rotation_x(15f32.to_radians());
+        let clamped = clamp_swing(swing, 0.0);
+        assert_near_identity(clamped, "clamped");
+    }
+
+    // -----------------------------------------------------------------------
+    // compute_constrained_global
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn billboard_mode_no_rotation() {
+        // follow=0, lock_scale=true, parent rotated + scaled
+        let parent = GlobalTransform::from(Transform {
+            translation: Vec3::new(1.0, 2.0, 3.0),
+            rotation: Quat::from_rotation_y(PI / 3.0),
+            scale: Vec3::splat(2.0),
+        });
+        let constraint = TransformConstraint {
+            rotation_follow: 0.0,
+            max_tilt_degrees: 0.0,
+            lock_scale: true,
+            intended_offset: Vec3::new(0.0, 1.0, 0.0),
+        };
+
+        let result = compute_constrained_global(&parent, &constraint);
+        let t = result.compute_transform();
+
+        assert_near_identity(t.rotation, "rotation");
+        assert!(
+            (t.scale - Vec3::ONE).length() < EPSILON,
+            "scale should be ONE, got {:?}",
+            t.scale
+        );
+        // Translation = parent_T + IDENTITY * offset = (1,2,3) + (0,1,0) = (1,3,3)
+        let expected_t = Vec3::new(1.0, 3.0, 3.0);
+        assert!(
+            (t.translation - expected_t).length() < EPSILON,
+            "expected translation {expected_t:?}, got {:?}",
+            t.translation
+        );
+    }
+
+    #[test]
+    fn scale_locked_ignores_parent_scale() {
+        let parent = GlobalTransform::from(Transform {
+            translation: Vec3::ZERO,
+            rotation: Quat::IDENTITY,
+            scale: Vec3::splat(3.0),
+        });
+        let constraint = TransformConstraint {
+            rotation_follow: 0.0,
+            max_tilt_degrees: 0.0,
+            lock_scale: true,
+            intended_offset: Vec3::new(1.0, 0.0, 0.0),
+        };
+
+        let result = compute_constrained_global(&parent, &constraint);
+        let t = result.compute_transform();
+
+        assert!(
+            (t.scale - Vec3::ONE).length() < EPSILON,
+            "scale should be ONE, got {:?}",
+            t.scale
+        );
+        // Offset should NOT be multiplied by parent scale
+        let expected_t = Vec3::new(1.0, 0.0, 0.0);
+        assert!(
+            (t.translation - expected_t).length() < EPSILON,
+            "expected translation {expected_t:?}, got {:?}",
+            t.translation
+        );
+    }
+
+    #[test]
+    fn partial_follow_with_clamp() {
+        // follow=1.0, maxTilt=10°, parent tilted 60° around X
+        let parent = GlobalTransform::from(Transform {
+            translation: Vec3::ZERO,
+            rotation: Quat::from_rotation_x(60f32.to_radians()),
+            scale: Vec3::ONE,
+        });
+        let constraint = TransformConstraint {
+            rotation_follow: 1.0,
+            max_tilt_degrees: 10.0,
+            lock_scale: true,
+            intended_offset: Vec3::ZERO,
+        };
+
+        let result = compute_constrained_global(&parent, &constraint);
+        let t = result.compute_transform();
+
+        let tilt_deg = t.rotation.angle_between(Quat::IDENTITY).to_degrees();
+        assert!(
+            tilt_deg <= 10.5,
+            "expected tilt <= ~10°, got {tilt_deg}°"
+        );
+    }
+}

--- a/engine/crates/homunculus_api/src/webview/constraint.rs
+++ b/engine/crates/homunculus_api/src/webview/constraint.rs
@@ -25,10 +25,7 @@ impl Plugin for ConstraintPlugin {
 }
 
 /// Inserts a default `TransformConstraint` on every entity that just received `LinkedPersona`.
-fn auto_insert_constraints(
-    mut commands: Commands,
-    query: Query<Entity, Added<LinkedPersona>>,
-) {
+fn auto_insert_constraints(mut commands: Commands, query: Query<Entity, Added<LinkedPersona>>) {
     for entity in &query {
         commands
             .entity(entity)
@@ -241,10 +238,7 @@ mod tests {
         let swing = Quat::from_rotation_x(30f32.to_radians());
         let clamped = clamp_swing(swing, 10.0);
         let angle = clamped.angle_between(Quat::IDENTITY).to_degrees();
-        assert!(
-            (angle - 10.0).abs() < 0.5,
-            "expected ~10°, got {angle}°"
-        );
+        assert!((angle - 10.0).abs() < 0.5, "expected ~10°, got {angle}°");
     }
 
     #[test]
@@ -341,9 +335,6 @@ mod tests {
         let t = result.compute_transform();
 
         let tilt_deg = t.rotation.angle_between(Quat::IDENTITY).to_degrees();
-        assert!(
-            tilt_deg <= 10.5,
-            "expected tilt <= ~10°, got {tilt_deg}°"
-        );
+        assert!(tilt_deg <= 10.5, "expected tilt <= ~10°, got {tilt_deg}°");
     }
 }

--- a/engine/crates/homunculus_api/src/webview/get.rs
+++ b/engine/crates/homunculus_api/src/webview/get.rs
@@ -41,8 +41,8 @@ fn get_webview(
                 viewport_size: viewport_size.0,
                 transform: TransformArgs {
                     translation: Some(transform.translation),
-                    rotation: None,
-                    scale: None,
+                    rotation: Some(transform.rotation),
+                    scale: Some(transform.scale),
                 },
                 constraints: WebviewConstraints {
                     rotation_follow: Some(c.rotation_follow),

--- a/engine/crates/homunculus_api/src/webview/get.rs
+++ b/engine/crates/homunculus_api/src/webview/get.rs
@@ -26,12 +26,13 @@ fn get_webview(
         &OriginalWebviewSource,
         Option<&WebviewMeshSize>,
         &WebviewSize,
+        &Transform,
         Option<&TransformConstraint>,
         Option<&LinkedPersona>,
     )>,
 ) -> ApiResult<WebviewInfo> {
     match webviews.get(webview) {
-        Ok((source, mesh_size, viewport_size, constraint, linked_persona)) => {
+        Ok((source, mesh_size, viewport_size, transform, constraint, linked_persona)) => {
             let c = constraint.copied().unwrap_or_default();
             Ok(WebviewInfo {
                 entity: webview,
@@ -39,7 +40,7 @@ fn get_webview(
                 size: mesh_size.map_or(WebviewMeshSize::default().0, |s| s.0),
                 viewport_size: viewport_size.0,
                 transform: TransformArgs {
-                    translation: Some(c.intended_offset),
+                    translation: Some(transform.translation),
                     rotation: None,
                     scale: None,
                 },

--- a/engine/crates/homunculus_api/src/webview/get.rs
+++ b/engine/crates/homunculus_api/src/webview/get.rs
@@ -5,8 +5,8 @@ use bevy::prelude::*;
 use bevy_cef::prelude::WebviewSize;
 use bevy_flurx::action::once;
 use homunculus_core::prelude::{
-    LinkedPersona, TransformConstraint, WebviewConstraints, WebviewInfo, WebviewMeshSize,
-    WebviewOffset,
+    LinkedPersona, TransformArgs, TransformConstraint, WebviewConstraints, WebviewInfo,
+    WebviewMeshSize,
 };
 
 impl WebviewApi {
@@ -38,7 +38,11 @@ fn get_webview(
                 source: webview_source_to_info(&source.0, true),
                 size: mesh_size.map_or(WebviewMeshSize::default().0, |s| s.0),
                 viewport_size: viewport_size.0,
-                offset: WebviewOffset(c.intended_offset),
+                transform: TransformArgs {
+                    translation: Some(c.intended_offset),
+                    rotation: None,
+                    scale: None,
+                },
                 constraints: WebviewConstraints {
                     rotation_follow: Some(c.rotation_follow),
                     max_tilt_degrees: Some(c.max_tilt_degrees),

--- a/engine/crates/homunculus_api/src/webview/get.rs
+++ b/engine/crates/homunculus_api/src/webview/get.rs
@@ -4,7 +4,10 @@ use crate::webview::open::{OriginalWebviewSource, webview_source_to_info};
 use bevy::prelude::*;
 use bevy_cef::prelude::WebviewSize;
 use bevy_flurx::action::once;
-use homunculus_core::prelude::{LinkedPersona, WebviewInfo, WebviewMeshSize, WebviewOffset};
+use homunculus_core::prelude::{
+    LinkedPersona, TransformConstraint, WebviewConstraints, WebviewInfo, WebviewMeshSize,
+    WebviewOffset,
+};
 
 impl WebviewApi {
     pub async fn get(&self, webview: Entity) -> ApiResult<WebviewInfo> {
@@ -23,19 +26,27 @@ fn get_webview(
         &OriginalWebviewSource,
         Option<&WebviewMeshSize>,
         &WebviewSize,
-        &WebviewOffset,
+        Option<&TransformConstraint>,
         Option<&LinkedPersona>,
     )>,
 ) -> ApiResult<WebviewInfo> {
     match webviews.get(webview) {
-        Ok((source, mesh_size, viewport_size, offset, linked_persona)) => Ok(WebviewInfo {
-            entity: webview,
-            source: webview_source_to_info(&source.0, true),
-            size: mesh_size.map_or(WebviewMeshSize::default().0, |s| s.0),
-            viewport_size: viewport_size.0,
-            offset: *offset,
-            linked_persona: linked_persona.map(|l| l.0.clone()),
-        }),
+        Ok((source, mesh_size, viewport_size, constraint, linked_persona)) => {
+            let c = constraint.copied().unwrap_or_default();
+            Ok(WebviewInfo {
+                entity: webview,
+                source: webview_source_to_info(&source.0, true),
+                size: mesh_size.map_or(WebviewMeshSize::default().0, |s| s.0),
+                viewport_size: viewport_size.0,
+                offset: WebviewOffset(c.intended_offset),
+                constraints: WebviewConstraints {
+                    rotation_follow: Some(c.rotation_follow),
+                    max_tilt_degrees: Some(c.max_tilt_degrees),
+                    lock_scale: Some(c.lock_scale),
+                },
+                linked_persona: linked_persona.map(|l| l.0.clone()),
+            })
+        }
         Err(_) => Err(ApiError::WebviewNotFound(webview)),
     }
 }

--- a/engine/crates/homunculus_api/src/webview/linked_persona.rs
+++ b/engine/crates/homunculus_api/src/webview/linked_persona.rs
@@ -2,7 +2,7 @@ use crate::error::{ApiError, ApiResult};
 use crate::prelude::WebviewApi;
 use bevy::prelude::*;
 use bevy_flurx::action::once;
-use homunculus_core::prelude::{LinkedPersona, PersonaId};
+use homunculus_core::prelude::{LinkedPersona, PersonaId, PersonaIndex};
 
 impl WebviewApi {
     /// Gets the linked persona ID for a webview.
@@ -57,13 +57,17 @@ fn set_linked_persona(
     In((webview, persona_id)): In<(Entity, PersonaId)>,
     mut commands: Commands,
     webviews: Query<Entity, With<bevy_cef::prelude::WebviewSource>>,
+    index: Res<PersonaIndex>,
 ) -> ApiResult<()> {
     if !webviews.contains(webview) {
         return Err(ApiError::WebviewNotFound(webview));
     }
     commands
         .entity(webview)
-        .try_insert(LinkedPersona(persona_id));
+        .try_insert(LinkedPersona(persona_id.clone()));
+    if let Some(persona_entity) = index.get(&persona_id) {
+        commands.entity(webview).set_parent_in_place(persona_entity);
+    }
     Ok(())
 }
 
@@ -73,7 +77,10 @@ fn unlink_persona(
     webviews: Query<Entity, With<bevy_cef::prelude::WebviewSource>>,
 ) -> ApiResult<()> {
     if webviews.contains(webview) {
-        commands.entity(webview).remove::<LinkedPersona>();
+        commands
+            .entity(webview)
+            .remove::<LinkedPersona>()
+            .remove_parent_in_place();
         Ok(())
     } else {
         Err(ApiError::WebviewNotFound(webview))

--- a/engine/crates/homunculus_api/src/webview/list.rs
+++ b/engine/crates/homunculus_api/src/webview/list.rs
@@ -40,8 +40,8 @@ fn list_webviews(
                     viewport_size: viewport_size.0,
                     transform: TransformArgs {
                         translation: Some(transform.translation),
-                        rotation: None,
-                        scale: None,
+                        rotation: Some(transform.rotation),
+                        scale: Some(transform.scale),
                     },
                     constraints: WebviewConstraints {
                         rotation_follow: Some(c.rotation_follow),

--- a/engine/crates/homunculus_api/src/webview/list.rs
+++ b/engine/crates/homunculus_api/src/webview/list.rs
@@ -4,7 +4,10 @@ use crate::webview::open::{OriginalWebviewSource, webview_source_to_info};
 use bevy::prelude::*;
 use bevy_cef::prelude::WebviewSize;
 use bevy_flurx::action::once;
-use homunculus_core::prelude::{LinkedPersona, WebviewInfo, WebviewMeshSize, WebviewOffset};
+use homunculus_core::prelude::{
+    LinkedPersona, TransformConstraint, WebviewConstraints, WebviewInfo, WebviewMeshSize,
+    WebviewOffset,
+};
 
 impl WebviewApi {
     pub async fn list(&self) -> ApiResult<Vec<WebviewInfo>> {
@@ -20,20 +23,28 @@ fn list_webviews(
         &OriginalWebviewSource,
         Option<&WebviewMeshSize>,
         &WebviewSize,
-        &WebviewOffset,
+        Option<&TransformConstraint>,
         Option<&LinkedPersona>,
     )>,
 ) -> Vec<WebviewInfo> {
     webviews
         .iter()
         .map(
-            |(entity, source, mesh_size, viewport_size, offset, linked_persona)| WebviewInfo {
-                entity,
-                source: webview_source_to_info(&source.0, false),
-                size: mesh_size.map_or(WebviewMeshSize::default().0, |s| s.0),
-                viewport_size: viewport_size.0,
-                offset: *offset,
-                linked_persona: linked_persona.map(|l| l.0.clone()),
+            |(entity, source, mesh_size, viewport_size, constraint, linked_persona)| {
+                let c = constraint.copied().unwrap_or_default();
+                WebviewInfo {
+                    entity,
+                    source: webview_source_to_info(&source.0, false),
+                    size: mesh_size.map_or(WebviewMeshSize::default().0, |s| s.0),
+                    viewport_size: viewport_size.0,
+                    offset: WebviewOffset(c.intended_offset),
+                    constraints: WebviewConstraints {
+                        rotation_follow: Some(c.rotation_follow),
+                        max_tilt_degrees: Some(c.max_tilt_degrees),
+                        lock_scale: Some(c.lock_scale),
+                    },
+                    linked_persona: linked_persona.map(|l| l.0.clone()),
+                }
             },
         )
         .collect()

--- a/engine/crates/homunculus_api/src/webview/list.rs
+++ b/engine/crates/homunculus_api/src/webview/list.rs
@@ -5,8 +5,8 @@ use bevy::prelude::*;
 use bevy_cef::prelude::WebviewSize;
 use bevy_flurx::action::once;
 use homunculus_core::prelude::{
-    LinkedPersona, TransformConstraint, WebviewConstraints, WebviewInfo, WebviewMeshSize,
-    WebviewOffset,
+    LinkedPersona, TransformArgs, TransformConstraint, WebviewConstraints, WebviewInfo,
+    WebviewMeshSize,
 };
 
 impl WebviewApi {
@@ -37,7 +37,11 @@ fn list_webviews(
                     source: webview_source_to_info(&source.0, false),
                     size: mesh_size.map_or(WebviewMeshSize::default().0, |s| s.0),
                     viewport_size: viewport_size.0,
-                    offset: WebviewOffset(c.intended_offset),
+                    transform: TransformArgs {
+                        translation: Some(c.intended_offset),
+                        rotation: None,
+                        scale: None,
+                    },
                     constraints: WebviewConstraints {
                         rotation_follow: Some(c.rotation_follow),
                         max_tilt_degrees: Some(c.max_tilt_degrees),

--- a/engine/crates/homunculus_api/src/webview/list.rs
+++ b/engine/crates/homunculus_api/src/webview/list.rs
@@ -23,6 +23,7 @@ fn list_webviews(
         &OriginalWebviewSource,
         Option<&WebviewMeshSize>,
         &WebviewSize,
+        &Transform,
         Option<&TransformConstraint>,
         Option<&LinkedPersona>,
     )>,
@@ -30,7 +31,7 @@ fn list_webviews(
     webviews
         .iter()
         .map(
-            |(entity, source, mesh_size, viewport_size, constraint, linked_persona)| {
+            |(entity, source, mesh_size, viewport_size, transform, constraint, linked_persona)| {
                 let c = constraint.copied().unwrap_or_default();
                 WebviewInfo {
                     entity,
@@ -38,7 +39,7 @@ fn list_webviews(
                     size: mesh_size.map_or(WebviewMeshSize::default().0, |s| s.0),
                     viewport_size: viewport_size.0,
                     transform: TransformArgs {
-                        translation: Some(c.intended_offset),
+                        translation: Some(transform.translation),
                         rotation: None,
                         scale: None,
                     },

--- a/engine/crates/homunculus_api/src/webview/open.rs
+++ b/engine/crates/homunculus_api/src/webview/open.rs
@@ -144,6 +144,11 @@ fn spawn_webview_entity(
     options: &WebviewOpenOptions,
 ) -> Entity {
     let size = options.size.unwrap_or(Vec2::splat(0.7));
+    let translation = options
+        .transform
+        .as_ref()
+        .and_then(|t| t.translation)
+        .unwrap_or(Vec3::new(0.0, 0.0, 10.0));
     let constraint = build_transform_constraint(options);
     let mut entity_commands = commands.spawn((
         Name::new("Webview"),
@@ -164,7 +169,7 @@ fn spawn_webview_entity(
             is_hoverable: true,
         },
         Visibility::Hidden,
-        Transform::from_translation(constraint.intended_offset),
+        Transform::from_translation(translation),
         constraint,
         WebviewMeshSize(size),
     ));
@@ -177,15 +182,7 @@ fn spawn_webview_entity(
 }
 
 fn build_transform_constraint(options: &WebviewOpenOptions) -> TransformConstraint {
-    let intended_offset = options
-        .transform
-        .as_ref()
-        .and_then(|t| t.translation)
-        .unwrap_or(Vec3::new(0.0, 0.0, 10.0));
-    let mut constraint = TransformConstraint {
-        intended_offset,
-        ..Default::default()
-    };
+    let mut constraint = TransformConstraint::default();
     if let Some(c) = &options.constraints {
         if let Some(v) = c.rotation_follow {
             constraint.rotation_follow = v;

--- a/engine/crates/homunculus_api/src/webview/open.rs
+++ b/engine/crates/homunculus_api/src/webview/open.rs
@@ -177,9 +177,13 @@ fn spawn_webview_entity(
 }
 
 fn build_transform_constraint(options: &WebviewOpenOptions) -> TransformConstraint {
-    let offset = options.offset.unwrap_or_default();
+    let intended_offset = options
+        .transform
+        .as_ref()
+        .and_then(|t| t.translation)
+        .unwrap_or(Vec3::new(0.0, 0.0, 10.0));
     let mut constraint = TransformConstraint {
-        intended_offset: offset.0,
+        intended_offset,
         ..Default::default()
     };
     if let Some(c) = &options.constraints {

--- a/engine/crates/homunculus_api/src/webview/open.rs
+++ b/engine/crates/homunculus_api/src/webview/open.rs
@@ -83,7 +83,7 @@ fn create_global_webview(
             .entity(webview)
             .try_insert(LinkedPersona(persona_id.clone()));
         if let Some(persona_entity) = index.get(&persona_id) {
-            commands.entity(webview).set_parent_in_place(persona_entity);
+            commands.entity(webview).insert(ChildOf(persona_entity));
         }
     }
     Ok(webview)

--- a/engine/crates/homunculus_api/src/webview/open.rs
+++ b/engine/crates/homunculus_api/src/webview/open.rs
@@ -4,9 +4,9 @@ use bevy::light::NotShadowCaster;
 use bevy::prelude::*;
 use bevy_cef::prelude::{PreloadScripts, WebviewExtendStandardMaterial, WebviewSize};
 use bevy_flurx::action::once;
-use bevy_vrm1::prelude::{Cameras, HeadBoneEntity};
+use bevy_vrm1::prelude::Cameras;
 use homunculus_core::prelude::{
-    AssetResolver, AssetType, LinkedPersona, PersonaIndex, WebviewMeshSize, WebviewOffset,
+    AssetResolver, AssetType, LinkedPersona, PersonaIndex, TransformConstraint, WebviewMeshSize,
     WebviewOpenOptions, WebviewSource, WebviewSourceInfo,
 };
 use homunculus_effects::{Entity, Update};
@@ -31,7 +31,7 @@ pub(crate) struct WebviewOpenPlugin;
 
 impl Plugin for WebviewOpenPlugin {
     fn build(&self, app: &mut App) {
-        app.add_systems(Update, (visible, track_for_linked_persona));
+        app.add_systems(Update, visible);
     }
 }
 
@@ -60,6 +60,7 @@ fn create_global_webview(
     mut materials: ResMut<Assets<WebviewExtendStandardMaterial>>,
     cameras: Cameras,
     asset_resolver: AssetResolver,
+    index: Res<PersonaIndex>,
 ) -> ApiResult<Entity> {
     let webview_source = source_to_webview_source(&options.source, &asset_resolver)?;
 
@@ -80,7 +81,10 @@ fn create_global_webview(
     if let Some(persona_id) = options.linked_persona {
         commands
             .entity(webview)
-            .try_insert(LinkedPersona(persona_id));
+            .try_insert(LinkedPersona(persona_id.clone()));
+        if let Some(persona_entity) = index.get(&persona_id) {
+            commands.entity(webview).set_parent_in_place(persona_entity);
+        }
     }
     Ok(webview)
 }
@@ -140,6 +144,7 @@ fn spawn_webview_entity(
     options: &WebviewOpenOptions,
 ) -> Entity {
     let size = options.size.unwrap_or(Vec2::splat(0.7));
+    let constraint = build_transform_constraint(options);
     let mut entity_commands = commands.spawn((
         Name::new("Webview"),
         webview_source,
@@ -159,11 +164,8 @@ fn spawn_webview_entity(
             is_hoverable: true,
         },
         Visibility::Hidden,
-        {
-            let offset = options.offset.unwrap_or_default();
-            Transform::from_translation(Vec3::new(0.0, 0.0, offset.0.z))
-        },
-        options.offset.unwrap_or_default(),
+        Transform::from_translation(constraint.intended_offset),
+        constraint,
         WebviewMeshSize(size),
     ));
 
@@ -174,31 +176,24 @@ fn spawn_webview_entity(
     entity_commands.id()
 }
 
-fn track_for_linked_persona(
-    par_commands: ParallelCommands,
-    head_bones: Query<&HeadBoneEntity>,
-    global_transforms: Query<&GlobalTransform>,
-    webviews: Query<(Entity, &LinkedPersona, &WebviewOffset, &Transform)>,
-    index: Res<PersonaIndex>,
-) {
-    webviews
-        .par_iter()
-        .for_each(|(entity, linked_persona, offset, tf)| {
-            let Some(vrm_entity) = index.get(&linked_persona.0) else {
-                return;
-            };
-            let Ok(head_bone) = head_bones.get(vrm_entity) else {
-                return;
-            };
-            let Ok(p) = global_transforms.get(head_bone.0) else {
-                return;
-            };
-            let mut new_tf = *tf;
-            new_tf.translation = p.translation() + offset.0;
-            par_commands.command_scope(|mut commands| {
-                commands.entity(entity).try_insert(new_tf);
-            });
-        });
+fn build_transform_constraint(options: &WebviewOpenOptions) -> TransformConstraint {
+    let offset = options.offset.unwrap_or_default();
+    let mut constraint = TransformConstraint {
+        intended_offset: offset.0,
+        ..Default::default()
+    };
+    if let Some(c) = &options.constraints {
+        if let Some(v) = c.rotation_follow {
+            constraint.rotation_follow = v;
+        }
+        if let Some(v) = c.max_tilt_degrees {
+            constraint.max_tilt_degrees = v;
+        }
+        if let Some(v) = c.lock_scale {
+            constraint.lock_scale = v;
+        }
+    }
+    constraint
 }
 
 fn insert_preload_scripts(commands: &mut Commands, webview: Entity) {

--- a/engine/crates/homunculus_api/src/webview/update.rs
+++ b/engine/crates/homunculus_api/src/webview/update.rs
@@ -3,7 +3,9 @@ use crate::prelude::WebviewApi;
 use bevy::prelude::*;
 use bevy_cef::prelude::WebviewSize;
 use bevy_flurx::action::once;
-use homunculus_core::prelude::{TransformArgs, TransformConstraint, WebviewMeshSize, WebviewPatchRequest};
+use homunculus_core::prelude::{
+    TransformArgs, TransformConstraint, WebviewMeshSize, WebviewPatchRequest,
+};
 use homunculus_effects::{Entity, Update};
 
 impl WebviewApi {
@@ -99,10 +101,7 @@ fn patch(
     In((webview, request)): In<(Entity, WebviewPatchRequest)>,
     mut commands: Commands,
     mut meshes: ResMut<Assets<Mesh>>,
-    webviews: Query<
-        (Entity, Option<&TransformConstraint>),
-        With<bevy_cef::prelude::WebviewSource>,
-    >,
+    webviews: Query<(Entity, Option<&TransformConstraint>), With<bevy_cef::prelude::WebviewSource>>,
 ) -> ApiResult<()> {
     let Ok((_, existing_constraint)) = webviews.get(webview) else {
         return Err(ApiError::WebviewNotFound(webview));

--- a/engine/crates/homunculus_api/src/webview/update.rs
+++ b/engine/crates/homunculus_api/src/webview/update.rs
@@ -4,17 +4,24 @@ use bevy::prelude::*;
 use bevy_cef::prelude::WebviewSize;
 use bevy_flurx::action::once;
 use homunculus_core::prelude::{
-    TransformConstraint, WebviewMeshSize, WebviewOffset, WebviewPatchRequest,
+    TransformArgs, TransformConstraint, WebviewMeshSize, WebviewPatchRequest,
 };
 use homunculus_effects::{Entity, Update};
 
 impl WebviewApi {
-    /// Updates the offset of a webview entity.
-    pub async fn set_offset(&self, webview: Entity, offset: WebviewOffset) -> ApiResult<()> {
+    /// Updates the transform of a webview entity.
+    pub async fn set_transform(
+        &self,
+        webview: Entity,
+        transform: TransformArgs,
+    ) -> ApiResult<()> {
         self.0
             .schedule(move |task| async move {
-                task.will(Update, once::run(set_offset).with((webview, offset)))
-                    .await
+                task.will(
+                    Update,
+                    once::run(set_transform).with((webview, transform)),
+                )
+                .await
             })
             .await?
     }
@@ -51,19 +58,21 @@ impl WebviewApi {
     }
 }
 
-fn set_offset(
-    In((webview, offset)): In<(Entity, WebviewOffset)>,
+fn set_transform(
+    In((webview, transform)): In<(Entity, TransformArgs)>,
     mut commands: Commands,
     webviews: Query<(Entity, Option<&TransformConstraint>), With<bevy_cef::prelude::WebviewSource>>,
 ) -> ApiResult<()> {
     let Ok((_, existing)) = webviews.get(webview) else {
         return Err(ApiError::WebviewNotFound(webview));
     };
-    let base = existing.copied().unwrap_or_default();
-    commands.entity(webview).try_insert(TransformConstraint {
-        intended_offset: offset.0,
-        ..base
-    });
+    if let Some(translation) = transform.translation {
+        let base = existing.copied().unwrap_or_default();
+        commands.entity(webview).try_insert(TransformConstraint {
+            intended_offset: translation,
+            ..base
+        });
+    }
     Ok(())
 }
 
@@ -101,10 +110,7 @@ fn patch(
     In((webview, request)): In<(Entity, WebviewPatchRequest)>,
     mut commands: Commands,
     mut meshes: ResMut<Assets<Mesh>>,
-    webviews: Query<
-        (Entity, Option<&TransformConstraint>),
-        With<bevy_cef::prelude::WebviewSource>,
-    >,
+    webviews: Query<(Entity, Option<&TransformConstraint>), With<bevy_cef::prelude::WebviewSource>>,
 ) -> ApiResult<()> {
     let Ok((_, existing_constraint)) = webviews.get(webview) else {
         return Err(ApiError::WebviewNotFound(webview));
@@ -112,10 +118,12 @@ fn patch(
 
     let mut entity_commands = commands.entity(webview);
 
-    if let Some(offset) = request.offset {
+    if let Some(transform) = request.transform
+        && let Some(translation) = transform.translation
+    {
         let base = existing_constraint.copied().unwrap_or_default();
         entity_commands.try_insert(TransformConstraint {
-            intended_offset: offset.0,
+            intended_offset: translation,
             ..base
         });
     }

--- a/engine/crates/homunculus_api/src/webview/update.rs
+++ b/engine/crates/homunculus_api/src/webview/update.rs
@@ -10,18 +10,11 @@ use homunculus_effects::{Entity, Update};
 
 impl WebviewApi {
     /// Updates the transform of a webview entity.
-    pub async fn set_transform(
-        &self,
-        webview: Entity,
-        transform: TransformArgs,
-    ) -> ApiResult<()> {
+    pub async fn set_transform(&self, webview: Entity, transform: TransformArgs) -> ApiResult<()> {
         self.0
             .schedule(move |task| async move {
-                task.will(
-                    Update,
-                    once::run(set_transform).with((webview, transform)),
-                )
-                .await
+                task.will(Update, once::run(set_transform).with((webview, transform)))
+                    .await
             })
             .await?
     }

--- a/engine/crates/homunculus_api/src/webview/update.rs
+++ b/engine/crates/homunculus_api/src/webview/update.rs
@@ -3,7 +3,9 @@ use crate::prelude::WebviewApi;
 use bevy::prelude::*;
 use bevy_cef::prelude::WebviewSize;
 use bevy_flurx::action::once;
-use homunculus_core::prelude::{WebviewMeshSize, WebviewOffset, WebviewPatchRequest};
+use homunculus_core::prelude::{
+    TransformConstraint, WebviewMeshSize, WebviewOffset, WebviewPatchRequest,
+};
 use homunculus_effects::{Entity, Update};
 
 impl WebviewApi {
@@ -52,14 +54,17 @@ impl WebviewApi {
 fn set_offset(
     In((webview, offset)): In<(Entity, WebviewOffset)>,
     mut commands: Commands,
-    webviews: Query<Entity, With<bevy_cef::prelude::WebviewSource>>,
+    webviews: Query<(Entity, Option<&TransformConstraint>), With<bevy_cef::prelude::WebviewSource>>,
 ) -> ApiResult<()> {
-    if webviews.contains(webview) {
-        commands.entity(webview).try_insert(offset);
-        Ok(())
-    } else {
-        Err(ApiError::WebviewNotFound(webview))
-    }
+    let Ok((_, existing)) = webviews.get(webview) else {
+        return Err(ApiError::WebviewNotFound(webview));
+    };
+    let base = existing.copied().unwrap_or_default();
+    commands.entity(webview).try_insert(TransformConstraint {
+        intended_offset: offset.0,
+        ..base
+    });
+    Ok(())
 }
 
 fn set_size(
@@ -96,16 +101,35 @@ fn patch(
     In((webview, request)): In<(Entity, WebviewPatchRequest)>,
     mut commands: Commands,
     mut meshes: ResMut<Assets<Mesh>>,
-    webviews: Query<Entity, With<bevy_cef::prelude::WebviewSource>>,
+    webviews: Query<
+        (Entity, Option<&TransformConstraint>),
+        With<bevy_cef::prelude::WebviewSource>,
+    >,
 ) -> ApiResult<()> {
-    if !webviews.contains(webview) {
+    let Ok((_, existing_constraint)) = webviews.get(webview) else {
         return Err(ApiError::WebviewNotFound(webview));
-    }
+    };
 
     let mut entity_commands = commands.entity(webview);
 
     if let Some(offset) = request.offset {
-        entity_commands.try_insert(offset);
+        let base = existing_constraint.copied().unwrap_or_default();
+        entity_commands.try_insert(TransformConstraint {
+            intended_offset: offset.0,
+            ..base
+        });
+    }
+
+    if let Some(constraints) = request.constraints {
+        let base = existing_constraint.copied().unwrap_or_default();
+        entity_commands.try_insert(TransformConstraint {
+            rotation_follow: constraints.rotation_follow.unwrap_or(base.rotation_follow),
+            max_tilt_degrees: constraints
+                .max_tilt_degrees
+                .unwrap_or(base.max_tilt_degrees),
+            lock_scale: constraints.lock_scale.unwrap_or(base.lock_scale),
+            intended_offset: base.intended_offset,
+        });
     }
 
     if let Some(size) = request.size {

--- a/engine/crates/homunculus_api/src/webview/update.rs
+++ b/engine/crates/homunculus_api/src/webview/update.rs
@@ -3,9 +3,7 @@ use crate::prelude::WebviewApi;
 use bevy::prelude::*;
 use bevy_cef::prelude::WebviewSize;
 use bevy_flurx::action::once;
-use homunculus_core::prelude::{
-    TransformArgs, TransformConstraint, WebviewMeshSize, WebviewPatchRequest,
-};
+use homunculus_core::prelude::{TransformArgs, TransformConstraint, WebviewMeshSize, WebviewPatchRequest};
 use homunculus_effects::{Entity, Update};
 
 impl WebviewApi {
@@ -54,17 +52,15 @@ impl WebviewApi {
 fn set_transform(
     In((webview, transform)): In<(Entity, TransformArgs)>,
     mut commands: Commands,
-    webviews: Query<(Entity, Option<&TransformConstraint>), With<bevy_cef::prelude::WebviewSource>>,
+    webviews: Query<Entity, With<bevy_cef::prelude::WebviewSource>>,
 ) -> ApiResult<()> {
-    let Ok((_, existing)) = webviews.get(webview) else {
+    if !webviews.contains(webview) {
         return Err(ApiError::WebviewNotFound(webview));
-    };
+    }
     if let Some(translation) = transform.translation {
-        let base = existing.copied().unwrap_or_default();
-        commands.entity(webview).try_insert(TransformConstraint {
-            intended_offset: translation,
-            ..base
-        });
+        commands
+            .entity(webview)
+            .try_insert(Transform::from_translation(translation));
     }
     Ok(())
 }
@@ -103,7 +99,10 @@ fn patch(
     In((webview, request)): In<(Entity, WebviewPatchRequest)>,
     mut commands: Commands,
     mut meshes: ResMut<Assets<Mesh>>,
-    webviews: Query<(Entity, Option<&TransformConstraint>), With<bevy_cef::prelude::WebviewSource>>,
+    webviews: Query<
+        (Entity, Option<&TransformConstraint>),
+        With<bevy_cef::prelude::WebviewSource>,
+    >,
 ) -> ApiResult<()> {
     let Ok((_, existing_constraint)) = webviews.get(webview) else {
         return Err(ApiError::WebviewNotFound(webview));
@@ -114,11 +113,7 @@ fn patch(
     if let Some(transform) = request.transform
         && let Some(translation) = transform.translation
     {
-        let base = existing_constraint.copied().unwrap_or_default();
-        entity_commands.try_insert(TransformConstraint {
-            intended_offset: translation,
-            ..base
-        });
+        entity_commands.try_insert(Transform::from_translation(translation));
     }
 
     if let Some(constraints) = request.constraints {
@@ -129,7 +124,6 @@ fn patch(
                 .max_tilt_degrees
                 .unwrap_or(base.max_tilt_degrees),
             lock_scale: constraints.lock_scale.unwrap_or(base.lock_scale),
-            intended_offset: base.intended_offset,
         });
     }
 

--- a/engine/crates/homunculus_core/src/schema.rs
+++ b/engine/crates/homunculus_core/src/schema.rs
@@ -1,8 +1,9 @@
 mod asset;
 mod mods;
 mod transform;
+mod transform_constraint;
 mod webview;
 
 pub mod prelude {
-    pub use crate::schema::{asset::*, mods::*, transform::*, webview::*};
+    pub use crate::schema::{asset::*, mods::*, transform::*, transform_constraint::*, webview::*};
 }

--- a/engine/crates/homunculus_core/src/schema/transform.rs
+++ b/engine/crates/homunculus_core/src/schema/transform.rs
@@ -2,10 +2,17 @@ use bevy::math::{Quat, Vec3};
 use bevy::prelude::Transform;
 use serde::{Deserialize, Serialize};
 
+/// Partial transform arguments for API requests.
+/// All fields are optional — omitted fields retain their current value.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
+#[serde(rename_all = "camelCase")]
 pub struct TransformArgs {
+    #[cfg_attr(feature = "openapi", schema(value_type = Option<[f32; 3]>))]
     pub translation: Option<Vec3>,
+    #[cfg_attr(feature = "openapi", schema(value_type = Option<[f32; 4]>))]
     pub rotation: Option<Quat>,
+    #[cfg_attr(feature = "openapi", schema(value_type = Option<[f32; 3]>))]
     pub scale: Option<Vec3>,
 }
 

--- a/engine/crates/homunculus_core/src/schema/transform_constraint.rs
+++ b/engine/crates/homunculus_core/src/schema/transform_constraint.rs
@@ -1,0 +1,56 @@
+use bevy::math::Vec3;
+use bevy::prelude::Component;
+use serde::{Deserialize, Serialize};
+
+/// Constrains how parent Transform propagation affects a child entity's GlobalTransform.
+///
+/// Designed for webview entities that are `ChildOf` a persona entity.
+/// The PostUpdate correction system reads this component and overrides the propagated
+/// GlobalTransform to keep the webview upright and correctly positioned.
+///
+/// # Architectural constraint
+///
+/// This component is only valid on **leaf entities** (entities with no children).
+/// Applying it to a non-leaf entity produces incorrect GlobalTransform for descendants
+/// because the PostUpdate correction does not cascade.
+#[derive(Component, Debug, Clone, Copy, PartialEq)]
+pub struct TransformConstraint {
+    /// How much rotation to inherit from parent. 0.0 = billboard (always upright), 1.0 = full inherit.
+    pub rotation_follow: f32,
+    /// Maximum tilt angle from upright in degrees (swing clamp ceiling). 0.0 = no tilt allowed.
+    pub max_tilt_degrees: f32,
+    /// Whether to lock scale at Vec3::ONE regardless of parent scale.
+    pub lock_scale: bool,
+    /// User-specified offset in unscaled parent-local space.
+    /// Stored separately from local Transform to prevent scale-coupling feedback loops.
+    pub intended_offset: Vec3,
+}
+
+impl Default for TransformConstraint {
+    fn default() -> Self {
+        Self {
+            rotation_follow: 0.0,
+            max_tilt_degrees: 0.0,
+            lock_scale: true,
+            intended_offset: Vec3::ZERO,
+        }
+    }
+}
+
+/// API-facing constraint parameters for HTTP/MCP.
+/// Maps to the non-offset fields of `TransformConstraint`.
+/// `intended_offset` is set via the `transform.translation` field instead.
+#[derive(Serialize, Deserialize, Debug, Clone, Copy, PartialEq)]
+#[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
+#[serde(rename_all = "camelCase")]
+pub struct WebviewConstraints {
+    /// How much rotation to inherit from parent. 0.0 = billboard, 1.0 = full inherit.
+    #[serde(default)]
+    pub rotation_follow: Option<f32>,
+    /// Maximum tilt angle from upright in degrees. 0.0 = no tilt allowed.
+    #[serde(default)]
+    pub max_tilt_degrees: Option<f32>,
+    /// Whether to lock scale at 1.0 regardless of parent scale.
+    #[serde(default)]
+    pub lock_scale: Option<bool>,
+}

--- a/engine/crates/homunculus_core/src/schema/transform_constraint.rs
+++ b/engine/crates/homunculus_core/src/schema/transform_constraint.rs
@@ -1,4 +1,3 @@
-use bevy::math::Vec3;
 use bevy::prelude::Component;
 use serde::{Deserialize, Serialize};
 
@@ -6,7 +5,7 @@ use serde::{Deserialize, Serialize};
 ///
 /// Designed for webview entities that are `ChildOf` a persona entity.
 /// The PostUpdate correction system reads this component and overrides the propagated
-/// GlobalTransform to keep the webview upright and correctly positioned.
+/// rotation and scale while preserving translation from Bevy's standard propagation.
 ///
 /// # Architectural constraint
 ///
@@ -21,9 +20,6 @@ pub struct TransformConstraint {
     pub max_tilt_degrees: f32,
     /// Whether to lock scale at Vec3::ONE regardless of parent scale.
     pub lock_scale: bool,
-    /// User-specified offset in unscaled parent-local space.
-    /// Stored separately from local Transform to prevent scale-coupling feedback loops.
-    pub intended_offset: Vec3,
 }
 
 impl Default for TransformConstraint {
@@ -32,14 +28,12 @@ impl Default for TransformConstraint {
             rotation_follow: 0.0,
             max_tilt_degrees: 0.0,
             lock_scale: true,
-            intended_offset: Vec3::ZERO,
         }
     }
 }
 
 /// API-facing constraint parameters for HTTP/MCP.
-/// Maps to the non-offset fields of `TransformConstraint`.
-/// `intended_offset` is set via the `transform.translation` field instead.
+/// Maps to the fields of `TransformConstraint`.
 #[derive(Serialize, Deserialize, Debug, Clone, Copy, PartialEq)]
 #[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
 #[serde(rename_all = "camelCase")]

--- a/engine/crates/homunculus_core/src/schema/webview.rs
+++ b/engine/crates/homunculus_core/src/schema/webview.rs
@@ -1,4 +1,5 @@
 use super::asset::AssetId;
+use super::transform_constraint::WebviewConstraints;
 use crate::components::PersonaId;
 use bevy::math::{Vec2, Vec3};
 use bevy::prelude::{Component, Entity, Reflect};
@@ -52,8 +53,12 @@ pub struct WebviewOpenOptions {
     #[serde(default)]
     #[cfg_attr(feature = "openapi", schema(value_type = Option<[f32; 2]>))]
     pub viewport_size: Option<Vec2>,
+    /// Deprecated: use `transform` instead. Maps to transform.translation with z=10.0.
     #[serde(default)]
     pub offset: Option<WebviewOffset>,
+    /// Transform constraint parameters for parent transform propagation.
+    #[serde(default)]
+    pub constraints: Option<WebviewConstraints>,
     /// Persona to link to this webview (optional).
     #[serde(default)]
     pub linked_persona: Option<PersonaId>,
@@ -109,7 +114,10 @@ pub struct WebviewInfo {
     pub size: Vec2,
     #[cfg_attr(feature = "openapi", schema(value_type = [f32; 2]))]
     pub viewport_size: Vec2,
+    /// Deprecated: included for backward compatibility.
     pub offset: WebviewOffset,
+    /// Active constraint parameters.
+    pub constraints: WebviewConstraints,
     #[serde(default)]
     pub linked_persona: Option<PersonaId>,
 }
@@ -119,6 +127,7 @@ pub struct WebviewInfo {
 #[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
 #[serde(rename_all = "camelCase")]
 pub struct WebviewPatchRequest {
+    /// Deprecated: use transform via /entities/{entity}/transform instead.
     #[serde(default)]
     pub offset: Option<WebviewOffset>,
     #[serde(default)]
@@ -127,6 +136,9 @@ pub struct WebviewPatchRequest {
     #[serde(default)]
     #[cfg_attr(feature = "openapi", schema(value_type = Option<[f32; 2]>))]
     pub viewport_size: Option<Vec2>,
+    /// Constraint parameters update (partial merge).
+    #[serde(default)]
+    pub constraints: Option<WebviewConstraints>,
 }
 
 /// Request for POST /webviews/{entity}/navigate

--- a/engine/crates/homunculus_core/src/schema/webview.rs
+++ b/engine/crates/homunculus_core/src/schema/webview.rs
@@ -1,7 +1,8 @@
 use super::asset::AssetId;
+use super::transform::TransformArgs;
 use super::transform_constraint::WebviewConstraints;
 use crate::components::PersonaId;
-use bevy::math::{Vec2, Vec3};
+use bevy::math::Vec2;
 use bevy::prelude::{Component, Entity, Reflect};
 use serde::{Deserialize, Serialize};
 
@@ -53,42 +54,15 @@ pub struct WebviewOpenOptions {
     #[serde(default)]
     #[cfg_attr(feature = "openapi", schema(value_type = Option<[f32; 2]>))]
     pub viewport_size: Option<Vec2>,
-    /// Deprecated: use `transform` instead. Maps to transform.translation with z=10.0.
+    /// Transform for positioning. translation sets the offset from parent.
     #[serde(default)]
-    pub offset: Option<WebviewOffset>,
+    pub transform: Option<TransformArgs>,
     /// Transform constraint parameters for parent transform propagation.
     #[serde(default)]
     pub constraints: Option<WebviewConstraints>,
     /// Persona to link to this webview (optional).
     #[serde(default)]
     pub linked_persona: Option<PersonaId>,
-}
-
-#[derive(Debug, Serialize, Clone, PartialEq, Component, Copy)]
-#[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
-#[cfg_attr(feature = "openapi", schema(value_type = [f32; 3]))]
-pub struct WebviewOffset(pub Vec3);
-
-impl Default for WebviewOffset {
-    fn default() -> Self {
-        Self(Vec3::new(0.0, 0.0, 10.0))
-    }
-}
-
-impl<'de> Deserialize<'de> for WebviewOffset {
-    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
-    where
-        D: serde::Deserializer<'de>,
-    {
-        let arr: Vec<f32> = Vec::deserialize(deserializer)?;
-        match arr.len() {
-            2 => Ok(WebviewOffset(Vec3::new(arr[0], arr[1], 10.0))),
-            3 => Ok(WebviewOffset(Vec3::new(arr[0], arr[1], arr[2]))),
-            _ => Err(serde::de::Error::custom(
-                "offset must be [x, y] or [x, y, z]",
-            )),
-        }
-    }
 }
 
 /// Tracks the mesh size of a webview in world units.
@@ -114,8 +88,8 @@ pub struct WebviewInfo {
     pub size: Vec2,
     #[cfg_attr(feature = "openapi", schema(value_type = [f32; 2]))]
     pub viewport_size: Vec2,
-    /// Deprecated: included for backward compatibility.
-    pub offset: WebviewOffset,
+    /// Current transform (translation = intended offset from parent).
+    pub transform: TransformArgs,
     /// Active constraint parameters.
     pub constraints: WebviewConstraints,
     #[serde(default)]
@@ -127,9 +101,9 @@ pub struct WebviewInfo {
 #[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
 #[serde(rename_all = "camelCase")]
 pub struct WebviewPatchRequest {
-    /// Deprecated: use transform via /entities/{entity}/transform instead.
+    /// Transform update (translation updates the offset from parent).
     #[serde(default)]
-    pub offset: Option<WebviewOffset>,
+    pub transform: Option<TransformArgs>,
     #[serde(default)]
     #[cfg_attr(feature = "openapi", schema(value_type = Option<[f32; 2]>))]
     pub size: Option<Vec2>,

--- a/engine/crates/homunculus_mcp/src/handler/tools/webview.rs
+++ b/engine/crates/homunculus_mcp/src/handler/tools/webview.rs
@@ -3,7 +3,9 @@
 use super::super::HomunculusMcpHandler;
 use bevy::math::{Vec2, Vec3};
 use bevy::prelude::Entity;
-use homunculus_core::prelude::{WebviewConstraints, WebviewOffset, WebviewOpenOptions, WebviewSource};
+use homunculus_core::prelude::{
+    TransformArgs, WebviewConstraints, WebviewOpenOptions, WebviewSource,
+};
 use rmcp::handler::server::wrapper::Parameters;
 use rmcp::schemars;
 use rmcp::schemars::JsonSchema;
@@ -18,10 +20,12 @@ const DEFAULT_SIZE_Y: f32 = 0.5;
 const DEFAULT_VIEWPORT_WIDTH: u32 = 800;
 /// Default internal browser height in pixels.
 const DEFAULT_VIEWPORT_HEIGHT: u32 = 600;
-/// Default horizontal offset from character center.
-const DEFAULT_OFFSET_X: f32 = 0.0;
-/// Default vertical offset from character center (positive = above).
-const DEFAULT_OFFSET_Y: f32 = 0.5;
+/// Default horizontal translation from character center.
+const DEFAULT_TRANSLATION_X: f32 = 0.0;
+/// Default vertical translation from character center (positive = above).
+const DEFAULT_TRANSLATION_Y: f32 = 1.5;
+/// Default depth translation (z-offset from character).
+const DEFAULT_TRANSLATION_Z: f32 = 10.0;
 
 /// Parameters for the `open_webview` tool.
 #[derive(Debug, Serialize, Deserialize, JsonSchema)]
@@ -41,10 +45,12 @@ pub struct OpenWebviewParams {
     pub viewport_width: Option<u32>,
     /// Internal browser height in pixels.
     pub viewport_height: Option<u32>,
-    /// Horizontal offset from character center.
-    pub offset_x: Option<f32>,
-    /// Vertical offset from character center (positive = above).
-    pub offset_y: Option<f32>,
+    /// Horizontal translation from character center.
+    pub translation_x: Option<f32>,
+    /// Vertical translation from character center (positive = above).
+    pub translation_y: Option<f32>,
+    /// Depth translation (z-offset). Default: 10.0.
+    pub translation_z: Option<f32>,
     /// Name of the character to link this webview to.
     /// When linked, the webview follows the character's head position.
     /// Use get_character_snapshot to see available character names.
@@ -107,7 +113,7 @@ impl HomunculusMcpHandler {
     /// Open a webview panel displaying HTML content, a URL, or a local mod asset near the active character.
     #[tool(
         name = "open_webview",
-        description = "Open a webview panel. Provide exactly one of: 'html' (inline HTML), 'url' (a URL to load), or 'asset_id' (a local mod asset, e.g. 'mod-name:asset-id'). Optionally provide 'characterName' to link the webview to a specific character (it will follow the character's head position). Returns the webview entity ID. Use close_webview to close it."
+        description = "Open a webview panel. Provide exactly one of: 'html' (inline HTML), 'url' (a URL to load), or 'asset_id' (a local mod asset, e.g. 'mod-name:asset-id'). Position with 'translationX', 'translationY', 'translationZ'. Optionally provide 'characterName' to link the webview to a specific character (it will follow the character's head position). Returns the webview entity ID. Use close_webview to close it."
     )]
     async fn open_webview(&self, params: Parameters<OpenWebviewParams>) -> String {
         let args = params.0;
@@ -130,14 +136,19 @@ impl HomunculusMcpHandler {
         let size_y = args.size_y.unwrap_or(DEFAULT_SIZE_Y);
         let viewport_width = args.viewport_width.unwrap_or(DEFAULT_VIEWPORT_WIDTH);
         let viewport_height = args.viewport_height.unwrap_or(DEFAULT_VIEWPORT_HEIGHT);
-        let offset_x = args.offset_x.unwrap_or(DEFAULT_OFFSET_X);
-        let offset_y = args.offset_y.unwrap_or(DEFAULT_OFFSET_Y);
+        let translation_x = args.translation_x.unwrap_or(DEFAULT_TRANSLATION_X);
+        let translation_y = args.translation_y.unwrap_or(DEFAULT_TRANSLATION_Y);
+        let translation_z = args.translation_z.unwrap_or(DEFAULT_TRANSLATION_Z);
 
         let options = WebviewOpenOptions {
             source,
             size: Some(Vec2::new(size_x, size_y)),
             viewport_size: Some(Vec2::new(viewport_width as f32, viewport_height as f32)),
-            offset: Some(WebviewOffset(Vec3::new(offset_x, offset_y, 10.0))),
+            transform: Some(TransformArgs {
+                translation: Some(Vec3::new(translation_x, translation_y, translation_z)),
+                rotation: None,
+                scale: None,
+            }),
             constraints: if args.rotation_follow.is_some()
                 || args.max_tilt_degrees.is_some()
                 || args.lock_scale.is_some()

--- a/engine/crates/homunculus_mcp/src/handler/tools/webview.rs
+++ b/engine/crates/homunculus_mcp/src/handler/tools/webview.rs
@@ -3,7 +3,7 @@
 use super::super::HomunculusMcpHandler;
 use bevy::math::{Vec2, Vec3};
 use bevy::prelude::Entity;
-use homunculus_core::prelude::{WebviewOffset, WebviewOpenOptions, WebviewSource};
+use homunculus_core::prelude::{WebviewConstraints, WebviewOffset, WebviewOpenOptions, WebviewSource};
 use rmcp::handler::server::wrapper::Parameters;
 use rmcp::schemars;
 use rmcp::schemars::JsonSchema;
@@ -49,6 +49,12 @@ pub struct OpenWebviewParams {
     /// When linked, the webview follows the character's head position.
     /// Use get_character_snapshot to see available character names.
     pub character_name: Option<String>,
+    /// How much rotation to inherit from parent (0.0 = billboard, 1.0 = full). Default: 0.0.
+    pub rotation_follow: Option<f32>,
+    /// Maximum tilt angle from upright in degrees. Default: 0.0.
+    pub max_tilt_degrees: Option<f32>,
+    /// Lock scale at 1.0 regardless of parent scale. Default: true.
+    pub lock_scale: Option<bool>,
 }
 
 /// Parameters for the `close_webview` tool.
@@ -132,6 +138,18 @@ impl HomunculusMcpHandler {
             size: Some(Vec2::new(size_x, size_y)),
             viewport_size: Some(Vec2::new(viewport_width as f32, viewport_height as f32)),
             offset: Some(WebviewOffset(Vec3::new(offset_x, offset_y, 10.0))),
+            constraints: if args.rotation_follow.is_some()
+                || args.max_tilt_degrees.is_some()
+                || args.lock_scale.is_some()
+            {
+                Some(WebviewConstraints {
+                    rotation_follow: args.rotation_follow,
+                    max_tilt_degrees: args.max_tilt_degrees,
+                    lock_scale: args.lock_scale,
+                })
+            } else {
+                None
+            },
             linked_persona,
         };
 

--- a/mods/agent/commands/open-agent.ts
+++ b/mods/agent/commands/open-agent.ts
@@ -2,7 +2,7 @@
 /// <reference types="node" />
 
 import { z } from "zod";
-import { audio, Webview, webviewSource } from "@hmcs/sdk";
+import { audio, Webview, WebviewLayer, webviewSource } from "@hmcs/sdk";
 import { input, output } from "@hmcs/sdk/commands";
 
 try {
@@ -12,7 +12,7 @@ try {
     source: webviewSource.local("agent:session-ui"),
     size: [1.07, 0.8],
     viewportSize: [800, 500],
-    transform: { translation: [1.3, 1.0, 10.0] },
+    transform: { translation: [1.3, 0.8, WebviewLayer.UI] },
     linkedPersona: personaId,
   });
   await audio.se.play("se:open");

--- a/mods/agent/commands/open-agent.ts
+++ b/mods/agent/commands/open-agent.ts
@@ -12,7 +12,7 @@ try {
     source: webviewSource.local("agent:session-ui"),
     size: [1.07, 0.8],
     viewportSize: [800, 500],
-    offset: [1.3, -0.5],
+    transform: { translation: [1.3, 1.0, 10.0] },
     linkedPersona: personaId,
   });
   await audio.se.play("se:open");

--- a/mods/menu/service.ts
+++ b/mods/menu/service.ts
@@ -72,7 +72,7 @@ async function setupPersonaEvents(p: Persona) {
         source: webviewSource.local("menu:ui"),
         size: [0.8, 1],
         viewportSize: [500, 600],
-        offset: [1, -0.3],
+        transform: { translation: [1.0, 1.2, 10.0] },
         linkedPersona: p.id,
       });
       await audio.se.play("se:open");

--- a/mods/menu/service.ts
+++ b/mods/menu/service.ts
@@ -1,6 +1,7 @@
 import {
   Persona,
   Webview,
+  WebviewLayer,
   audio,
   signals,
   isWebviewSourceInfoLocal,
@@ -24,13 +25,18 @@ const existsLinkedWebview = async (personaId: string) => {
 };
 
 function isNonBlockingSource(source: WebviewSourceInfo): boolean {
-  return isWebviewSourceInfoLocal(source) && NON_BLOCKING_SOURCES.has(source.id);
+  return (
+    isWebviewSourceInfoLocal(source) && NON_BLOCKING_SOURCES.has(source.id)
+  );
 }
 
 const openedMenu = async () => {
   const webviews = await Webview.list();
   for (let webview of webviews) {
-    if (isWebviewSourceInfoLocal(webview.source) && webview.source.id === menuUIAssetId) {
+    if (
+      isWebviewSourceInfoLocal(webview.source) &&
+      webview.source.id === menuUIAssetId
+    ) {
       return new Webview(webview.entity);
     }
   }
@@ -72,7 +78,7 @@ async function setupPersonaEvents(p: Persona) {
         source: webviewSource.local("menu:ui"),
         size: [0.8, 1],
         viewportSize: [500, 600],
-        transform: { translation: [1.0, 1.2, 10.0] },
+        transform: { translation: [1.0, 0.8, WebviewLayer.UI] },
         linkedPersona: p.id,
       });
       await audio.se.play("se:open");

--- a/mods/persona/commands/open-management.ts
+++ b/mods/persona/commands/open-management.ts
@@ -2,7 +2,7 @@
 
 /// <reference types="node" />
 
-import { audio, Webview, webviewSource } from "@hmcs/sdk";
+import { audio, Webview, WebviewLayer, webviewSource } from "@hmcs/sdk";
 import { output } from "@hmcs/sdk/commands";
 
 try {
@@ -18,7 +18,7 @@ try {
             source: webviewSource.local("persona:management"),
             size: [1.4, 0.9],
             viewportSize: [1200, 700],
-            transform: { translation: [1.3, 1.5, 15.0] },
+            transform: { translation: [1.3, 0.8, WebviewLayer.FOREGROUND] },
         });
         await audio.se.play("se:open");
         output.succeed();

--- a/mods/persona/commands/open-management.ts
+++ b/mods/persona/commands/open-management.ts
@@ -2,7 +2,7 @@
 
 /// <reference types="node" />
 
-import { audio, Webview, webviewSource, WebviewLayer } from "@hmcs/sdk";
+import { audio, Webview, webviewSource } from "@hmcs/sdk";
 import { output } from "@hmcs/sdk/commands";
 
 try {
@@ -18,7 +18,7 @@ try {
             source: webviewSource.local("persona:management"),
             size: [1.4, 0.9],
             viewportSize: [1200, 700],
-            offset: [1.3, 0, WebviewLayer.FOREGROUND],
+            transform: { translation: [1.3, 1.5, 15.0] },
         });
         await audio.se.play("se:open");
         output.succeed();

--- a/mods/persona/commands/open-ui.ts
+++ b/mods/persona/commands/open-ui.ts
@@ -3,7 +3,7 @@
 /// <reference types="node" />
 
 import { z } from "zod";
-import { audio, Webview, webviewSource } from "@hmcs/sdk";
+import { audio, Webview, WebviewLayer, webviewSource } from "@hmcs/sdk";
 import { input, output } from "@hmcs/sdk/commands";
 
 try {
@@ -14,7 +14,7 @@ try {
     source: webviewSource.local("persona:ui"),
     size: [1, 0.85],
     viewportSize: [1000, 700],
-    transform: { translation: [1.4, 1.0, 10.0] },
+    transform: { translation: [1.4, 0.8, WebviewLayer.UI] },
     linkedPersona: personaId,
   });
   await audio.se.play("se:open");

--- a/mods/persona/commands/open-ui.ts
+++ b/mods/persona/commands/open-ui.ts
@@ -14,7 +14,7 @@ try {
     source: webviewSource.local("persona:ui"),
     size: [1, 0.85],
     viewportSize: [1000, 700],
-    offset: [1.4, -0.5],
+    transform: { translation: [1.4, 1.0, 10.0] },
     linkedPersona: personaId,
   });
   await audio.se.play("se:open");

--- a/mods/settings/commands/open-ui.ts
+++ b/mods/settings/commands/open-ui.ts
@@ -10,7 +10,7 @@ try {
     source: webviewSource.local("settings:ui"),
     size: [0.8, 1],
     viewportSize: [600, 800],
-    offset: [1.1, 0],
+    transform: { translation: [1.1, 1.5, 10.0] },
   });
   await audio.se.play("se:open");
   output.succeed();

--- a/mods/settings/commands/open-ui.ts
+++ b/mods/settings/commands/open-ui.ts
@@ -2,7 +2,7 @@
 
 /// <reference types="node" />
 
-import { audio, Webview, webviewSource } from "@hmcs/sdk";
+import { audio, Webview, WebviewLayer, webviewSource } from "@hmcs/sdk";
 import { output } from "@hmcs/sdk/commands";
 
 try {
@@ -10,7 +10,7 @@ try {
     source: webviewSource.local("settings:ui"),
     size: [0.8, 1],
     viewportSize: [600, 800],
-    transform: { translation: [1.1, 1.5, 10.0] },
+    transform: { translation: [1.1, 0.8, WebviewLayer.UI] },
   });
   await audio.se.play("se:open");
   output.succeed();

--- a/mods/stt/commands/open-ui.ts
+++ b/mods/stt/commands/open-ui.ts
@@ -2,7 +2,7 @@
 
 /// <reference types="node" />
 
-import { audio, Webview, webviewSource } from "@hmcs/sdk";
+import { audio, Webview, WebviewLayer, webviewSource } from "@hmcs/sdk";
 import { output } from "@hmcs/sdk/commands";
 
 try {
@@ -10,7 +10,7 @@ try {
     source: webviewSource.local("stt:ui"),
     size: [0.8, 1],
     viewportSize: [700, 800],
-    transform: { translation: [1.1, 1.5, 10.0] },
+    transform: { translation: [1.1, 0.8, WebviewLayer.UI] },
   });
   await audio.se.play("se:open");
   output.succeed();

--- a/mods/stt/commands/open-ui.ts
+++ b/mods/stt/commands/open-ui.ts
@@ -10,7 +10,7 @@ try {
     source: webviewSource.local("stt:ui"),
     size: [0.8, 1],
     viewportSize: [700, 800],
-    offset: [1.1, 0],
+    transform: { translation: [1.1, 1.5, 10.0] },
   });
   await audio.se.play("se:open");
   output.succeed();

--- a/mods/voicevox/commands/open-settings.ts
+++ b/mods/voicevox/commands/open-settings.ts
@@ -12,7 +12,7 @@ try {
     source: webviewSource.local("voicevox:ui"),
     size: [0.6, 0.8],
     viewportSize: [460, 520],
-    offset: [1.1, 0],
+    transform: { translation: [1.1, 1.5, 10.0] },
     linkedPersona: personaId,
   });
   await audio.se.play("se:open");

--- a/mods/voicevox/commands/open-settings.ts
+++ b/mods/voicevox/commands/open-settings.ts
@@ -3,7 +3,7 @@
 /// <reference types="node" />
 
 import { z } from "zod";
-import { audio, Webview, webviewSource } from "@hmcs/sdk";
+import { audio, Webview, WebviewLayer, webviewSource } from "@hmcs/sdk";
 import { input, output } from "@hmcs/sdk/commands";
 
 try {
@@ -12,7 +12,7 @@ try {
     source: webviewSource.local("voicevox:ui"),
     size: [0.6, 0.8],
     viewportSize: [460, 520],
-    transform: { translation: [1.1, 1.5, 10.0] },
+    transform: { translation: [1.1, 0.8, WebviewLayer.UI] },
     linkedPersona: personaId,
   });
   await audio.se.play("se:open");

--- a/packages/sdk/src/webviews.ts
+++ b/packages/sdk/src/webviews.ts
@@ -1,5 +1,5 @@
 import { host } from "./host";
-import { type Vec2, type Vec3 } from "./math";
+import { type TransformArgs, type Vec2 } from "./math";
 import { Persona } from "./persona";
 
 // --- Z-layer constants ---
@@ -14,7 +14,7 @@ import { Persona } from "./persona";
  * ```typescript
  * await Webview.open({
  *   source: webviewSource.local("my-mod:ui"),
- *   offset: [0, 0, WebviewLayer.FOREGROUND],
+ *   transform: { translation: [0, 1.5, WebviewLayer.FOREGROUND] },
  * });
  * ```
  */
@@ -201,7 +201,8 @@ export interface WebviewInfo {
     source: WebviewSourceInfo;
     size: Vec2;
     viewportSize: Vec2;
-    offset: Vec2 | Vec3;
+    /** Current transform (translation = intended offset from parent). */
+    transform: TransformArgs;
     /** The persona ID linked to this webview, or null/undefined if none. */
     linkedPersona?: string | null;
     /** Active constraint parameters. */
@@ -227,7 +228,7 @@ export interface WebviewConstraints {
  *   source: webviewSource.url("my-mod::ui.html"),
  *   size: [0.7, 0.7],
  *   viewportSize: [800, 600],
- *   offset: [0, 0.5],
+ *   transform: { translation: [0, 1.5, 10.0] },
  * };
  * ```
  */
@@ -235,8 +236,8 @@ export interface WebviewOpenOptions {
     source: WebviewSource;
     size?: Vec2;
     viewportSize?: Vec2;
-    /** @deprecated Use transform instead. */
-    offset?: [number, number] | [number, number, number];
+    /** Transform for positioning. translation sets the offset from parent. */
+    transform?: TransformArgs;
     /** Transform constraint parameters. */
     constraints?: WebviewConstraints;
     /** The persona ID to link to this webview. */
@@ -245,7 +246,8 @@ export interface WebviewOpenOptions {
 
 /** Request body for patching webview properties. */
 export interface WebviewPatchRequest {
-    offset?: Vec2 | Vec3;
+    /** Transform update (translation updates the offset from parent). */
+    transform?: TransformArgs;
     size?: Vec2;
     viewportSize?: Vec2;
     /** Transform constraint parameters (partial merge). */
@@ -269,7 +271,7 @@ export interface WebviewNavigateRequest {
  *   source: webviewSource.url("my-mod::ui.html"),
  *   size: [0.7, 0.7],
  *   viewportSize: [800, 600],
- *   offset: [0, 0.5],
+ *   transform: { translation: [0, 1.5, 10.0] },
  * });
  *
  * if (!(await webview.isClosed())) {
@@ -314,7 +316,7 @@ export class Webview {
     }
 
     /**
-     * Patches webview properties (offset, size, viewportSize).
+     * Patches webview properties (transform, size, viewportSize).
      *
      * @param options - The properties to update
      */
@@ -323,12 +325,12 @@ export class Webview {
     }
 
     /**
-     * Sets the offset of the webview.
+     * Sets the transform of the webview.
      *
-     * @param offset - The new offset
+     * @param transform - The new transform
      */
-    async setOffset(offset: Vec2 | Vec3): Promise<void> {
-        await this.patch({ offset });
+    async setTransform(transform: TransformArgs): Promise<void> {
+        await this.patch({ transform });
     }
 
     /**
@@ -480,7 +482,7 @@ export class Webview {
      *   source: webviewSource.url("my-mod::settings.html"),
      *   size: [0.7, 0.5],
      *   viewportSize: [800, 600],
-     *   offset: [0, 1.0],
+     *   transform: { translation: [0, 1.5, 10.0] },
      * });
      *
      * // Open with inline HTML
@@ -491,7 +493,7 @@ export class Webview {
      * // Open with a local asset
      * const local = await Webview.open({
      *   source: webviewSource.local("my-mod::panel.html"),
-     *   offset: [0.5, 0],
+     *   transform: { translation: [0.5, 1.5, 10.0] },
      * });
      * ```
      */

--- a/packages/sdk/src/webviews.ts
+++ b/packages/sdk/src/webviews.ts
@@ -21,6 +21,8 @@ import { Persona } from "./persona";
 export const WebviewLayer = {
     /** Default webview layer (z=0). Standard depth, behind VRM characters. */
     DEFAULT: 0,
+    /** UI layer (z=10). Standard depth for UI panels (settings, menus, etc.). */
+    UI: 10,
     /** Foreground layer (z=15). Renders in front of VRM characters and other webviews. */
     FOREGROUND: 15,
 } as const;

--- a/packages/sdk/src/webviews.ts
+++ b/packages/sdk/src/webviews.ts
@@ -204,6 +204,18 @@ export interface WebviewInfo {
     offset: Vec2 | Vec3;
     /** The persona ID linked to this webview, or null/undefined if none. */
     linkedPersona?: string | null;
+    /** Active constraint parameters. */
+    constraints: WebviewConstraints;
+}
+
+/** Transform constraint parameters for webview panels. */
+export interface WebviewConstraints {
+    /** How much rotation to inherit from parent. 0.0 = billboard, 1.0 = full inherit. */
+    rotationFollow?: number;
+    /** Maximum tilt angle from upright in degrees. 0.0 = no tilt allowed. */
+    maxTiltDegrees?: number;
+    /** Lock scale at 1.0 regardless of parent scale. */
+    lockScale?: boolean;
 }
 
 /**
@@ -223,7 +235,10 @@ export interface WebviewOpenOptions {
     source: WebviewSource;
     size?: Vec2;
     viewportSize?: Vec2;
-    offset?: Vec2 | Vec3;
+    /** @deprecated Use transform instead. */
+    offset?: [number, number] | [number, number, number];
+    /** Transform constraint parameters. */
+    constraints?: WebviewConstraints;
     /** The persona ID to link to this webview. */
     linkedPersona?: string;
 }
@@ -233,6 +248,8 @@ export interface WebviewPatchRequest {
     offset?: Vec2 | Vec3;
     size?: Vec2;
     viewportSize?: Vec2;
+    /** Transform constraint parameters (partial merge). */
+    constraints?: WebviewConstraints;
 }
 
 /** Request body for navigating a webview to a new source. */


### PR DESCRIPTION
## Problem

Webview positioning relied on `WebviewOffset` — a custom Vec3 component tracked manually via `track_for_linked_persona`, which copied the head bone's world position each frame. This approach had two problems:

1. For unlinked webviews, `WebviewOffset` was confusing and unnecessary — it added indirection where `Transform` would suffice.
2. It prevented using Bevy's standard parent-child Transform hierarchy, missing opportunities for automatic following and future constraint-based behavior.

## Solution

Replace the entire offset-based positioning model with Transform-based positioning using Bevy's `ChildOf` hierarchy and a PostUpdate constraint system.

### Core changes (engine)
- **New `TransformConstraint` component** (`homunculus_core`): Stores `rotation_follow`, `max_tilt_degrees`, `lock_scale`, and `intended_offset` per-webview.
- **Swing-twist constraint system** (`homunculus_api/webview/constraint.rs`): PostUpdate system running after `TransformSystems::Propagate` that corrects `GlobalTransform` using swing-twist decomposition about Vec3::Y. Includes 10 unit tests.
- **ChildOf integration**: Linked webviews become children of the persona root entity via `set_parent_in_place()`. Removed `track_for_linked_persona` entirely.
- **Auto-insertion**: Reactive system inserts default `TransformConstraint` on `Added<LinkedPersona>` (with `Without<TransformConstraint>` guard to prevent overwriting explicit values).

### Schema changes (engine + SDK)
- **Removed** `WebviewOffset` struct and all `offset` fields from `WebviewOpenOptions`, `WebviewPatchRequest`, `WebviewInfo`.
- **Added** `transform: TransformArgs` (translation/rotation/scale) and `constraints: WebviewConstraints` (rotationFollow/maxTiltDegrees/lockScale) to all webview schema types.
- **Added** `WebviewLayer.UI` (z=10) constant to the SDK.
- **MCP**: Renamed `offset_x`/`offset_y` to `translation_x`/`translation_y`/`translation_z`. Added `rotation_follow`, `max_tilt_degrees`, `lock_scale` params.

### MOD updates
- All 7 MOD webview.open calls migrated from `offset: [x, y]` to `transform: { translation: [x, y, WebviewLayer.UI] }` with y=0.8 (root-relative).

### Breaking Changes

- `WebviewOffset` type removed from Rust and TypeScript SDK.
- `offset` field removed from `WebviewOpenOptions`, `WebviewPatchRequest`, `WebviewInfo`.
- `setOffset()` method removed from SDK `Webview` class, replaced by `setTransform()`.
- MCP `open_webview` params renamed: `offset_x`→`translation_x`, `offset_y`→`translation_y`.
- Webview positioning reference point changed from head bone to persona root entity (feet).

## Documentation

- [ ] Included in this PR
- [ ] Will be added in a follow-up PR
- [x] Not needed

---

- [x] If HTTP endpoints changed: I ran `make gen-open-api` and `pnpm build`
- [x] This PR includes breaking changes