### PR TITLE
feat(sdk): add assets.fetchFile() for raw asset bytes

### DIFF
--- a/packages/sdk/src/assets.ts
+++ b/packages/sdk/src/assets.ts
@@ -1,4 +1,4 @@
-import {host} from "./host";
+import { host } from "./host";
 
 /**
  * Assets API namespace for querying available mod assets.
@@ -20,124 +20,126 @@ import {host} from "./host";
  * ```
  */
 export namespace assets {
-    /** The type of an asset. */
-    export type AssetType = "vrm" | "vrma" | "sound" | "image" | "html";
+  /** The type of an asset. */
+  export type AssetType = "vrm" | "vrma" | "sound" | "image" | "html";
 
-    /** Information about a registered asset. */
-    export interface AssetInfo {
-        /** Globally unique asset ID. */
-        id: string;
-        /** The asset type. */
-        type: AssetType;
-        /** The mod that provides this asset. */
-        mod: string;
-        /** Optional description of the asset. */
-        description?: string;
-    }
+  /** Information about a registered asset. */
+  export interface AssetInfo {
+    /** Globally unique asset ID. */
+    id: string;
+    /** The asset type. */
+    type: AssetType;
+    /** The mod that provides this asset. */
+    mod: string;
+    /** Optional description of the asset. */
+    description?: string;
+  }
 
-    /** Filter options for listing assets. */
-    export interface AssetFilter {
-        /** Filter by asset type. */
-        type?: AssetType;
-        /** Filter by mod name. */
-        mod?: string;
-    }
+  /** Filter options for listing assets. */
+  export interface AssetFilter {
+    /** Filter by asset type. */
+    type?: AssetType;
+    /** Filter by mod name. */
+    mod?: string;
+  }
 
-    /**
-     * Lists available assets, optionally filtered by type and/or mod.
-     *
-     * @param filter - Optional filter criteria
-     * @returns Array of matching asset info objects
-     *
-     * @example
-     * ```typescript
-     * // Get all assets
-     * const all = await assets.list();
-     *
-     * // Get only VRM models
-     * const vrms = await assets.list({ type: "vrm" });
-     *
-     * // Get assets from a specific mod
-     * const modAssets = await assets.list({ mod: "elmer" });
-     *
-     * // Combine filters
-     * const sounds = await assets.list({ type: "sound", mod: "my-mod" });
-     * ```
-     */
-    export async function list(filter?: AssetFilter): Promise<AssetInfo[]> {
-        const response = await host.get(host.createUrl("assets", filter));
-        return await response.json() as AssetInfo[];
-    }
+  /**
+   * Lists available assets, optionally filtered by type and/or mod.
+   *
+   * @param filter - Optional filter criteria
+   * @returns Array of matching asset info objects
+   *
+   * @example
+   * ```typescript
+   * // Get all assets
+   * const all = await assets.list();
+   *
+   * // Get only VRM models
+   * const vrms = await assets.list({ type: "vrm" });
+   *
+   * // Get assets from a specific mod
+   * const modAssets = await assets.list({ mod: "elmer" });
+   *
+   * // Combine filters
+   * const sounds = await assets.list({ type: "sound", mod: "my-mod" });
+   * ```
+   */
+  export async function list(filter?: AssetFilter): Promise<AssetInfo[]> {
+    const response = await host.get(host.createUrl("assets", filter));
+    return (await response.json()) as AssetInfo[];
+  }
 
-    /** Parameters for importing an asset file. */
-    export interface ImportAssetParams {
-        /** Absolute path to the source file */
-        sourcePath: string;
-        /** Asset ID to register (e.g., "vrm:local:my-persona") */
-        assetId: string;
-        /** Asset type */
-        assetType: AssetType;
-        /** Optional description */
-        description?: string;
-    }
+  /** Parameters for importing an asset file. */
+  export interface ImportAssetParams {
+    /** Absolute path to the source file */
+    sourcePath: string;
+    /** Asset ID to register (e.g., "vrm:local:my-persona") */
+    assetId: string;
+    /** Asset type */
+    assetType: AssetType;
+    /** Optional description */
+    description?: string;
+  }
 
-    /** Result of an asset import. */
-    export interface ImportAssetResult {
-        /** The registered asset ID */
-        assetId: string;
-    }
+  /** Result of an asset import. */
+  export interface ImportAssetResult {
+    /** The registered asset ID */
+    assetId: string;
+  }
 
-    /**
-     * Imports a file as a managed asset.
-     *
-     * Copies the source file to the managed assets directory, registers it in the
-     * asset registry, and persists the registration to the database.
-     *
-     * @returns The registered asset info
-     *
-     * @example
-     * ```typescript
-     * const result = await assets.importAsset({
-     *   sourcePath: "/Users/me/Downloads/model.vrm",
-     *   assetId: "vrm:local:alice",
-     *   assetType: "vrm",
-     *   description: "Alice's custom model",
-     * });
-     * console.log("Imported:", result.assetId);
-     * ```
-     */
-    export async function importAsset(params: ImportAssetParams): Promise<ImportAssetResult> {
-        const response = await host.post(host.createUrl("assets/import"), params);
-        return await response.json() as ImportAssetResult;
-    }
+  /**
+   * Imports a file as a managed asset.
+   *
+   * Copies the source file to the managed assets directory, registers it in the
+   * asset registry, and persists the registration to the database.
+   *
+   * @returns The registered asset info
+   *
+   * @example
+   * ```typescript
+   * const result = await assets.importAsset({
+   *   sourcePath: "/Users/me/Downloads/model.vrm",
+   *   assetId: "vrm:local:alice",
+   *   assetType: "vrm",
+   *   description: "Alice's custom model",
+   * });
+   * console.log("Imported:", result.assetId);
+   * ```
+   */
+  export async function importAsset(
+    params: ImportAssetParams,
+  ): Promise<ImportAssetResult> {
+    const response = await host.post(host.createUrl("assets/import"), params);
+    return (await response.json()) as ImportAssetResult;
+  }
 
-    /**
-     * Fetches the raw file content of an asset by ID.
-     *
-     * The returned `Blob` carries both the byte payload and the MIME type
-     * (inferred server-side from the file extension). Unknown extensions
-     * fall back to `application/octet-stream`.
-     *
-     * @param id - Asset ID (e.g. `"@hmcs/elmer:thumbnail"`)
-     * @returns A Blob containing the asset bytes. `blob.type` holds the MIME type.
-     * @throws {HomunculusApiError} 400 if the id is missing, 404 if the asset
-     *         or underlying file is missing, 500 on IO error.
-     *
-     * @example
-     * ```typescript
-     * const blob = await assets.getFile("@hmcs/elmer:thumbnail");
-     * console.log(blob.type);  // "image/png"
-     * console.log(blob.size);  // e.g. 12345
-     *
-     * // Read as bytes
-     * const bytes = new Uint8Array(await blob.arrayBuffer());
-     *
-     * // Or use directly as an <img src> in a browser/CEF context
-     * const url = URL.createObjectURL(blob);
-     * ```
-     */
-    export async function getFile(id: string): Promise<Blob> {
-        const response = await host.get(host.createUrl("assets/file", {id}));
-        return await response.blob();
-    }
+  /**
+   * Fetches the raw file content of an asset by ID.
+   *
+   * The returned `Blob` carries both the byte payload and the MIME type
+   * (inferred server-side from the file extension). Unknown extensions
+   * fall back to `application/octet-stream`.
+   *
+   * @param id - Asset ID (e.g. `"@hmcs/elmer:thumbnail"`)
+   * @returns A Blob containing the asset bytes. `blob.type` holds the MIME type.
+   * @throws {HomunculusApiError} 400 if the id is missing, 404 if the asset
+   *         or underlying file is missing, 500 on IO error.
+   *
+   * @example
+   * ```typescript
+   * const blob = await assets.fetchFile("@hmcs/elmer:thumbnail");
+   * console.log(blob.type);  // "image/png"
+   * console.log(blob.size);  // e.g. 12345
+   *
+   * // Read as bytes
+   * const bytes = new Uint8Array(await blob.arrayBuffer());
+   *
+   * // Or use directly as an <img src> in a browser/CEF context
+   * const url = URL.createObjectURL(blob);
+   * ```
+   */
+  export async function fetchFile(id: string): Promise<Blob> {
+    const response = await host.get(host.createUrl("assets/file", { id }));
+    return await response.blob();
+  }
 }

