### PR TITLE
feat(voicevox): add speech test to settings UI

### DIFF
--- a/engine/scripts/setup.py
+++ b/engine/scripts/setup.py
@@ -19,9 +19,9 @@ def setup() -> None:
     cargo_packages = ["export-cef-dir@145.6.1+145.0.28", "cargo-about"]
     if plat == Platform.MACOS:
         cargo_packages.extend([
-            "bevy_cef_debug_render_process@0.4.1",
-            "bevy_cef_render_process@0.4.1",
-            "bevy_cef_bundle_app@0.4.1",
+            "bevy_cef_debug_render_process@0.8.1",
+            "bevy_cef_render_process@0.8.1",
+            "bevy_cef_bundle_app@0.8.1",
         ])
     elif plat == Platform.WINDOWS:
         cargo_packages.append("bevy_cef_render_process@0.4.1")

--- a/mods/voicevox/ui/src/App.tsx
+++ b/mods/voicevox/ui/src/App.tsx
@@ -1,3 +1,4 @@
+import { useState } from 'react';
 import {
   Select,
   SelectContent,
@@ -87,10 +88,13 @@ export function App() {
     saved,
     characterName,
     invalidSpeaker,
+    personaId,
+    speaking,
     handleSave,
     handleReset,
     handleClose,
     handleRetry,
+    handleSpeak,
   } = useVoicevoxSettings();
 
   if (loading) {
@@ -119,6 +123,9 @@ export function App() {
             settings={settings}
             onSettingsChange={setSettings}
             invalidSpeaker={invalidSpeaker}
+            speaking={speaking}
+            disabled={!connected || speakers.length === 0 || invalidSpeaker || !personaId}
+            onSpeak={handleSpeak}
           />
         )}
       </div>
@@ -180,11 +187,17 @@ function SettingsForm({
   settings,
   onSettingsChange,
   invalidSpeaker,
+  speaking,
+  disabled,
+  onSpeak,
 }: {
   speakers: { name: string; styles: { name: string; id: number }[] }[];
   settings: VoicevoxSettings;
   onSettingsChange: (s: VoicevoxSettings) => void;
   invalidSpeaker: boolean;
+  speaking: boolean;
+  disabled: boolean;
+  onSpeak: (text: string) => void;
 }) {
   return (
     <>
@@ -246,7 +259,46 @@ function SettingsForm({
           <div className="voicevox-param-desc">{param.desc}</div>
         </label>
       ))}
+
+      <div className="voicevox-divider" />
+      <SpeechTest speaking={speaking} disabled={disabled} onSpeak={onSpeak} />
     </>
+  );
+}
+
+function SpeechTest({
+  speaking,
+  disabled,
+  onSpeak,
+}: {
+  speaking: boolean;
+  disabled: boolean;
+  onSpeak: (text: string) => void;
+}) {
+  const [text, setText] = useState('');
+
+  return (
+    <div className="voicevox-speech-test">
+      <div className="voicevox-section-title">Speech Test</div>
+      <textarea
+        className="voicevox-speech-test-textarea"
+        rows={3}
+        placeholder="Enter text to test..."
+        value={text}
+        onChange={(e) => setText(e.target.value)}
+        disabled={disabled || speaking}
+      />
+      <div className="voicevox-speech-test-actions">
+        <button
+          type="button"
+          className="voicevox-speech-test-btn"
+          disabled={disabled || speaking || text.trim().length === 0}
+          onClick={() => onSpeak(text.trim())}
+        >
+          {speaking ? 'Speaking...' : '▶ Speak'}
+        </button>
+      </div>
+    </div>
   );
 }
 

