### PR TITLE
fix(persona): animation lost when switching VRM on spawned persona

### DIFF
--- a/engine/crates/homunculus_api/src/persona/vrm_attach.rs
+++ b/engine/crates/homunculus_api/src/persona/vrm_attach.rs
@@ -4,7 +4,7 @@ use crate::persona::{PersonaApi, PersonaSnapshot};
 use crate::prelude::initialized;
 use bevy::prelude::*;
 use bevy_flurx::prelude::*;
-use bevy_vrm1::prelude::{BodyTracking, Cameras, LookAt, VrmHandle};
+use bevy_vrm1::prelude::{BodyTracking, Cameras, LookAt, Vrm, VrmHandle};
 use homunculus_core::prelude::{
     AssetResolver, Persona, PersonaChangeEvent, PersonaId, PersonaIndex, PersonaState,
     VrmAttachedEvent, VrmDetachedEvent, VrmEvent, VrmEventSender,
@@ -67,7 +67,7 @@ fn detach_phase(
     mut commands: Commands,
     index: Res<PersonaIndex>,
     mut personas: Query<(&mut Persona, &PersonaState)>,
-    vrm_handles: Query<&VrmHandle>,
+    vrm_check: Query<(), With<Vrm>>,
     prefs: NonSend<PrefsDatabase>,
     tx_detached: Option<Res<VrmEventSender<VrmDetachedEvent>>>,
     tx_change: Option<Res<VrmEventSender<PersonaChangeEvent>>>,
@@ -78,8 +78,10 @@ fn detach_phase(
         .get_mut(entity)
         .map_err(|_| ApiError::EntityNotFound)?;
 
-    // Detach old VRM if present (no intermediate persist/broadcast)
-    let old_asset_id = if vrm_handles.get(entity).is_ok() {
+    // Detach old VRM if present (no intermediate persist/broadcast).
+    // Check for `Vrm` (not `VrmHandle`) because `VrmHandle` is consumed
+    // during initialization by bevy_vrm1's `spawn_vrm` system.
+    let old_asset_id = if vrm_check.get(entity).is_ok() {
         detach_core(&mut commands, &mut persona, entity)
     } else {
         None


### PR DESCRIPTION
## Problem

When changing the VRM model on an already-spawned persona (e.g., switching from Alice to Elmer via the persona context menu), all animations (idle, drag, sitting) were lost — the character would stand motionless.

## Solution

The root cause was in `detach_phase` (`engine/crates/homunculus_api/src/persona/vrm_attach.rs`), which checked for `VrmHandle` to detect an existing VRM before detaching. However, `bevy_vrm1`'s `spawn_vrm` system **consumes (removes)** the `VrmHandle` component during initialization. This meant that for any initialized VRM, the detach step was silently skipped:

1. `detach_core` was never called → `RequestDetachVrm` never fired
2. The stale `Initialized` component remained on the entity
3. `wait::until(initialized)` passed immediately without waiting for the **new** VRM to initialize
4. `VrmAttachedEvent` was broadcast before the new VRM was ready
5. The behavior process tried to play animations on an uninitialized VRM

**Fix**: Check for the `Vrm` component instead of `VrmHandle`. `Vrm` persists after initialization and is only removed by `RequestDetachVrm`, making it the correct indicator of an attached VRM.

Affected area: engine (`homunculus_api`).

## Documentation

- [ ] Included in this PR
- [ ] Will be added in a follow-up PR
- [x] Not needed

---

- [ ] If HTTP endpoints changed: I ran `make gen-open-api` and `pnpm build`
- [ ] This PR includes breaking changes