### PR TITLE
fix(agent): unify webview aspect ratio and stabilize main area size

### DIFF
--- a/mods/agent/commands/open-agent.ts
+++ b/mods/agent/commands/open-agent.ts
@@ -10,7 +10,7 @@ try {
 
   await Webview.open({
     source: webviewSource.local("agent:session-ui"),
-    size: [1.07, 0.8],
+    size: [1.28, 0.8],
     viewportSize: [800, 500],
     transform: { translation: [1.3, 0.8, WebviewLayer.UI] },
     linkedPersona: personaId,

--- a/mods/agent/commands/open-agent.ts
+++ b/mods/agent/commands/open-agent.ts
@@ -6,13 +6,15 @@ import { audio, Webview, WebviewLayer, webviewSource } from "@hmcs/sdk";
 import { input, output } from "@hmcs/sdk/commands";
 
 try {
-  const { linkedPersona: personaId } = await input.parse(z.object({ linkedPersona: z.string() }));
+  const { linkedPersona: personaId } = await input.parse(
+    z.object({ linkedPersona: z.string() }),
+  );
 
   await Webview.open({
     source: webviewSource.local("agent:session-ui"),
     size: [1.28, 0.8],
     viewportSize: [800, 500],
-    transform: { translation: [1.3, 0.8, WebviewLayer.UI] },
+    transform: { translation: [1.7, 0.8, WebviewLayer.UI] },
     linkedPersona: personaId,
   });
   await audio.se.play("se:open");

--- a/mods/agent/ui/session/src/UnifiedView.tsx
+++ b/mods/agent/ui/session/src/UnifiedView.tsx
@@ -24,7 +24,7 @@ export function UnifiedView() {
   const isActive = session.state !== "idle";
 
   const [sidebarOpen, setSidebarOpen] = useState(true);
-  const [sidebarWidth, setSidebarWidth] = useState(300);
+  const [sidebarWidth, setSidebarWidth] = useState(270);
   const [resizing, setResizing] = useState(false);
   const [bodyContent, setBodyContent] = useState<BodyContent>({ kind: "sessionLog" });
   const [activeCategory, setActiveCategory] = useState<SettingsCategory | null>(null);
@@ -238,7 +238,7 @@ export function UnifiedView() {
       data-resizing={resizing || undefined}
       data-minimized={minimized || undefined}
       data-mounted={mounted || undefined}
-      style={minimized ? undefined : { width: sidebarOpen ? 700 : 400 }}
+      style={minimized ? undefined : { width: sidebarOpen ? 800 : 400 }}
       onClick={minimized ? handleRestore : undefined}
       onKeyDown={minimized ? (e: React.KeyboardEvent) => { if (e.key === "Enter") handleRestore(); } : undefined}
       role={minimized ? "button" : undefined}

--- a/mods/agent/ui/session/src/UnifiedView.tsx
+++ b/mods/agent/ui/session/src/UnifiedView.tsx
@@ -238,7 +238,7 @@ export function UnifiedView() {
       data-resizing={resizing || undefined}
       data-minimized={minimized || undefined}
       data-mounted={mounted || undefined}
-      style={minimized ? undefined : { width: sidebarOpen ? 800 : 400 }}
+      style={minimized ? undefined : { width: sidebarOpen ? sidebarWidth + 400 : 400 }}
       onClick={minimized ? handleRestore : undefined}
       onKeyDown={minimized ? (e: React.KeyboardEvent) => { if (e.key === "Enter") handleRestore(); } : undefined}
       role={minimized ? "button" : undefined}


### PR DESCRIPTION
## Problem

The Agent webview had two sizing issues:

1. **Aspect ratio mismatch**: the mesh size `[1.07, 0.8]` (1.34:1) did not match the viewport `[800, 500]` (1.6:1), causing ~16% horizontal compression of UI content.
2. **Main area resize on session start**: the sidebar auto-collapses when a session starts, and the container width shrank from 700px to 400px, cutting the main area (chat log / text input) significantly and making the layout feel unstable.

## Solution

- Align the mesh to `[1.28, 0.8]` so its aspect ratio matches the viewport's 16:10 (1.6:1), eliminating horizontal compression.
- Reduce the sidebar default width from 300px to 270px.
- Compute the chrome container width as `sidebarOpen ? sidebarWidth + 400 : 400`, which keeps the main area at a constant 400px whether the sidebar is expanded or collapsed — the panel grows/shrinks by exactly the sidebar width, so the user-facing main area never changes size.
- Fine-tune the webview position offset so the panel sits in a more natural spot beside the character.

Affected files: `mods/agent/commands/open-agent.ts`, `mods/agent/ui/session/src/UnifiedView.tsx`.

<details><summary>Screenshots</summary>

_TODO: paste before/after screenshots_

</details>

## Documentation

- [ ] Included in this PR
- [ ] Will be added in a follow-up PR
- [x] Not needed

---

- [ ] If HTTP endpoints changed: I ran `make gen-open-api` and `pnpm build`
- [ ] This PR includes breaking changes