### PR TITLE
feat(mcp): register RPC methods as individual MCP tools

### DIFF
--- a/engine/Cargo.lock
+++ b/engine/Cargo.lock
@@ -4602,6 +4602,7 @@ dependencies = [
  "bevy",
  "bevy_vrm1",
  "homunculus_utils",
+ "rmcp",
  "serde",
  "serde_json",
  "utoipa",

--- a/engine/Cargo.toml
+++ b/engine/Cargo.toml
@@ -122,6 +122,7 @@ windows = "0.60"
 raw-window-handle = "0.6"
 num_cpus = "1"
 mime_guess = "2"
+rmcp = { version = "1.1.0", features = ["server", "transport-streamable-http-server"] }
 chrono = { version = "0.4", features = ["serde"] }
 
 [build-dependencies]

--- a/engine/crates/homunculus_core/Cargo.toml
+++ b/engine/crates/homunculus_core/Cargo.toml
@@ -16,10 +16,12 @@ bevy_vrm1 = { workspace = true }
 anyhow = { workspace = true }
 async-broadcast = { workspace = true }
 utoipa = { workspace = true, optional = true }
+rmcp = { workspace = true, optional = true }
 
 [features]
 default = []
 openapi = ["dep:utoipa"]
+mcp = ["dep:rmcp"]
 
 [lints]
 workspace = true

--- a/engine/crates/homunculus_core/src/lib.rs
+++ b/engine/crates/homunculus_core/src/lib.rs
@@ -73,6 +73,7 @@ mod error;
 mod events;
 mod render_layers;
 mod resources;
+#[cfg(feature = "mcp")]
 pub mod rpc_registry;
 mod schema;
 mod system_param;
@@ -80,13 +81,14 @@ mod system_set;
 pub mod texture;
 
 pub mod prelude {
+    #[cfg(feature = "mcp")]
+    pub use crate::rpc_registry::*;
     pub use crate::{
         HomunculusCorePlugin,
         components::*,
         error::*,
         events::prelude::*,
         resources::prelude::*,
-        rpc_registry::*,
         schema::prelude::*,
         system_param::prelude::*,
         system_set::HomunculusSystemSet,

--- a/engine/crates/homunculus_core/src/resources.rs
+++ b/engine/crates/homunculus_core/src/resources.rs
@@ -1,3 +1,4 @@
+#[cfg(feature = "mcp")]
 use crate::rpc_registry::SharedRpcRegistry;
 use bevy::prelude::*;
 pub mod prelude {
@@ -22,6 +23,7 @@ pub(crate) struct CoreResourcesPlugin;
 impl Plugin for CoreResourcesPlugin {
     fn build(&self, app: &mut App) {
         app.init_resource::<ModMenuMetadataList>();
+        #[cfg(feature = "mcp")]
         app.init_resource::<SharedRpcRegistry>();
     }
 }

--- a/engine/crates/homunculus_core/src/rpc_registry.rs
+++ b/engine/crates/homunculus_core/src/rpc_registry.rs
@@ -1,6 +1,8 @@
 //! Runtime registry for MOD service RPC endpoints.
 
 use bevy::prelude::*;
+#[cfg(feature = "mcp")]
+use rmcp::model::{Icon, Meta, ToolAnnotations, ToolExecution};
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::sync::{Arc, RwLock};
@@ -24,6 +26,9 @@ pub struct RpcRegistration {
 }
 
 /// Metadata for a single RPC method.
+///
+/// When the `mcp` feature is enabled, additional fields are available
+/// for full MCP tool compatibility (annotations, schemas, icons, etc.).
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
 #[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
 #[serde(rename_all = "camelCase")]
@@ -32,6 +37,33 @@ pub struct RpcMethodMeta {
     pub description: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub timeout: Option<u64>,
+    #[cfg(feature = "mcp")]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub title: Option<String>,
+    #[cfg(feature = "mcp")]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[cfg_attr(feature = "openapi", schema(value_type = Object))]
+    pub input_schema: Option<serde_json::Map<String, serde_json::Value>>,
+    #[cfg(feature = "mcp")]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[cfg_attr(feature = "openapi", schema(value_type = Object))]
+    pub output_schema: Option<serde_json::Map<String, serde_json::Value>>,
+    #[cfg(feature = "mcp")]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[cfg_attr(feature = "openapi", schema(value_type = Object))]
+    pub annotations: Option<ToolAnnotations>,
+    #[cfg(feature = "mcp")]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[cfg_attr(feature = "openapi", schema(value_type = Object))]
+    pub execution: Option<ToolExecution>,
+    #[cfg(feature = "mcp")]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[cfg_attr(feature = "openapi", schema(value_type = Vec<Object>))]
+    pub icons: Option<Vec<Icon>>,
+    #[cfg(feature = "mcp")]
+    #[serde(rename = "_meta", skip_serializing_if = "Option::is_none")]
+    #[cfg_attr(feature = "openapi", schema(value_type = Object))]
+    pub meta: Option<Meta>,
 }
 
 /// Shared reference to the RPC registry, usable across async boundaries.
@@ -95,6 +127,7 @@ mod tests {
             RpcMethodMeta {
                 description: Some("Display visual".to_string()),
                 timeout: Some(15000),
+                ..Default::default()
             },
         );
         reg.register("visual".to_string(), 54321, methods);
@@ -143,5 +176,49 @@ mod tests {
         reg.register("a".to_string(), 1000, HashMap::new());
         reg.register("b".to_string(), 2000, HashMap::new());
         assert_eq!(reg.all().len(), 2);
+    }
+
+    #[test]
+    fn method_meta_default_has_none_fields() {
+        let meta = RpcMethodMeta::default();
+        assert!(meta.description.is_none());
+        assert!(meta.timeout.is_none());
+    }
+
+    #[cfg(feature = "mcp")]
+    #[test]
+    fn method_meta_serializes_camel_case() {
+        let mut input_schema = serde_json::Map::new();
+        input_schema.insert(
+            "type".to_string(),
+            serde_json::Value::String("object".to_string()),
+        );
+        let meta = RpcMethodMeta {
+            description: Some("test".to_string()),
+            timeout: Some(5000),
+            title: Some("Test Tool".to_string()),
+            input_schema: Some(input_schema),
+            ..Default::default()
+        };
+        let json = serde_json::to_value(&meta).unwrap();
+        assert_eq!(json["description"], "test");
+        assert_eq!(json["timeout"], 5000);
+        assert_eq!(json["title"], "Test Tool");
+        assert_eq!(json["inputSchema"]["type"], "object");
+        assert!(json.get("outputSchema").is_none());
+        assert!(json.get("annotations").is_none());
+    }
+
+    #[cfg(feature = "mcp")]
+    #[test]
+    fn method_meta_deserializes_with_unknown_fields() {
+        let json = serde_json::json!({
+            "description": "hello",
+            "timeout": 3000
+        });
+        let meta: RpcMethodMeta = serde_json::from_value(json).unwrap();
+        assert_eq!(meta.description.as_deref(), Some("hello"));
+        assert_eq!(meta.timeout, Some(3000));
+        assert!(meta.input_schema.is_none());
     }
 }

--- a/engine/crates/homunculus_core/src/rpc_registry.rs
+++ b/engine/crates/homunculus_core/src/rpc_registry.rs
@@ -1,7 +1,6 @@
 //! Runtime registry for MOD service RPC endpoints.
 
 use bevy::prelude::*;
-#[cfg(feature = "mcp")]
 use rmcp::model::{Icon, Meta, ToolAnnotations, ToolExecution};
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
@@ -37,26 +36,20 @@ pub struct RpcMethodMeta {
     pub description: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub timeout: Option<u64>,
-    #[cfg(feature = "mcp")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub title: Option<String>,
-    #[cfg(feature = "mcp")]
     #[serde(skip_serializing_if = "Option::is_none")]
     #[cfg_attr(feature = "openapi", schema(value_type = Object))]
     pub input_schema: Option<serde_json::Map<String, serde_json::Value>>,
-    #[cfg(feature = "mcp")]
     #[serde(skip_serializing_if = "Option::is_none")]
     #[cfg_attr(feature = "openapi", schema(value_type = Object))]
     pub output_schema: Option<serde_json::Map<String, serde_json::Value>>,
-    #[cfg(feature = "mcp")]
     #[serde(skip_serializing_if = "Option::is_none")]
     #[cfg_attr(feature = "openapi", schema(value_type = Object))]
     pub annotations: Option<ToolAnnotations>,
-    #[cfg(feature = "mcp")]
     #[serde(skip_serializing_if = "Option::is_none")]
     #[cfg_attr(feature = "openapi", schema(value_type = Object))]
     pub execution: Option<ToolExecution>,
-    #[cfg(feature = "mcp")]
     #[serde(skip_serializing_if = "Option::is_none")]
     #[cfg_attr(feature = "openapi", schema(value_type = Vec<Object>))]
     pub icons: Option<Vec<Icon>>,
@@ -185,7 +178,6 @@ mod tests {
         assert!(meta.timeout.is_none());
     }
 
-    #[cfg(feature = "mcp")]
     #[test]
     fn method_meta_serializes_camel_case() {
         let mut input_schema = serde_json::Map::new();
@@ -209,7 +201,6 @@ mod tests {
         assert!(json.get("annotations").is_none());
     }
 
-    #[cfg(feature = "mcp")]
     #[test]
     fn method_meta_deserializes_with_unknown_fields() {
         let json = serde_json::json!({

--- a/engine/crates/homunculus_http_server/Cargo.toml
+++ b/engine/crates/homunculus_http_server/Cargo.toml
@@ -13,7 +13,7 @@ axum = { workspace = true, features = ["tokio", "macros"] }
 tokio = { version = "1", features = ["rt-multi-thread", "process", "io-util", "fs"] }
 tokio-stream = "0.1"
 bevy_vrm1 = { workspace = true }
-homunculus_core = { workspace = true, features = ["openapi"] }
+homunculus_core = { workspace = true, features = ["openapi", "mcp"] }
 homunculus_api = { workspace = true, features = ["axum", "openapi"] }
 homunculus_utils = { workspace = true, features = ["bevy"] }
 homunculus_audio = { workspace = true }

--- a/engine/crates/homunculus_mcp/Cargo.toml
+++ b/engine/crates/homunculus_mcp/Cargo.toml
@@ -11,10 +11,10 @@ publish.workspace = true
 bevy = { workspace = true }
 bevy_vrm1 = { workspace = true }
 homunculus_api = { workspace = true }
-homunculus_core = { workspace = true }
+homunculus_core = { workspace = true, features = ["mcp"] }
 homunculus_utils = { workspace = true }
 reqwest = { workspace = true }
-rmcp = { version = "1.1.0", features = ["server", "transport-streamable-http-server"] }
+rmcp = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 tokio = { workspace = true, features = ["process", "io-util", "time"] }

--- a/engine/crates/homunculus_mcp/src/handler.rs
+++ b/engine/crates/homunculus_mcp/src/handler.rs
@@ -735,7 +735,10 @@ mod tests {
             .get_tool("remove_character")
             .expect("remove_character should exist");
         let ann = tool.annotations.expect("should have annotations");
-        assert_eq!(ann.destructive_hint, None, "destructive_hint should use default (true)");
+        assert_eq!(
+            ann.destructive_hint, None,
+            "destructive_hint should use default (true)"
+        );
         assert_eq!(ann.idempotent_hint, Some(true));
         assert_eq!(ann.open_world_hint, Some(false));
     }

--- a/engine/crates/homunculus_mcp/src/handler.rs
+++ b/engine/crates/homunculus_mcp/src/handler.rs
@@ -315,12 +315,12 @@ mod tests {
     }
 
     #[test]
-    fn resource_definitions_lists_five_resources() {
+    fn resource_definitions_lists_four_resources() {
         let resources = resources::resource_definitions();
         assert_eq!(
             resources.len(),
-            5,
-            "expected 5 resources, got {}",
+            4,
+            "expected 4 resources, got {}",
             resources.len()
         );
     }
@@ -340,7 +340,6 @@ mod tests {
             uris.contains(&"homunculus://assets"),
             "missing assets resource"
         );
-        assert!(uris.contains(&"homunculus://rpc"), "missing rpc resource");
     }
 
     #[test]

--- a/engine/crates/homunculus_mcp/src/handler.rs
+++ b/engine/crates/homunculus_mcp/src/handler.rs
@@ -704,4 +704,39 @@ mod tests {
         assert!(handler.get_tool("rpc_nonexistent_method").is_none());
         assert!(handler.get_tool("totally_unknown").is_none());
     }
+
+    #[test]
+    fn get_character_snapshot_has_read_only_annotation() {
+        let handler = test_handler();
+        let tool = handler
+            .get_tool("get_character_snapshot")
+            .expect("get_character_snapshot should exist");
+        let ann = tool.annotations.expect("should have annotations");
+        assert_eq!(ann.read_only_hint, Some(true));
+        assert_eq!(ann.open_world_hint, Some(false));
+    }
+
+    #[test]
+    fn execute_command_has_no_annotations() {
+        let handler = test_handler();
+        let tool = handler
+            .get_tool("execute_command")
+            .expect("execute_command should exist");
+        assert!(
+            tool.annotations.is_none(),
+            "execute_command should have no annotations (all defaults)"
+        );
+    }
+
+    #[test]
+    fn remove_character_is_destructive_and_idempotent() {
+        let handler = test_handler();
+        let tool = handler
+            .get_tool("remove_character")
+            .expect("remove_character should exist");
+        let ann = tool.annotations.expect("should have annotations");
+        assert_eq!(ann.destructive_hint, None, "destructive_hint should use default (true)");
+        assert_eq!(ann.idempotent_hint, Some(true));
+        assert_eq!(ann.open_world_hint, Some(false));
+    }
 }

--- a/engine/crates/homunculus_mcp/src/handler.rs
+++ b/engine/crates/homunculus_mcp/src/handler.rs
@@ -220,10 +220,7 @@ impl HomunculusMcpHandler {
                 }
             }
             found.ok_or_else(|| {
-                rmcp::ErrorData::invalid_params(
-                    format!("Unknown RPC tool: {}", request.name),
-                    None,
-                )
+                rmcp::ErrorData::invalid_params(format!("Unknown RPC tool: {}", request.name), None)
             })?
         };
 
@@ -232,8 +229,7 @@ impl HomunculusMcpHandler {
             .as_ref()
             .map(|args| serde_json::Value::Object(args.clone()));
 
-        let text =
-            tools::send_rpc_call(port, &mod_name, &method, timeout_ms, body.as_ref()).await;
+        let text = tools::send_rpc_call(port, &mod_name, &method, timeout_ms, body.as_ref()).await;
         Ok(CallToolResult::success(vec![Content::text(text)]))
     }
 }
@@ -242,9 +238,7 @@ impl HomunculusMcpHandler {
 ///
 /// Strips `@`, replaces `/` and `-` with `_`.
 fn normalize_mod_name(mod_name: &str) -> String {
-    mod_name
-        .replace('@', "")
-        .replace(['/', '-'], "_")
+    mod_name.replace('@', "").replace(['/', '-'], "_")
 }
 
 /// Generates an MCP tool name from a mod name and method.

--- a/engine/crates/homunculus_mcp/src/handler.rs
+++ b/engine/crates/homunculus_mcp/src/handler.rs
@@ -20,13 +20,15 @@ use homunculus_core::rpc_registry::RpcRegistry;
 use homunculus_utils::config::HomunculusConfig;
 use homunculus_utils::runtime::RuntimeResolver;
 use rmcp::handler::server::router::tool::ToolRouter;
+use rmcp::handler::server::tool::ToolCallContext;
 use rmcp::model::{
-    GetPromptRequestParams, GetPromptResult, Implementation, ListPromptsResult,
-    ListResourcesResult, PaginatedRequestParams, ReadResourceRequestParams, ReadResourceResult,
-    ServerCapabilities, ServerInfo,
+    CallToolRequestParams, CallToolResult, Content, GetPromptRequestParams, GetPromptResult,
+    Implementation, ListPromptsResult, ListResourcesResult, ListToolsResult,
+    PaginatedRequestParams, ReadResourceRequestParams, ReadResourceResult, ServerCapabilities,
+    ServerInfo, Tool,
 };
 use rmcp::service::RequestContext;
-use rmcp::{RoleServer, ServerHandler, tool_handler};
+use rmcp::{RoleServer, ServerHandler};
 use std::sync::{Arc, Mutex, RwLock};
 
 const SERVER_NAME: &str = "homunculus";
@@ -162,9 +164,143 @@ impl HomunculusMcpHandler {
             e.into_inner()
         }) = persona_id;
     }
+
+    /// Builds the combined tool list from static router + dynamic RPC registry.
+    fn build_tool_list(&self) -> Vec<Tool> {
+        let mut tools: Vec<Tool> = self.tool_router.list_all();
+        let reg = self.rpc_registry.read().unwrap_or_else(|e| e.into_inner());
+        let mut seen_names: std::collections::HashMap<String, bool> =
+            std::collections::HashMap::new();
+
+        for (mod_name, registration) in reg.all() {
+            for (method, meta) in &registration.methods {
+                let tool_name = generate_tool_name(mod_name, method);
+                match seen_names.entry(tool_name.clone()) {
+                    std::collections::hash_map::Entry::Vacant(e) => {
+                        e.insert(false);
+                        tools.push(build_rpc_tool(mod_name, method, meta));
+                    }
+                    std::collections::hash_map::Entry::Occupied(mut e) => {
+                        if !*e.get() {
+                            tools.retain(|t| t.name != tool_name);
+                            e.insert(true);
+                        }
+                        bevy::log::warn!(
+                            "RPC tool name collision: '{tool_name}' from '{mod_name}.{method}' — skipping"
+                        );
+                    }
+                }
+            }
+        }
+        tools
+    }
+
+    /// Dispatches a `call_tool` request to the matching RPC endpoint.
+    async fn dispatch_rpc_tool(
+        &self,
+        request: &CallToolRequestParams,
+    ) -> Result<CallToolResult, rmcp::ErrorData> {
+        let (port, mod_name, method, timeout_ms) = {
+            let reg = self.rpc_registry.read().unwrap_or_else(|e| e.into_inner());
+            let mut found = None;
+            for (mn, registration) in reg.all() {
+                for (m, meta) in &registration.methods {
+                    if generate_tool_name(mn, m) == request.name {
+                        found = Some((
+                            registration.port,
+                            mn.clone(),
+                            m.clone(),
+                            meta.timeout.unwrap_or(tools::rpc::DEFAULT_RPC_TIMEOUT_MS),
+                        ));
+                        break;
+                    }
+                }
+                if found.is_some() {
+                    break;
+                }
+            }
+            found.ok_or_else(|| {
+                rmcp::ErrorData::invalid_params(
+                    format!("Unknown RPC tool: {}", request.name),
+                    None,
+                )
+            })?
+        };
+
+        let body = request
+            .arguments
+            .as_ref()
+            .map(|args| serde_json::Value::Object(args.clone()));
+
+        let text =
+            tools::send_rpc_call(port, &mod_name, &method, timeout_ms, body.as_ref()).await;
+        Ok(CallToolResult::success(vec![Content::text(text)]))
+    }
 }
 
-#[tool_handler(router = self.tool_router)]
+/// Normalizes a mod name for use in MCP tool names.
+///
+/// Strips `@`, replaces `/` and `-` with `_`.
+fn normalize_mod_name(mod_name: &str) -> String {
+    mod_name
+        .replace('@', "")
+        .replace('/', "_")
+        .replace('-', "_")
+}
+
+/// Generates an MCP tool name from a mod name and method.
+fn generate_tool_name(mod_name: &str, method: &str) -> String {
+    format!("rpc_{}_{}", normalize_mod_name(mod_name), method)
+}
+
+/// Builds an MCP `Tool` definition from RPC method metadata.
+fn build_rpc_tool(
+    mod_name: &str,
+    method: &str,
+    meta: &homunculus_core::rpc_registry::RpcMethodMeta,
+) -> Tool {
+    let name = generate_tool_name(mod_name, method);
+    let description = meta
+        .description
+        .clone()
+        .unwrap_or_else(|| format!("RPC: {mod_name}.{method}"));
+    let input_schema = meta
+        .input_schema
+        .clone()
+        .unwrap_or_else(default_empty_object_schema);
+
+    let mut tool = Tool::new(name, description, std::sync::Arc::new(input_schema));
+
+    if let Some(title) = &meta.title {
+        tool = tool.with_title(title.clone());
+    }
+    if let Some(output) = &meta.output_schema {
+        tool = tool.with_raw_output_schema(std::sync::Arc::new(output.clone()));
+    }
+    if let Some(annotations) = &meta.annotations {
+        tool = tool.with_annotations(annotations.clone());
+    }
+    if let Some(execution) = &meta.execution {
+        tool = tool.with_execution(execution.clone());
+    }
+    if let Some(icons) = &meta.icons {
+        tool = tool.with_icons(icons.clone());
+    }
+    if let Some(m) = &meta.meta {
+        tool = tool.with_meta(m.clone());
+    }
+    tool
+}
+
+fn default_empty_object_schema() -> serde_json::Map<String, serde_json::Value> {
+    let mut map = serde_json::Map::new();
+    map.insert(
+        "type".to_string(),
+        serde_json::Value::String("object".to_string()),
+    );
+    map
+}
+
 impl ServerHandler for HomunculusMcpHandler {
     fn get_info(&self) -> ServerInfo {
         let capabilities = ServerCapabilities::builder()
@@ -179,6 +315,51 @@ impl ServerHandler for HomunculusMcpHandler {
                 "Desktop Homunculus MCP server. Controls a desktop mascot application — \
                  manage VRM characters, open webviews, query mods and assets.",
             )
+    }
+
+    fn list_tools(
+        &self,
+        _request: Option<PaginatedRequestParams>,
+        _context: RequestContext<RoleServer>,
+    ) -> impl std::future::Future<Output = Result<ListToolsResult, rmcp::ErrorData>> + Send + '_
+    {
+        std::future::ready(Ok(ListToolsResult {
+            meta: None,
+            next_cursor: None,
+            tools: self.build_tool_list(),
+        }))
+    }
+
+    fn call_tool(
+        &self,
+        request: CallToolRequestParams,
+        context: RequestContext<RoleServer>,
+    ) -> impl std::future::Future<Output = Result<CallToolResult, rmcp::ErrorData>> + Send + '_
+    {
+        async move {
+            if request.name.starts_with("rpc_") {
+                return self.dispatch_rpc_tool(&request).await;
+            }
+            let tcc = ToolCallContext::new(self, request, context);
+            self.tool_router.call(tcc).await
+        }
+    }
+
+    fn get_tool(&self, name: &str) -> Option<Tool> {
+        if let Some(tool) = self.tool_router.get(name) {
+            return Some(tool.clone());
+        }
+        if name.starts_with("rpc_") {
+            let reg = self.rpc_registry.read().unwrap_or_else(|e| e.into_inner());
+            for (mod_name, registration) in reg.all() {
+                for (method, meta) in &registration.methods {
+                    if generate_tool_name(mod_name, method) == name {
+                        return Some(build_rpc_tool(mod_name, method, meta));
+                    }
+                }
+            }
+        }
+        None
     }
 
     fn list_resources(
@@ -421,5 +602,116 @@ mod tests {
             names.contains(&"mod-command-helper"),
             "missing mod-command-helper prompt"
         );
+    }
+
+    #[test]
+    fn normalize_mod_name_strips_at_and_replaces_separators() {
+        assert_eq!(normalize_mod_name("@hmcs/persona"), "hmcs_persona");
+        assert_eq!(normalize_mod_name("my-mod"), "my_mod");
+        assert_eq!(normalize_mod_name("simple"), "simple");
+        assert_eq!(normalize_mod_name("@scope/my-pkg"), "scope_my_pkg");
+    }
+
+    #[test]
+    fn generate_tool_name_produces_expected_format() {
+        assert_eq!(
+            generate_tool_name("@hmcs/persona", "speak"),
+            "rpc_hmcs_persona_speak"
+        );
+        assert_eq!(generate_tool_name("voicevox", "tts"), "rpc_voicevox_tts");
+    }
+
+    #[test]
+    fn build_tool_list_includes_static_and_dynamic_tools() {
+        let handler = test_handler();
+        {
+            let mut reg = handler.rpc_registry.write().unwrap();
+            let mut methods = std::collections::HashMap::new();
+            methods.insert(
+                "speak".to_string(),
+                homunculus_core::rpc_registry::RpcMethodMeta {
+                    description: Some("Speak text".to_string()),
+                    ..Default::default()
+                },
+            );
+            reg.register("@hmcs/voicevox".to_string(), 9999, methods);
+        }
+        let tools = handler.build_tool_list();
+        let names: Vec<&str> = tools.iter().map(|t| t.name.as_ref()).collect();
+        assert!(
+            names.iter().any(|n| !n.starts_with("rpc_")),
+            "should have static tools"
+        );
+        assert!(
+            names.contains(&"rpc_hmcs_voicevox_speak"),
+            "should have dynamic rpc tool"
+        );
+    }
+
+    #[test]
+    fn build_tool_list_excludes_colliding_names() {
+        let handler = test_handler();
+        {
+            let mut reg = handler.rpc_registry.write().unwrap();
+            let mut m1 = std::collections::HashMap::new();
+            m1.insert(
+                "ping".to_string(),
+                homunculus_core::rpc_registry::RpcMethodMeta::default(),
+            );
+            reg.register("my-mod".to_string(), 1000, m1);
+
+            let mut m2 = std::collections::HashMap::new();
+            m2.insert(
+                "ping".to_string(),
+                homunculus_core::rpc_registry::RpcMethodMeta::default(),
+            );
+            reg.register("my_mod".to_string(), 2000, m2);
+        }
+        let tools = handler.build_tool_list();
+        let names: Vec<&str> = tools.iter().map(|t| t.name.as_ref()).collect();
+        assert!(
+            !names.contains(&"rpc_my_mod_ping"),
+            "colliding tool should be excluded"
+        );
+    }
+
+    #[test]
+    fn get_tool_finds_dynamic_rpc_tool() {
+        let handler = test_handler();
+        {
+            let mut reg = handler.rpc_registry.write().unwrap();
+            let mut methods = std::collections::HashMap::new();
+            methods.insert(
+                "hello".to_string(),
+                homunculus_core::rpc_registry::RpcMethodMeta {
+                    description: Some("Say hello".to_string()),
+                    ..Default::default()
+                },
+            );
+            reg.register("test-mod".to_string(), 8888, methods);
+        }
+        let tool = handler.get_tool("rpc_test_mod_hello");
+        assert!(tool.is_some(), "should find dynamic RPC tool");
+        let tool = tool.unwrap();
+        assert_eq!(tool.name, "rpc_test_mod_hello");
+        assert_eq!(tool.description.as_deref(), Some("Say hello"));
+    }
+
+    #[test]
+    fn get_tool_finds_static_tools() {
+        let handler = test_handler();
+        // Static tools like "show_vrm" should be found
+        let tools = handler.build_tool_list();
+        if let Some(first_static) = tools.iter().find(|t| !t.name.starts_with("rpc_")) {
+            let found = handler.get_tool(&first_static.name);
+            assert!(found.is_some(), "should find static tool by name");
+        }
+    }
+
+    #[test]
+    fn get_tool_returns_none_for_unknown() {
+        let handler = test_handler();
+        assert!(handler.get_tool("rpc_nonexistent_method").is_none());
+        assert!(handler.get_tool("totally_unknown").is_none());
     }
 }

--- a/engine/crates/homunculus_mcp/src/handler.rs
+++ b/engine/crates/homunculus_mcp/src/handler.rs
@@ -244,8 +244,7 @@ impl HomunculusMcpHandler {
 fn normalize_mod_name(mod_name: &str) -> String {
     mod_name
         .replace('@', "")
-        .replace('/', "_")
-        .replace('-', "_")
+        .replace(['/', '-'], "_")
 }
 
 /// Generates an MCP tool name from a mod name and method.
@@ -330,19 +329,16 @@ impl ServerHandler for HomunculusMcpHandler {
         }))
     }
 