--- a/packages/sdk/src/assets.ts
+++ b/packages/sdk/src/assets.ts
@@ -110,4 +110,34 @@ export namespace assets {
         const response = await host.post(host.createUrl("assets/import"), params);
         return await response.json() as ImportAssetResult;
     }
+
+    /**
+     * Fetches the raw file content of an asset by ID.
+     *
+     * The returned `Blob` carries both the byte payload and the MIME type
+     * (inferred server-side from the file extension). Unknown extensions
+     * fall back to `application/octet-stream`.
+     *
+     * @param id - Asset ID (e.g. `"@hmcs/elmer:thumbnail"`)
+     * @returns A Blob containing the asset bytes. `blob.type` holds the MIME type.
+     * @throws {HomunculusApiError} 400 if the id is missing, 404 if the asset
+     *         or underlying file is missing, 500 on IO error.
+     *
+     * @example
+     * ```typescript
+     * const blob = await assets.getFile("@hmcs/elmer:thumbnail");
+     * console.log(blob.type);  // "image/png"
+     * console.log(blob.size);  // e.g. 12345
+     *
+     * // Read as bytes
+     * const bytes = new Uint8Array(await blob.arrayBuffer());
+     *
+     * // Or use directly as an <img src> in a browser/CEF context
+     * const url = URL.createObjectURL(blob);
+     * ```
+     */
+    export async function getFile(id: string): Promise<Blob> {
+        const response = await host.get(host.createUrl("assets/file", {id}));
+        return await response.blob();
+    }
 }