--- a/mods/voicevox/ui/src/App.tsx
+++ b/mods/voicevox/ui/src/App.tsx
@@ -1,4 +1,3 @@
-import { useState } from 'react';
 import {
   Select,
   SelectContent,
@@ -7,7 +6,9 @@ import {
   SelectLabel,
   SelectTrigger,
   SelectValue,
+  Textarea,
 } from '@hmcs/ui';
+import { useState } from 'react';
 import type { VoicevoxSettings } from './hooks/useVoicevoxSettings';
 import { useVoicevoxSettings } from './hooks/useVoicevoxSettings';
 
@@ -280,8 +281,8 @@ function SpeechTest({
   return (
     <div className="voicevox-speech-test">
       <div className="voicevox-section-title">Speech Test</div>
-      <textarea
-        className="voicevox-speech-test-textarea"
+      <Textarea
+        className="resize-none"
         rows={3}
         placeholder="Enter text to test..."
         value={text}

--- a/mods/voicevox/ui/src/hooks/useVoicevoxSettings.ts
+++ b/mods/voicevox/ui/src/hooks/useVoicevoxSettings.ts
@@ -1,4 +1,5 @@
 import { audio, preferences, Webview } from '@hmcs/sdk';
+import { rpc } from '@hmcs/sdk/rpc';
 import { useCallback, useEffect, useState } from 'react';
 
 const VOICEVOX_HOST = 'http://localhost:50021';
@@ -45,6 +46,8 @@ export function useVoicevoxSettings() {
   const [assetId, setAssetId] = useState<string | null>(null);
   const [characterName, setCharacterName] = useState('');
   const [invalidSpeaker, setInvalidSpeaker] = useState(false);
+  const [personaId, setPersonaId] = useState<string | null>(null);
+  const [speaking, setSpeaking] = useState(false);
 
   const prefsKey = assetId ? `voicevox::${assetId}` : null;
 
@@ -55,6 +58,7 @@ export function useVoicevoxSettings() {
         const linked = await resolveLinkedPersona();
         if (cancelled) return;
 
+        setPersonaId(linked?.personaId ?? null);
         const resolvedAssetId = linked?.assetId ?? null;
         setAssetId(resolvedAssetId);
 
@@ -135,6 +139,26 @@ export function useVoicevoxSettings() {
     }
   }, []);
 
+  const handleSpeak = useCallback(
+    async (text: string) => {
+      if (speaking || !personaId || !prefsKey) return;
+      setSpeaking(true);
+      try {
+        await preferences.save(prefsKey, settings);
+        await rpc.call({
+          modName: 'voicevox',
+          method: 'speak',
+          body: { personaId, text },
+        });
+      } catch (err) {
+        console.error('Speech test failed:', err);
+      } finally {
+        setSpeaking(false);
+      }
+    },
+    [speaking, personaId, prefsKey, settings],
+  );
+
   return {
     loading,
     connected,
@@ -146,15 +170,19 @@ export function useVoicevoxSettings() {
     assetId,
     characterName,
     invalidSpeaker,
+    personaId,
+    speaking,
     handleSave,
     handleReset,
     handleClose,
     handleRetry,
+    handleSpeak,
   };
 }
 
-/** Resolves the linked persona's VRM asset ID. */
+/** Resolves the linked persona's ID, name, and VRM asset ID. */
 async function resolveLinkedPersona(): Promise<{
+  personaId: string;
   name: string;
   assetId: string | null;
 } | null> {
@@ -163,7 +191,7 @@ async function resolveLinkedPersona(): Promise<{
   const linked = await webview.linkedPersona();
   if (!linked) return null;
   const snapshot = await linked.snapshot();
-  return { name: snapshot.name ?? '', assetId: snapshot.vrmAssetId ?? null };
+  return { personaId: linked.id, name: snapshot.name ?? '', assetId: snapshot.vrmAssetId ?? null };
 }
 
 async function fetchSpeakers(): Promise<VoicevoxSpeaker[] | null> {

--- a/mods/voicevox/ui/src/hooks/useVoicevoxSettings.ts
+++ b/mods/voicevox/ui/src/hooks/useVoicevoxSettings.ts
@@ -146,7 +146,7 @@ export function useVoicevoxSettings() {
       try {
         await preferences.save(prefsKey, settings);
         await rpc.call({
-          modName: 'voicevox',
+          modName: '@hmcs/voicevox',
           method: 'speak',
           body: { personaId, text },
         });
@@ -191,7 +191,11 @@ async function resolveLinkedPersona(): Promise<{
   const linked = await webview.linkedPersona();
   if (!linked) return null;
   const snapshot = await linked.snapshot();
-  return { personaId: linked.id, name: snapshot.name ?? '', assetId: snapshot.vrmAssetId ?? null };
+  return {
+    personaId: linked.id,
+    name: snapshot.name ?? '',
+    assetId: snapshot.vrmAssetId ?? null,
+  };
 }
 
 async function fetchSpeakers(): Promise<VoicevoxSpeaker[] | null> {

--- a/mods/voicevox/ui/src/index.css
+++ b/mods/voicevox/ui/src/index.css
@@ -678,3 +678,81 @@ body {
   position: relative;
   z-index: 7;
 }
+
+/* === Speech Test === */
+
+.voicevox-speech-test {
+  display: flex;
+  flex-direction: column;
+  gap: var(--hud-space-md);
+  position: relative;
+  z-index: 7;
+}
+
+.voicevox-speech-test-textarea {
+  background: oklch(0.12 0.01 250 / 0.8);
+  border: 1px solid oklch(0.72 0.14 192 / 0.2);
+  border-radius: 6px;
+  padding: var(--hud-space-md) var(--hud-space-lg);
+  color: oklch(0.92 0.01 250);
+  font-size: var(--hud-font-size-base);
+  font-family: inherit;
+  outline: none;
+  resize: none;
+  transition:
+    border-color var(--hud-duration-content) ease,
+    box-shadow var(--hud-duration-content) ease;
+}
+
+.voicevox-speech-test-textarea:focus {
+  border-color: oklch(0.72 0.14 192 / 0.5);
+  box-shadow:
+    0 0 8px oklch(0.72 0.14 192 / 0.15),
+    inset 0 0 4px oklch(0.72 0.14 192 / 0.05);
+}
+
+.voicevox-speech-test-textarea::placeholder {
+  color: oklch(0.55 0.02 250 / 0.5);
+}
+
+.voicevox-speech-test-textarea:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.voicevox-speech-test-actions {
+  display: flex;
+  justify-content: flex-end;
+}
+
+.voicevox-speech-test-btn {
+  background: oklch(0.72 0.14 192 / 0.15);
+  border: 1px solid oklch(0.72 0.14 192 / 0.3);
+  border-radius: 6px;
+  padding: var(--hud-space-md) var(--hud-space-2xl);
+  color: oklch(0.72 0.14 192);
+  font-size: var(--hud-font-size-sm);
+  font-family: inherit;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  cursor: pointer;
+  transition:
+    background var(--hud-duration-content) ease,
+    border-color var(--hud-duration-content) ease,
+    box-shadow var(--hud-duration-content) ease;
+}
+
+.voicevox-speech-test-btn:hover:not(:disabled) {
+  background: oklch(0.72 0.14 192 / 0.25);
+  border-color: oklch(0.72 0.14 192 / 0.5);
+  box-shadow: 0 0 12px oklch(0.72 0.14 192 / 0.2);
+}
+
+.voicevox-speech-test-btn:active:not(:disabled) {
+  transform: scale(0.97);
+}
+
+.voicevox-speech-test-btn:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}

--- a/mods/voicevox/ui/src/index.css
+++ b/mods/voicevox/ui/src/index.css
@@ -689,37 +689,6 @@ body {
   z-index: 7;
 }
 
-.voicevox-speech-test-textarea {
-  background: oklch(0.12 0.01 250 / 0.8);
-  border: 1px solid oklch(0.72 0.14 192 / 0.2);
-  border-radius: 6px;
-  padding: var(--hud-space-md) var(--hud-space-lg);
-  color: oklch(0.92 0.01 250);
-  font-size: var(--hud-font-size-base);
-  font-family: inherit;
-  outline: none;
-  resize: none;
-  transition:
-    border-color var(--hud-duration-content) ease,
-    box-shadow var(--hud-duration-content) ease;
-}
-
-.voicevox-speech-test-textarea:focus {
-  border-color: oklch(0.72 0.14 192 / 0.5);
-  box-shadow:
-    0 0 8px oklch(0.72 0.14 192 / 0.15),
-    inset 0 0 4px oklch(0.72 0.14 192 / 0.05);
-}
-
-.voicevox-speech-test-textarea::placeholder {
-  color: oklch(0.55 0.02 250 / 0.5);
-}
-
-.voicevox-speech-test-textarea:disabled {
-  opacity: 0.5;
-  cursor: not-allowed;
-}
-
 .voicevox-speech-test-actions {
   display: flex;
   justify-content: flex-end;


### PR DESCRIPTION
## Problem

The VoiceVox settings UI has no way to test speech output with the current configuration, requiring users to leave the settings panel to verify their voice settings work correctly.

## Solution

Added a "Speech Test" section to the VoiceVox settings form that allows users to type text and hear it spoken with the currently configured voice settings.

Changes in **mods/voicevox**:
- Added `SpeechTest` component with a textarea and "Speak" button (`App.tsx`)
- Added `handleSpeak` callback and `speaking` state to `useVoicevoxSettings` hook — saves current settings, then calls the `speak` RPC method
- Added `personaId` tracking from linked persona for RPC calls
- Added glassmorphism-styled CSS for the speech test area (`index.css`)

Also bumped `bevy_cef` macOS tool versions from 0.4.1 to 0.8.1 in `engine/scripts/setup.py`.

## Documentation

- [ ] Included in this PR
- [x] Will be added in a follow-up PR
- [ ] Not needed

---

- [ ] If HTTP endpoints changed: I ran `make gen-open-api` and `pnpm build`
- [ ] This PR includes breaking changes