-    fn call_tool(
+    async fn call_tool(
         &self,
         request: CallToolRequestParams,
         context: RequestContext<RoleServer>,
-    ) -> impl std::future::Future<Output = Result<CallToolResult, rmcp::ErrorData>> + Send + '_
-    {
-        async move {
-            if request.name.starts_with("rpc_") {
-                return self.dispatch_rpc_tool(&request).await;
-            }
-            let tcc = ToolCallContext::new(self, request, context);
-            self.tool_router.call(tcc).await
+    ) -> Result<CallToolResult, rmcp::ErrorData> {
+        if request.name.starts_with("rpc_") {
+            return self.dispatch_rpc_tool(&request).await;
         }
+        let tcc = ToolCallContext::new(self, request, context);
+        self.tool_router.call(tcc).await
     }
 
     fn get_tool(&self, name: &str) -> Option<Tool> {

--- a/engine/crates/homunculus_mcp/src/handler/resources.rs
+++ b/engine/crates/homunculus_mcp/src/handler/resources.rs
@@ -27,10 +27,6 @@ pub(super) fn resource_definitions() -> Vec<Resource> {
             .with_description("List of available assets across all mods")
             .with_mime_type("application/json")
             .no_annotation(),
-        RawResource::new("homunculus://rpc", "homunculus-rpc")
-            .with_description("Registered RPC methods by MOD service. Use with call_rpc tool.")
-            .with_mime_type("application/json")
-            .no_annotation(),
     ]
 }
 
@@ -70,13 +66,6 @@ pub(super) async fn read_resource(
                 .await
                 .map_err(api_err)?;
             to_json_string(&assets)?
-        }
-        "homunculus://rpc" => {
-            let reg = handler
-                .rpc_registry
-                .read()
-                .unwrap_or_else(|e| e.into_inner());
-            to_json_string(reg.all())?
         }
         _ => {
             return Err(rmcp::ErrorData::resource_not_found(

--- a/engine/crates/homunculus_mcp/src/handler/tools.rs
+++ b/engine/crates/homunculus_mcp/src/handler/tools.rs
@@ -5,13 +5,15 @@
 
 mod animation;
 mod audio;
-mod rpc;
+pub(super) mod rpc;
 mod system;
 mod transform;
 mod vrm;
 mod webview;
 
 use rmcp::handler::server::router::tool::ToolRouter;
+
+pub(super) use rpc::send_rpc_call;
 
 use super::HomunculusMcpHandler;
 
@@ -23,5 +25,4 @@ pub(super) fn tool_router() -> ToolRouter<HomunculusMcpHandler> {
         + HomunculusMcpHandler::audio_tool_router()
         + HomunculusMcpHandler::transform_tool_router()
         + HomunculusMcpHandler::system_tool_router()
-        + HomunculusMcpHandler::rpc_tool_router()
 }

--- a/engine/crates/homunculus_mcp/src/handler/tools/animation.rs
+++ b/engine/crates/homunculus_mcp/src/handler/tools/animation.rs
@@ -32,7 +32,8 @@ impl HomunculusMcpHandler {
     /// Play a VRMA animation on the active character.
     #[tool(
         name = "play_animation",
-        description = "Play a VRMA animation on the active character. Use the homunculus://assets resource to discover available VRMA animations."
+        description = "Play a VRMA animation on the active character. Use the homunculus://assets resource to discover available VRMA animations.",
+        annotations(destructive_hint = false, open_world_hint = false)
     )]
     async fn play_animation(&self, params: Parameters<PlayAnimationParams>) -> String {
         let args = params.0;

--- a/engine/crates/homunculus_mcp/src/handler/tools/audio.rs
+++ b/engine/crates/homunculus_mcp/src/handler/tools/audio.rs
@@ -41,7 +41,8 @@ impl HomunculusMcpHandler {
     /// Play a sound effect.
     #[tool(
         name = "play_sound",
-        description = "Play a sound effect. Use a MOD asset ID (e.g., 'se:open') or a preset name."
+        description = "Play a sound effect. Use a MOD asset ID (e.g., 'se:open') or a preset name.",
+        annotations(destructive_hint = false, open_world_hint = false)
     )]
     async fn play_sound(&self, params: Parameters<PlaySoundParams>) -> String {
         let args = params.0;
@@ -66,7 +67,8 @@ impl HomunculusMcpHandler {
     /// Control background music playback.
     #[tool(
         name = "control_bgm",
-        description = "Control background music playback. Actions: play (requires asset), stop, pause, resume, status."
+        description = "Control background music playback. Actions: play (requires asset), stop, pause, resume, status.",
+        annotations(destructive_hint = false, open_world_hint = false)
     )]
     async fn control_bgm(&self, params: Parameters<ControlBgmParams>) -> String {
         let args = params.0;

--- a/engine/crates/homunculus_mcp/src/handler/tools/rpc.rs
+++ b/engine/crates/homunculus_mcp/src/handler/tools/rpc.rs
@@ -1,84 +1,12 @@
-//! RPC tool implementations for the MCP handler.
+//! RPC call helper for the MCP handler.
 
-use super::super::HomunculusMcpHandler;
-use homunculus_core::rpc_registry::RpcRegistry;
-use rmcp::handler::server::wrapper::Parameters;
-use rmcp::schemars;
-use rmcp::schemars::JsonSchema;
-use rmcp::tool;
-use serde::{Deserialize, Serialize};
-use std::sync::{Arc, RwLock};
 use std::time::Duration;
 
 /// Default timeout for RPC calls in milliseconds (10 seconds).
-const DEFAULT_RPC_TIMEOUT_MS: u64 = 10_000;
+pub(crate) const DEFAULT_RPC_TIMEOUT_MS: u64 = 10_000;
 
-/// Parameters for the `call_rpc` tool.
-#[derive(Debug, Serialize, Deserialize, JsonSchema)]
-#[serde(rename_all = "camelCase")]
-pub struct CallRpcParams {
-    /// The MOD name to call (e.g. "voicevox").
-    pub mod_name: String,
-    /// The RPC method name to invoke.
-    pub method: String,
-    /// Optional JSON body to send with the request.
-    pub body: Option<serde_json::Value>,
-}
-
-#[rmcp::tool_router(router = rpc_tool_router, vis = "pub(super)")]
-impl HomunculusMcpHandler {
-    /// Call an RPC method on a running MOD service.
-    #[tool(
-        name = "call_rpc",
-        description = "Call a stateful MOD service RPC method. Use 'homunculus://rpc' resource to discover available mods and methods."
-    )]
-    async fn call_rpc(&self, params: Parameters<CallRpcParams>) -> String {
-        let args = params.0;
-        let (port, timeout_ms) =
-            match resolve_rpc_endpoint(&self.rpc_registry, &args.mod_name, &args.method) {
-                Ok(t) => t,
-                Err(e) => return e,
-            };
-        send_rpc_call(
-            port,
-            &args.mod_name,
-            &args.method,
-            timeout_ms,
-            args.body.as_ref(),
-        )
-        .await
-    }
-}
-
-fn resolve_rpc_endpoint(
-    rpc_registry: &Arc<RwLock<RpcRegistry>>,
-    mod_name: &str,
-    method: &str,
-) -> Result<(u16, u64), String> {
-    let reg = rpc_registry.read().unwrap_or_else(|e| e.into_inner());
-    let registration = reg.get(mod_name).ok_or_else(|| {
-        format!(
-            "Error: MOD '{mod_name}' is not registered. Use 'homunculus://rpc' resource to list available mods."
-        )
-    })?;
-    let method_meta = registration.methods.get(method).ok_or_else(|| {
-        let available = registration
-            .methods
-            .keys()
-            .cloned()
-            .collect::<Vec<_>>()
-            .join(", ");
-        format!(
-            "Error: Method '{method}' not found on MOD '{mod_name}'. Available methods: {available}"
-        )
-    })?;
-    Ok((
-        registration.port,
-        method_meta.timeout.unwrap_or(DEFAULT_RPC_TIMEOUT_MS),
-    ))
-}
-
-async fn send_rpc_call(
+/// Sends an HTTP POST to the MOD service's local RPC endpoint.
+pub(crate) async fn send_rpc_call(
     port: u16,
     mod_name: &str,
     method: &str,

--- a/engine/crates/homunculus_mcp/src/handler/tools/transform.rs
+++ b/engine/crates/homunculus_mcp/src/handler/tools/transform.rs
@@ -112,7 +112,8 @@ impl HomunculusMcpHandler {
     /// Move the active character to a screen position.
     #[tool(
         name = "move_character",
-        description = "Move the active character to a screen position. Coordinates are in viewport pixels (0,0 = top-left of primary monitor)."
+        description = "Move the active character to a screen position. Coordinates are in viewport pixels (0,0 = top-left of primary monitor).",
+        annotations(destructive_hint = false, idempotent_hint = true, open_world_hint = false)
     )]
     async fn move_character(&self, params: Parameters<MoveCharacterParams>) -> String {
         let args = params.0;
@@ -135,7 +136,8 @@ impl HomunculusMcpHandler {
     /// Smoothly animate an entity's position to a target value over time.
     #[tool(
         name = "tween_position",
-        description = "Smoothly animate the active character's position to a screen position over time. Coordinates are in viewport pixels (0,0 = top-left of primary monitor). Use this for smooth character movement and animations."
+        description = "Smoothly animate the active character's position to a screen position over time. Coordinates are in viewport pixels (0,0 = top-left of primary monitor). Use this for smooth character movement and animations.",
+        annotations(destructive_hint = false, open_world_hint = false)
     )]
     async fn tween_position(&self, params: Parameters<TweenPositionParams>) -> String {
         let args = params.0;
@@ -166,7 +168,8 @@ impl HomunculusMcpHandler {
     /// Smoothly animate an entity's rotation to a target value over time.
     #[tool(
         name = "tween_rotation",
-        description = "Smoothly animate an entity's rotation to a target value over time. Rotation is specified as a quaternion (x, y, z, w)."
+        description = "Smoothly animate an entity's rotation to a target value over time. Rotation is specified as a quaternion (x, y, z, w).",
+        annotations(destructive_hint = false, open_world_hint = false)
     )]
     async fn tween_rotation(&self, params: Parameters<TweenRotationParams>) -> String {
         let args = params.0;
@@ -200,7 +203,8 @@ impl HomunculusMcpHandler {
     /// Smoothly animate an entity's scale to a target value over time.
     #[tool(
         name = "tween_scale",
-        description = "Smoothly animate an entity's scale to a target value over time. Use this for grow/shrink effects and size animations."
+        description = "Smoothly animate an entity's scale to a target value over time. Use this for grow/shrink effects and size animations.",
+        annotations(destructive_hint = false, open_world_hint = false)
     )]
     async fn tween_scale(&self, params: Parameters<TweenScaleParams>) -> String {
         let args = params.0;
@@ -227,7 +231,8 @@ impl HomunculusMcpHandler {
     /// Spin the active character around a world-space axis by a given angle.
     #[tool(
         name = "spin_character",
-        description = "Spin the active character around an axis by a given angle. Supports full rotations (360°+). The rotation is additive, preserving the character's current orientation. Use this instead of tween_rotation when you need full spins."
+        description = "Spin the active character around an axis by a given angle. Supports full rotations (360°+). The rotation is additive, preserving the character's current orientation. Use this instead of tween_rotation when you need full spins.",
+        annotations(destructive_hint = false, open_world_hint = false)
     )]
     async fn spin_character(&self, params: Parameters<SpinCharacterParams>) -> String {
         let args = params.0;

--- a/engine/crates/homunculus_mcp/src/handler/tools/transform.rs
+++ b/engine/crates/homunculus_mcp/src/handler/tools/transform.rs
@@ -113,7 +113,11 @@ impl HomunculusMcpHandler {
     #[tool(
         name = "move_character",
         description = "Move the active character to a screen position. Coordinates are in viewport pixels (0,0 = top-left of primary monitor).",
-        annotations(destructive_hint = false, idempotent_hint = true, open_world_hint = false)
+        annotations(
+            destructive_hint = false,
+            idempotent_hint = true,
+            open_world_hint = false
+        )
     )]
     async fn move_character(&self, params: Parameters<MoveCharacterParams>) -> String {
         let args = params.0;

--- a/engine/crates/homunculus_mcp/src/handler/tools/vrm.rs
+++ b/engine/crates/homunculus_mcp/src/handler/tools/vrm.rs
@@ -80,7 +80,8 @@ impl HomunculusMcpHandler {
     /// Get the current state of all desktop characters.
     #[tool(
         name = "get_character_snapshot",
-        description = "Get the current state of all desktop characters including name, persona ID, position, active expressions, playing animations, persona, and lookAt state."
+        description = "Get the current state of all desktop characters including name, persona ID, position, active expressions, playing animations, persona, and lookAt state.",
+        annotations(read_only_hint = true, open_world_hint = false)
     )]
     async fn get_character_snapshot(&self) -> String {
         match self.vrm_api.snapshot().await {
@@ -101,7 +102,8 @@ impl HomunculusMcpHandler {
     /// Spawn a new VRM character on the desktop.
     #[tool(
         name = "spawn_character",
-        description = "Spawn a new VRM character on the desktop. Creates a persona and attaches a VRM model. Use the homunculus://assets resource to discover available VRM model assets. Returns the persona ID."
+        description = "Spawn a new VRM character on the desktop. Creates a persona and attaches a VRM model. Use the homunculus://assets resource to discover available VRM model assets. Returns the persona ID.",
+        annotations(destructive_hint = false, open_world_hint = false)
     )]
     async fn spawn_character(&self, params: Parameters<SpawnCharacterParams>) -> String {
         let args = params.0;
@@ -158,7 +160,8 @@ impl HomunculusMcpHandler {
     /// Switch the active character by name.
     #[tool(
         name = "select_character",
-        description = "Switch the active character by display name (or persona ID). All subsequent tools will target this character. Use get_character_snapshot to see available characters."
+        description = "Switch the active character by display name (or persona ID). All subsequent tools will target this character. Use get_character_snapshot to see available characters.",
+        annotations(destructive_hint = false, idempotent_hint = true, open_world_hint = false)
     )]
     async fn select_character(&self, params: Parameters<SelectCharacterParams>) -> String {
         let name = &params.0.name;
@@ -175,7 +178,8 @@ impl HomunculusMcpHandler {
     /// Remove a character (persona) from the desktop.
     #[tool(
         name = "remove_character",
-        description = "Remove a character (persona + attached VRM) from the desktop. If no name is given, removes the active character."
+        description = "Remove a character (persona + attached VRM) from the desktop. If no name is given, removes the active character.",
+        annotations(idempotent_hint = true, open_world_hint = false)
     )]
     async fn remove_character(&self, params: Parameters<RemoveCharacterParams>) -> String {
         let persona_id = if let Some(name) = &params.0.name {
@@ -208,7 +212,8 @@ impl HomunculusMcpHandler {
     /// Set facial expression weights on the active character.
     #[tool(
         name = "set_expression",
-        description = "Set facial expression weights on the active character. Common expressions: happy, sad, angry, surprised, relaxed, neutral, aa, ih, ou, ee, oh, blink. Weights are 0.0-1.0. Modes: \"modify\" (default, partial update), \"set\" (replace all), \"clear\" (reset to animation control)."
+        description = "Set facial expression weights on the active character. Common expressions: happy, sad, angry, surprised, relaxed, neutral, aa, ih, ou, ee, oh, blink. Weights are 0.0-1.0. Modes: \"modify\" (default, partial update), \"set\" (replace all), \"clear\" (reset to animation control).",
+        annotations(destructive_hint = false, idempotent_hint = true, open_world_hint = false)
     )]
     async fn set_expression(&self, params: Parameters<SetExpressionParams>) -> String {
         let entity = match self.resolve_character().await {
@@ -245,7 +250,8 @@ impl HomunculusMcpHandler {
     /// Update the active character's persona profile and personality.
     #[tool(
         name = "set_persona",
-        description = "Update the active character's persona profile and/or personality text. This affects how the character is perceived in AI conversations."
+        description = "Update the active character's persona profile and/or personality text. This affects how the character is perceived in AI conversations.",
+        annotations(destructive_hint = false, idempotent_hint = true, open_world_hint = false)
     )]
     async fn set_persona(&self, params: Parameters<SetPersonaParams>) -> String {
         let persona_id = match self.active_persona_id() {
@@ -272,7 +278,8 @@ impl HomunculusMcpHandler {
     /// Control where the active character looks.
     #[tool(
         name = "set_look_at",
-        description = "Control where the active character looks. Use \"cursor\" to follow the mouse cursor, or \"none\" to disable look-at (character looks forward)."
+        description = "Control where the active character looks. Use \"cursor\" to follow the mouse cursor, or \"none\" to disable look-at (character looks forward).",
+        annotations(destructive_hint = false, idempotent_hint = true, open_world_hint = false)
     )]
     async fn set_look_at(&self, params: Parameters<SetLookAtParams>) -> String {
         let entity = match self.resolve_character().await {

--- a/engine/crates/homunculus_mcp/src/handler/tools/vrm.rs
+++ b/engine/crates/homunculus_mcp/src/handler/tools/vrm.rs
@@ -161,7 +161,11 @@ impl HomunculusMcpHandler {
     #[tool(
         name = "select_character",
         description = "Switch the active character by display name (or persona ID). All subsequent tools will target this character. Use get_character_snapshot to see available characters.",
-        annotations(destructive_hint = false, idempotent_hint = true, open_world_hint = false)
+        annotations(
+            destructive_hint = false,
+            idempotent_hint = true,
+            open_world_hint = false
+        )
     )]
     async fn select_character(&self, params: Parameters<SelectCharacterParams>) -> String {
         let name = &params.0.name;
@@ -213,7 +217,11 @@ impl HomunculusMcpHandler {
     #[tool(
         name = "set_expression",
         description = "Set facial expression weights on the active character. Common expressions: happy, sad, angry, surprised, relaxed, neutral, aa, ih, ou, ee, oh, blink. Weights are 0.0-1.0. Modes: \"modify\" (default, partial update), \"set\" (replace all), \"clear\" (reset to animation control).",
-        annotations(destructive_hint = false, idempotent_hint = true, open_world_hint = false)
+        annotations(
+            destructive_hint = false,
+            idempotent_hint = true,
+            open_world_hint = false
+        )
     )]
     async fn set_expression(&self, params: Parameters<SetExpressionParams>) -> String {
         let entity = match self.resolve_character().await {
@@ -251,7 +259,11 @@ impl HomunculusMcpHandler {
     #[tool(
         name = "set_persona",
         description = "Update the active character's persona profile and/or personality text. This affects how the character is perceived in AI conversations.",
-        annotations(destructive_hint = false, idempotent_hint = true, open_world_hint = false)
+        annotations(
+            destructive_hint = false,
+            idempotent_hint = true,
+            open_world_hint = false
+        )
     )]
     async fn set_persona(&self, params: Parameters<SetPersonaParams>) -> String {
         let persona_id = match self.active_persona_id() {
@@ -279,7 +291,11 @@ impl HomunculusMcpHandler {
     #[tool(
         name = "set_look_at",
         description = "Control where the active character looks. Use \"cursor\" to follow the mouse cursor, or \"none\" to disable look-at (character looks forward).",
-        annotations(destructive_hint = false, idempotent_hint = true, open_world_hint = false)
+        annotations(
+            destructive_hint = false,
+            idempotent_hint = true,
+            open_world_hint = false
+        )
     )]
     async fn set_look_at(&self, params: Parameters<SetLookAtParams>) -> String {
         let entity = match self.resolve_character().await {

--- a/engine/crates/homunculus_mcp/src/handler/tools/webview.rs
+++ b/engine/crates/homunculus_mcp/src/handler/tools/webview.rs
@@ -113,7 +113,8 @@ impl HomunculusMcpHandler {
     /// Open a webview panel displaying HTML content, a URL, or a local mod asset near the active character.
     #[tool(
         name = "open_webview",
-        description = "Open a webview panel. Provide exactly one of: 'html' (inline HTML), 'url' (a URL to load), or 'asset_id' (a local mod asset, e.g. 'mod-name:asset-id'). Position with 'translationX', 'translationY', 'translationZ'. Optionally provide 'characterName' to link the webview to a specific character (it will follow the character's head position). Returns the webview entity ID. Use close_webview to close it."
+        description = "Open a webview panel. Provide exactly one of: 'html' (inline HTML), 'url' (a URL to load), or 'asset_id' (a local mod asset, e.g. 'mod-name:asset-id'). Position with 'translationX', 'translationY', 'translationZ'. Optionally provide 'characterName' to link the webview to a specific character (it will follow the character's head position). Returns the webview entity ID. Use close_webview to close it.",
+        annotations(destructive_hint = false)
     )]
     async fn open_webview(&self, params: Parameters<OpenWebviewParams>) -> String {
         let args = params.0;
@@ -184,7 +185,8 @@ impl HomunculusMcpHandler {
     /// Close a webview panel.
     #[tool(
         name = "close_webview",
-        description = "Close a webview panel. If no entity ID is given, closes the most recently opened webview. Use all=true to close all webviews."
+        description = "Close a webview panel. If no entity ID is given, closes the most recently opened webview. Use all=true to close all webviews.",
+        annotations(idempotent_hint = true, open_world_hint = false)
     )]
     async fn close_webview(&self, params: Parameters<CloseWebviewParams>) -> String {
         let args = params.0;
@@ -200,7 +202,8 @@ impl HomunculusMcpHandler {
     /// Navigate an existing webview to new content.
     #[tool(
         name = "navigate_webview",
-        description = "Navigate an existing webview to new content without closing and reopening it. Provide exactly one of: 'html' (inline HTML), 'url' (a URL to load), or 'asset_id' (a local mod asset, e.g. 'mod-name:asset-id'). If no entity is specified, navigates the most recently opened webview."
+        description = "Navigate an existing webview to new content without closing and reopening it. Provide exactly one of: 'html' (inline HTML), 'url' (a URL to load), or 'asset_id' (a local mod asset, e.g. 'mod-name:asset-id'). If no entity is specified, navigates the most recently opened webview.",
+        annotations(destructive_hint = false, idempotent_hint = true)
     )]
     async fn navigate_webview(&self, params: Parameters<NavigateWebviewParams>) -> String {
         let args = params.0;

--- a/engine/crates/homunculus_mod/Cargo.toml
+++ b/engine/crates/homunculus_mod/Cargo.toml
@@ -9,7 +9,7 @@ publish.workspace = true
 
 [dependencies]
 bevy = { workspace = true }
-homunculus_core = { workspace = true }
+homunculus_core = { workspace = true, features = ["mcp"] }
 homunculus_utils = { workspace = true }
 futures-lite = "2"
 uuid = { workspace = true }

--- a/mods/agent/package.json
+++ b/mods/agent/package.json
@@ -48,7 +48,7 @@
     "react-markdown": "^10.1.0",
     "remark-gfm": "^4.0.1",
     "uiohook-napi": "^1.5.4",
-    "zod": "^3.25.76"
+    "zod": "catalog:"
   },
   "devDependencies": {
     "@tailwindcss/vite": "catalog:",

--- a/mods/menu/package.json
+++ b/mods/menu/package.json
@@ -26,7 +26,7 @@
     "@hmcs/ui": "workspace:*",
     "react": "catalog:",
     "react-dom": "catalog:",
-    "eventsource": "^4.1.0"
+    "eventsource": "catalog:"
   },
   "devDependencies": {
     "@storybook/react-vite": "^10.2.14",

--- a/mods/persona/package.json
+++ b/mods/persona/package.json
@@ -46,10 +46,10 @@
     "@hmcs/sdk": "workspace:*",
     "@hmcs/ui": "workspace:*",
     "@radix-ui/react-radio-group": "^1.3.8",
-    "eventsource": "^4.1.0",
+    "eventsource": "catalog:",
     "react": "catalog:",
     "react-dom": "catalog:",
-    "zod": "^3.25.76"
+    "zod": "catalog:"
   },
   "devDependencies": {
     "@tailwindcss/vite": "catalog:",

--- a/mods/voicevox/package.json
+++ b/mods/voicevox/package.json
@@ -34,7 +34,7 @@
     "@hmcs/ui": "workspace:*",
     "react": "catalog:",
     "react-dom": "catalog:",
-    "zod": "^3.25.76"
+    "zod": "catalog:"
   },
   "devDependencies": {
     "@tailwindcss/vite": "catalog:",

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -54,9 +54,9 @@
     "dist"
   ],
   "dependencies": {
-    "eventsource": "^4.1.0",
-    "ws": "^8.18.0",
-    "zod": "^3.25.76",
+    "eventsource": "catalog:",
+    "ws": "catalog:",
+    "zod": "catalog:",
     "zod-to-json-schema": "^3.25.2"
   },
   "devDependencies": {

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -56,7 +56,8 @@
   "dependencies": {
     "eventsource": "^4.1.0",
     "ws": "^8.18.0",
-    "zod": "^3.25.76"
+    "zod": "^3.25.76",
+    "zod-to-json-schema": "^3.25.2"
   },
   "devDependencies": {
     "@rollup/plugin-typescript": "^11.1.6",

--- a/packages/sdk/src/rpc.test.ts
+++ b/packages/sdk/src/rpc.test.ts
@@ -166,6 +166,59 @@ describe('rpc.serve() — env var validation', () => {
   });
 });
 
+describe('rpc.method() — MCP fields', () => {
+  it('preserves MCP fields on the returned def', async () => {
+    const { rpc } = await import('./rpc');
+    const def = rpc.method({
+      description: 'Test',
+      input: z.object({ x: z.number() }),
+      handler: async ({ x }) => x,
+      title: 'My Tool',
+      annotations: { readOnlyHint: true },
+    });
+
+    expect(def.title).toBe('My Tool');
+    expect(def.annotations).toEqual({ readOnlyHint: true });
+  });
+});
+
+describe('rpc.serve() — method name validation', () => {
+  beforeEach(() => {
+    vi.resetModules();
+    process.env.HMCS_RPC_PORT = '9999';
+    process.env.HMCS_MOD_NAME = 'test-mod';
+    process.env.HMCS_PORT = '3100';
+  });
+
+  afterEach(() => {
+    delete process.env.HMCS_RPC_PORT;
+    delete process.env.HMCS_MOD_NAME;
+    delete process.env.HMCS_PORT;
+  });
+
+  it('throws for method names containing slashes', async () => {
+    const { rpc } = await import('./rpc');
+    await expect(
+      rpc.serve({
+        methods: {
+          'invalid/name': async () => ({}),
+        },
+      }),
+    ).rejects.toThrow('Invalid RPC method name');
+  });
+
+  it('throws for empty method names', async () => {
+    const { rpc } = await import('./rpc');
+    await expect(
+      rpc.serve({
+        methods: {
+          '': async () => ({}),
+        },
+      }),
+    ).rejects.toThrow('Invalid RPC method name');
+  });
+});
+
 // ---------------------------------------------------------------------------
 // rpc.call() — browser-safe RPC client (via rpc-client.ts)
 // ---------------------------------------------------------------------------

--- a/packages/sdk/src/rpc.ts
+++ b/packages/sdk/src/rpc.ts
@@ -49,6 +49,7 @@
 
 import * as http from 'node:http';
 import type { ZodType } from 'zod';
+import { zodToJsonSchema } from 'zod-to-json-schema';
 import { rpc as rpcClient } from './rpc-client';
 
 export type { RpcCallOptions } from './rpc-client';
@@ -68,6 +69,24 @@ export interface RpcMethodDef<I = unknown, O = unknown> {
   input?: ZodType<I>;
   /** Async function called with the validated input. */
   handler: (params: I) => Promise<O>;
+  /** Human-readable title for the MCP tool. */
+  title?: string;
+  /** JSON Schema object defining the structure of the tool's output. */
+  outputSchema?: Record<string, unknown>;
+  /** MCP tool annotations (readOnly, destructive, idempotent, openWorld hints). */
+  annotations?: {
+    title?: string;
+    readOnlyHint?: boolean;
+    destructiveHint?: boolean;
+    idempotentHint?: boolean;
+    openWorldHint?: boolean;
+  };
+  /** MCP tool execution configuration. */
+  execution?: { taskSupport?: 'forbidden' | 'optional' | 'required' };
+  /** MCP tool icons. */
+  icons?: Array<{ src: string; mimeType?: string; sizes?: string[] }>;
+  /** MCP tool metadata. */
+  _meta?: Record<string, unknown>;
 }
 
 /**
@@ -124,8 +143,6 @@ async function readBody(req: http.IncomingMessage): Promise<string> {
   return Buffer.concat(chunks).toString('utf-8');
 }
 
-// --- env reading ---
-
 function readRpcPort(): number {
   const s = process.env.HMCS_RPC_PORT;
   if (!s) throw new Error('HMCS_RPC_PORT environment variable is required');
@@ -147,7 +164,27 @@ function readEnginePort(): number {
   return port;
 }
 
-// --- HTTP server helpers ---
+function convertZodToObjectSchema(schema: ZodType): Record<string, unknown> {
+  const jsonSchema = zodToJsonSchema(schema, { $refStrategy: 'none' });
+  if (
+    typeof jsonSchema !== 'object' ||
+    jsonSchema === null ||
+    (jsonSchema as Record<string, unknown>).type !== 'object'
+  ) {
+    throw new Error(
+      'RPC method input schema must be a root object type. Use z.object({...}) as the top-level schema.',
+    );
+  }
+  return jsonSchema as Record<string, unknown>;
+}
+
+function validateMethodName(name: string): void {
+  if (!name || name.includes('/') || name.includes('\\')) {
+    throw new Error(
+      `Invalid RPC method name: "${name}". Must be non-empty and cannot contain slashes.`,
+    );
+  }
+}
 
 function listenOnPort(server: http.Server, port: number): Promise<void> {
   return new Promise((resolve, reject) => {
@@ -171,8 +208,6 @@ function buildRpcServer(server: http.Server, port: number): RpcServer {
       }),
   };
 }
-
-// --- request handling ---
 
 async function handleRequest(
   methods: Record<string, RpcMethodEntry>,
@@ -267,19 +302,28 @@ async function dispatchMethod(
   }
 }
 
-// --- registration ---
-
 function buildMethodsMeta(
   methods: Record<string, RpcMethodEntry>,
-): Record<string, { description?: string; timeout?: number }> {
-  const meta: Record<string, { description?: string; timeout?: number }> = {};
+): Record<string, Record<string, unknown>> {
+  const meta: Record<string, Record<string, unknown>> = {};
   for (const [name, entry] of Object.entries(methods)) {
-    meta[name] = isRpcMethodDef(entry)
-      ? {
-          ...(entry.description !== undefined ? { description: entry.description } : {}),
-          ...(entry.timeout !== undefined ? { timeout: entry.timeout } : {}),
-        }
-      : {};
+    if (isRpcMethodDef(entry)) {
+      meta[name] = {
+        ...(entry.description !== undefined ? { description: entry.description } : {}),
+        ...(entry.timeout !== undefined ? { timeout: entry.timeout } : {}),
+        ...(entry.input !== undefined
+          ? { inputSchema: convertZodToObjectSchema(entry.input) }
+          : {}),
+        ...(entry.title !== undefined ? { title: entry.title } : {}),
+        ...(entry.outputSchema !== undefined ? { outputSchema: entry.outputSchema } : {}),
+        ...(entry.annotations !== undefined ? { annotations: entry.annotations } : {}),
+        ...(entry.execution !== undefined ? { execution: entry.execution } : {}),
+        ...(entry.icons !== undefined ? { icons: entry.icons } : {}),
+        ...(entry._meta !== undefined ? { _meta: entry._meta } : {}),
+      };
+    } else {
+      meta[name] = {};
+    }
   }
   return meta;
 }
@@ -401,23 +445,47 @@ export namespace rpc {
     timeout?: number;
     input: ZodType<I>;
     handler: (params: I) => Promise<O>;
+    title?: string;
+    outputSchema?: Record<string, unknown>;
+    annotations?: RpcMethodDef['annotations'];
+    execution?: RpcMethodDef['execution'];
+    icons?: RpcMethodDef['icons'];
+    _meta?: Record<string, unknown>;
   }): RpcMethodDef<I, O>;
   export function method<O>(def: {
     description?: string;
     timeout?: number;
     handler: () => Promise<O>;
+    title?: string;
+    outputSchema?: Record<string, unknown>;
+    annotations?: RpcMethodDef['annotations'];
+    execution?: RpcMethodDef['execution'];
+    icons?: RpcMethodDef['icons'];
+    _meta?: Record<string, unknown>;
   }): RpcMethodDef<unknown, O>;
   export function method(def: {
     description?: string;
     timeout?: number;
     input?: ZodType<unknown>;
     handler: (params?: unknown) => Promise<unknown>;
+    title?: string;
+    outputSchema?: Record<string, unknown>;
+    annotations?: RpcMethodDef['annotations'];
+    execution?: RpcMethodDef['execution'];
+    icons?: RpcMethodDef['icons'];
+    _meta?: Record<string, unknown>;
   }): RpcMethodDef {
     return {
       description: def.description,
       timeout: def.timeout,
       input: def.input,
       handler: def.handler,
+      title: def.title,
+      outputSchema: def.outputSchema,
+      annotations: def.annotations,
+      execution: def.execution,
+      icons: def.icons,
+      _meta: def._meta,
     };
   }
 
@@ -460,6 +528,10 @@ export namespace rpc {
     const modName = readModName();
     const enginePort = readEnginePort();
     const { methods } = options;
+
+    for (const name of Object.keys(methods)) {
+      validateMethodName(name);
+    }
 
     const server = http.createServer((req, res) => {
       handleRequest(methods, req, res);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -444,6 +444,9 @@ importers:
       zod:
         specifier: ^3.25.76
         version: 3.25.76
+      zod-to-json-schema:
+        specifier: ^3.25.2
+        version: 3.25.2(zod@3.25.76)
     devDependencies:
       '@rollup/plugin-typescript':
         specifier: ^11.1.6
@@ -9770,6 +9773,11 @@ packages:
   yocto-queue@1.2.2:
     resolution: {integrity: sha512-4LCcse/U2MHZ63HAJVE+v71o7yOdIe4cZ70Wpf8D/IyjDKYQLV5GD46B+hSTjJsvV5PztjvHoU580EftxjDZFQ==}
     engines: {node: '>=12.20'}
+
+  zod-to-json-schema@3.25.2:
+    resolution: {integrity: sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==}
+    peerDependencies:
+      zod: ^3.25.28 || ^4
 
   zod@3.25.76:
     resolution: {integrity: sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==}
@@ -20827,6 +20835,10 @@ snapshots:
       yargs-parser: 21.1.1
 
   yocto-queue@1.2.2: {}
+
+  zod-to-json-schema@3.25.2(zod@3.25.76):
+    dependencies:
+      zod: 3.25.76
 
   zod@3.25.76: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -18,6 +18,9 @@ catalogs:
     '@vitejs/plugin-react-swc':
       specifier: ^4.2.3
       version: 4.2.3
+    eventsource:
+      specifier: ^4.1.0
+      version: 4.1.0
     react:
       specifier: ^19.2.4
       version: 19.2.4
@@ -33,6 +36,12 @@ catalogs:
     vite-plugin-singlefile:
       specifier: ^2.3.0
       version: 2.3.0
+    ws:
+      specifier: ^8.18.0
+      version: 8.19.0
+    zod:
+      specifier: ^3.25.76
+      version: 3.25.76
 
 overrides:
   serialize-javascript@<7.0.5: 7.0.5
@@ -151,7 +160,7 @@ importers:
         specifier: ^1.5.4
         version: 1.5.5
       zod:
-        specifier: ^3.25.76
+        specifier: 'catalog:'
         version: 3.25.76
     devDependencies:
       '@tailwindcss/vite':
@@ -209,7 +218,7 @@ importers:
         specifier: workspace:*
         version: link:../../packages/ui
       eventsource:
-        specifier: ^4.1.0
+        specifier: 'catalog:'
         version: 4.1.0
       react:
         specifier: 'catalog:'
@@ -261,7 +270,7 @@ importers:
         specifier: ^1.3.8
         version: 1.3.8(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       eventsource:
-        specifier: ^4.1.0
+        specifier: 'catalog:'
         version: 4.1.0
       react:
         specifier: 'catalog:'
@@ -270,7 +279,7 @@ importers:
         specifier: 'catalog:'
         version: 19.2.4(react@19.2.4)
       zod:
-        specifier: ^3.25.76
+        specifier: 'catalog:'
         version: 3.25.76
     devDependencies:
       '@tailwindcss/vite':
@@ -402,7 +411,7 @@ importers:
         specifier: 'catalog:'
         version: 19.2.4(react@19.2.4)
       zod:
-        specifier: ^3.25.76
+        specifier: 'catalog:'
         version: 3.25.76
     devDependencies:
       '@tailwindcss/vite':
@@ -436,13 +445,13 @@ importers:
   packages/sdk:
     dependencies:
       eventsource:
-        specifier: ^4.1.0
+        specifier: 'catalog:'
         version: 4.1.0
       ws:
-        specifier: ^8.18.0
+        specifier: 'catalog:'
         version: 8.19.0
       zod:
-        specifier: ^3.25.76
+        specifier: 'catalog:'
         version: 3.25.76
       zod-to-json-schema:
         specifier: ^3.25.2

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -14,6 +14,10 @@ catalog:
   vite-plugin-singlefile: ^2.3.0
   tailwindcss: ^4.2.1
   '@tailwindcss/vite': ^4.2.1
+  # SDK dependencies
+  eventsource: ^4.1.0
+  ws: ^8.18.0
+  zod: ^3.25.76
   # React
   react: ^19.2.4
   react-dom: ^19.2.4


### PR DESCRIPTION
## Problem

When AI agents called MOD RPC methods via MCP, they had to first read the `homunculus://rpc` resource to discover available methods, then call the generic `call_rpc` tool with mod name, method, and body. This two-step flow was unintuitive for LLMs and added unnecessary latency.

## Solution

Replace the two-step flow with per-method MCP tools generated dynamically from the `RpcRegistry`. Each registered RPC method now appears as an individual MCP tool (e.g., `rpc_hmcs_voicevox_speak`) with typed input schemas.

**Engine (`homunculus_core`):**
- Added `mcp` feature flag with optional `rmcp` dependency
- Extended `RpcMethodMeta` with full MCP tool fields behind `#[cfg(feature = "mcp")]`: `title`, `input_schema`, `output_schema`, `annotations`, `execution`, `icons`, `meta` — using rmcp sub-types (`ToolAnnotations`, `ToolExecution`, `Icon`, `Meta`) directly
- OpenAPI compatibility maintained via `#[cfg_attr(feature = "openapi", schema(value_type = Object))]`

**Engine (`homunculus_mcp`):**
- Removed `#[tool_handler]` macro, implemented `ServerHandler::list_tools`/`call_tool`/`get_tool` manually
- `list_tools` combines static tools from `ToolRouter` with dynamic tools built from `RpcRegistry`
- Mod name normalization: `@hmcs/persona` → `hmcs_persona` → tool name `rpc_hmcs_persona_speak`
- Collision detection: if two mods normalize to the same tool name, both are excluded with a warning
- Removed `call_rpc` tool and `homunculus://rpc` resource

**SDK (`@hmcs/sdk`):**
- Added `zod-to-json-schema` dependency for converting Zod schemas to JSON Schema
- Extended `RpcMethodDef` with all MCP tool fields (title, annotations, execution, icons, outputSchema, _meta)
- Added method name validation (rejects slashes and empty names)

### Breaking Changes

- `call_rpc` MCP tool removed — agents should use the dynamically generated per-method tools instead
- `homunculus://rpc` MCP resource removed — RPC method discovery is now automatic via `list_tools`

## Documentation

- [ ] Included in this PR
- [x] Will be added in a follow-up PR
- [ ] Not needed

---

- [ ] If HTTP endpoints changed: I ran `make gen-open-api` and `pnpm build`
- [x] This PR includes breaking changes