### PR DESCRIPTION
## Problem

The `GET /assets/file?id={assetId}` HTTP endpoint has existed on the Bevy engine for a while, but the TypeScript SDK (`@hmcs/sdk`) had no corresponding wrapper. The `assets` namespace only exposed `list()` and `importAsset()`, so any mod or extension that wanted to read the raw bytes of a registered asset had to hand-roll a URL, call `fetch` directly, and bypass the SDK's `HomunculusApiError` convention. This PR fills that gap.

## Solution

Adds one function to `packages/sdk/src/assets.ts`:

```ts
assets.getFile(id: string): Promise<Blob>
```

It is a thin wrapper around the existing endpoint that:

- routes through the SDK's `host.get()` + `host.createUrl()` helpers, so non-2xx responses automatically throw `HomunculusApiError` like every other SDK call;
- returns a standard Web Platform `Blob` so the caller gets the byte payload **and** the MIME type in one value — `blob.type` is populated from the server's `Content-Type` response header (which the Rust route already infers from the file extension via `mime_guess`);
- carries full JSDoc with `@param`, `@returns`, `@throws`, and an `@example` block showing MIME inspection, `arrayBuffer()` byte reading, and `URL.createObjectURL()` usage.

**Affected area:** `packages/` only — specifically a single addition to `packages/sdk/src/assets.ts`. No Rust, no OpenAPI spec, no mods, no docs site.

**Intentionally out of scope:**

- No refactor of `Persona.thumbnailUrl()`. It currently inlines `host.createUrl("assets/file", { id })` to build a URL string for `<img src>`; since it has only one use site and a different (sync, URL-string) shape, promoting a shared `assets.fileUrl()` helper is deferred until a second consumer appears.
- No tests. `packages/sdk/` has no test runner configured; verification is via `pnpm check-types`, `pnpm build`, and `pnpm lint` (all green), plus a `grep getFile` spot-check against the bundled `dist/index.d.ts`.
- No version bump.

## Documentation

- [ ] Included in this PR
- [ ] Will be added in a follow-up PR
- [x] Not needed

---

- [ ] If HTTP endpoints changed: I ran `make gen-open-api` and `pnpm build`
- [ ] This PR includes breaking changes