### PR TITLE
fix(ci): repair check-build workflow and unify macOS bundle on PKG

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -34,7 +34,7 @@ Minimal steps to reproduce the issue.
 <!--
   Examples:
   - OS: macOS 15.3 / Windows 11 24H2
-  - Build method: local build / MSI installer / DMG / GitHub Actions artifact
+  - Build method: local build / PKG installer / MSI installer / GitHub Actions artifact
   - GPU: NVIDIA RTX 3080 Ti, driver 560.xx
 -->
 

--- a/.github/workflows/check-build.yml
+++ b/.github/workflows/check-build.yml
@@ -38,7 +38,7 @@ jobs:
           shared-key: arm64-engine-dist
           cef-cache-key: cef-arm64-144.4.0
 
-      - name: Build engine binary
+      - name: Build engine and CLI binaries
         run: |
           if ! sccache --start-server 2>/dev/null && ! sccache --show-stats 2>/dev/null; then
             echo "::warning::sccache unavailable, falling back to plain cargo build"
@@ -46,12 +46,17 @@ jobs:
           fi
           SDKROOT=$(xcrun -sdk macosx --show-sdk-path) \
             cargo build --profile dist --target=aarch64-apple-darwin --locked
+          SDKROOT=$(xcrun -sdk macosx --show-sdk-path) \
+            cargo build -p homunculus_cli --profile dist --target=aarch64-apple-darwin --locked
         env:
           CARGO_PROFILE_DIST_CODEGEN_UNITS: 2
 
       - name: Bundle .app and create DMG
         run: |
-          make bundle-macos-app BIN_SOURCE=target/aarch64-apple-darwin/dist/desktop_homunculus
+          make bundle-macos-app \
+            BIN_SOURCE=target/aarch64-apple-darwin/dist/desktop_homunculus \
+            CLI_SOURCE=target/aarch64-apple-darwin/dist/hmcs \
+            TARGET_ARCH=arm64
           make package-macos-dmg
         env:
           SKIP_GEN_CREDITS: "1"

--- a/.github/workflows/check-build.yml
+++ b/.github/workflows/check-build.yml
@@ -36,7 +36,7 @@ jobs:
       - uses: ./.github/actions/setup-engine-build
         with:
           shared-key: arm64-engine-dist
-          cef-cache-key: cef-arm64-144.4.0
+          cef-cache-key: cef-arm64-145.6.1
 
       - name: Cache runtime downloads
         uses: actions/cache@v4
@@ -88,7 +88,7 @@ jobs:
       - uses: ./.github/actions/setup-engine-build
         with:
           shared-key: x64-engine-dist
-          cef-cache-key: cef-windows-x64-144.4.0
+          cef-cache-key: cef-windows-x64-145.6.1
 
       - name: Clean stale CEF files from target cache
         run: |

--- a/.github/workflows/check-build.yml
+++ b/.github/workflows/check-build.yml
@@ -38,6 +38,12 @@ jobs:
           shared-key: arm64-engine-dist
           cef-cache-key: cef-arm64-144.4.0
 
+      - name: Cache runtime downloads
+        uses: actions/cache@v4
+        with:
+          path: engine/target/bundle/runtime-cache
+          key: runtime-${{ hashFiles('engine/runtime-versions.toml') }}-arm64
+
       - name: Build engine and CLI binaries
         run: |
           if ! sccache --start-server 2>/dev/null && ! sccache --show-stats 2>/dev/null; then
@@ -51,27 +57,21 @@ jobs:
         env:
           CARGO_PROFILE_DIST_CODEGEN_UNITS: 2
 
-      - name: Bundle .app and create DMG
+      - name: Bundle .app and create pkg
         run: |
           make bundle-macos-app \
             BIN_SOURCE=target/aarch64-apple-darwin/dist/desktop_homunculus \
             CLI_SOURCE=target/aarch64-apple-darwin/dist/hmcs \
             TARGET_ARCH=arm64
-          make package-macos-dmg
+          make package-macos-pkg
         env:
           SKIP_GEN_CREDITS: "1"
 
-      - name: Rename DMG with arch suffix
-        run: |
-          VERSION="${{ needs.resolve-version.outputs.version }}"
-          mv target/bundle/desktop_homunculus.dmg \
-             target/bundle/desktop-homunculus-${VERSION}-arm64.dmg
-
-      - name: Upload DMG artifact
+      - name: Upload pkg artifact
         uses: actions/upload-artifact@v4
         with:
           name: engine-macos-arm64
-          path: engine/target/bundle/desktop-homunculus-${{ needs.resolve-version.outputs.version }}-arm64.dmg
+          path: engine/target/bundle/desktop_homunculus-${{ needs.resolve-version.outputs.version }}-*.pkg
 
   build-engine-windows:
     needs: resolve-version

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -89,7 +89,7 @@ jobs:
       - uses: ./.github/actions/setup-engine-build
         with:
           shared-key: ${{ matrix.arch }}-engine-dist
-          cef-cache-key: cef-${{ matrix.arch }}-144.4.0
+          cef-cache-key: cef-${{ matrix.arch }}-145.6.1
 
       - name: Cache runtime downloads
         uses: actions/cache@v4
@@ -141,7 +141,7 @@ jobs:
       - uses: ./.github/actions/setup-engine-build
         with:
           shared-key: x64-engine-dist
-          cef-cache-key: cef-windows-x64-144.4.0
+          cef-cache-key: cef-windows-x64-145.6.1
 
       - name: Cache runtime downloads
         uses: actions/cache@v4

--- a/.gitignore
+++ b/.gitignore
@@ -29,6 +29,9 @@ storybook-static
 *.tsbuildinfo
 *.local
 
+# Build artifacts
+packages/openclaw-plugin/*.tgz
+
 .superpowers/
 docs/plans/
 docs/memo.md

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -41,7 +41,7 @@ make debug-cuda       # Same as debug but with CUDA STT support
 make test             # pnpm test (TS) + cargo test --workspace (Rust)
 make fix-lint         # cargo clippy --fix + cargo fmt (Rust) + pnpm lint:fix (TS)
 make gen-open-api     # Regenerate OpenAPI spec + Docusaurus API docs + pnpm build
-make release-macos    # pnpm build + native arch release → DMG
+make release-macos    # pnpm build + native arch release → PKG
 make release-windows  # pnpm build + MSI installer via WiX 4.x (Windows only)
 make install-cli      # cargo install the hmcs CLI binary
 make stage-runtime    # Download and stage Node.js, pnpm, tsx for bundling
@@ -65,7 +65,7 @@ cargo test -p homunculus_http_server test_health # Single test by name
 
 Release builds use `--profile dist` (not `--release`), which enables `lto = "thin"` and `strip = true`:
 ```bash
-make release-macos           # Native arch → .app bundle → DMG
+make release-macos           # Native arch → .app bundle → PKG
 make release-macos-arm       # Apple Silicon
 make release-macos-x86       # Intel
 make release-macos-universal # Universal binary (ARM + x86)

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,9 @@
-UNAME_S    := $(shell uname -s)
-IS_WINDOWS := $(findstring MINGW,$(UNAME_S))$(findstring MSYS,$(UNAME_S))
+ifeq ($(OS),Windows_NT)
+  IS_WINDOWS := 1
+else
+  UNAME_S    := $(shell uname -s)
+  IS_WINDOWS := $(findstring MINGW,$(UNAME_S))$(findstring MSYS,$(UNAME_S))
+endif
 
 ifeq ($(IS_WINDOWS),)
   PYTHON ?= python3
@@ -74,5 +78,5 @@ install-openclaw-plugin:
 	pnpm --filter @hmcs/openclaw-plugin build
 	cd packages/openclaw-plugin && pnpm pack --out hmcs-openclaw-plugin.tgz
 	openclaw plugins install --force --dangerously-force-unsafe-install packages/openclaw-plugin/hmcs-openclaw-plugin.tgz
-	rm -rf packages/openclaw-plugin/hmcs-openclaw-plugin.tgz
+	pnpm --filter @hmcs/openclaw-plugin exec rimraf hmcs-openclaw-plugin.tgz
 

--- a/engine/Cargo.lock
+++ b/engine/Cargo.lock
@@ -4832,6 +4832,7 @@ dependencies = [
  "serde_json",
  "thiserror 2.0.18",
  "toml 0.8.2",
+ "url",
  "utoipa",
  "windows-sys 0.59.0",
 ]

--- a/engine/Makefile
+++ b/engine/Makefile
@@ -14,8 +14,12 @@ VERSION = $(shell cargo metadata --format-version 1 --no-deps 2>/dev/null \
 	| jq -r '.packages[] | select(.name=="$(BIN_NAME)") | .version')
 
 # --- Platform detection ---
-UNAME_S    := $(shell uname -s)
-IS_WINDOWS := $(findstring MINGW,$(UNAME_S))$(findstring MSYS,$(UNAME_S))
+ifeq ($(OS),Windows_NT)
+  IS_WINDOWS := 1
+else
+  UNAME_S    := $(shell uname -s)
+  IS_WINDOWS := $(findstring MINGW,$(UNAME_S))$(findstring MSYS,$(UNAME_S))
+endif
 
 # Python command: python3 on macOS/Linux, python on Windows
 ifeq ($(IS_WINDOWS),)
@@ -40,12 +44,14 @@ setup-ci: ## CI release build setup (uses cargo-binstall, skips cargo-about and 
 setup-cef:
 	$(PYTHON) scripts/setup_cef.py
 
+debug: export HMCS_MODS_DIR := $(CURDIR)/../sandbox
 debug:
-	HMCS_MODS_DIR=$(CURDIR)/../sandbox cargo run --features develop
+	cargo run --features develop
 
+debug-cuda: export HMCS_MODS_DIR := $(CURDIR)/../sandbox
 debug-cuda:
 	$(PYTHON) scripts/patch_whisper_cuda.py
-	HMCS_MODS_DIR=$(CURDIR)/../sandbox cargo run --features develop,stt-cuda
+	cargo run --features develop,stt-cuda
 
 gen-open-api:
 	cargo run -p homunculus_http_server --bin gen_openapi -- --output $(OPENAPI_OUTPUT)

--- a/engine/Makefile
+++ b/engine/Makefile
@@ -4,7 +4,6 @@ BIN_NAME       := desktop_homunculus
 BUNDLE_DIR     := target/bundle
 APP_BUNDLE     := $(BUNDLE_DIR)/$(APP_NAME).app
 CONTENTS       := $(APP_BUNDLE)/Contents
-DMG_FILE       := $(BUNDLE_DIR)/$(BIN_NAME).dmg
 PLIST_TEMPLATE := build/macos/Info.plist
 ICNS_FILE      := build/macos/AppIcon.icns
 RUST_LICENSES_OUTPUT := credits/licenses/RUST_THIRD_PARTY.md
@@ -71,7 +70,7 @@ install-cli: ## Install hmcs CLI via cargo install
 # --- Release targets ---
 
 .PHONY: release-windows release-macos release-macos-arm release-macos-x86 release-macos-universal \
-        bundle-macos-app package-macos-pkg package-macos-dmg bundle-macos-cef bundle-macos-runtime
+        bundle-macos-app package-macos-pkg bundle-macos-cef bundle-macos-runtime
 
 release-windows: ## Build Windows MSI installer
 	$(PYTHON) scripts/release_windows.py
@@ -148,17 +147,6 @@ package-macos-pkg: ## Create pkg installer from .app bundle (internal)
 	@echo "Creating pkg..."
 	bash scripts/build_pkg.sh "$(VERSION)" "$(SIGNING_IDENTITY)"
 	@echo "Done."
-
-package-macos-dmg: ## Create DMG from .app bundle (internal, legacy)
-	@echo "Creating DMG..."
-	rm -f $(DMG_FILE)
-	mkdir -p $(BUNDLE_DIR)/dmg-staging
-	cp -r $(APP_BUNDLE) $(BUNDLE_DIR)/dmg-staging/
-	ln -s /Applications $(BUNDLE_DIR)/dmg-staging/Applications
-	hdiutil create -fs HFS+ -volname "$(APP_NAME)" \
-		-srcfolder $(BUNDLE_DIR)/dmg-staging $(DMG_FILE)
-	rm -rf $(BUNDLE_DIR)/dmg-staging
-	@echo "Done: $(DMG_FILE)"
 
 bundle-macos-cef: ## Bundle CEF framework and helper apps into .app
 	@echo "==> Bundling CEF framework..."

--- a/engine/build/windows/installer/Package.wxs
+++ b/engine/build/windows/installer/Package.wxs
@@ -70,7 +70,7 @@
                       Return="ignore" />
 
         <InstallExecuteSequence>
-            <Custom Action="InstallModsAction" After="InstallFiles">NOT Installed OR REINSTALL</Custom>
+            <Custom Action="InstallModsAction" After="InstallFiles" Condition="NOT Installed OR REINSTALL" />
         </InstallExecuteSequence>
     </Package>
 </Wix>

--- a/engine/crates/homunculus_utils/Cargo.toml
+++ b/engine/crates/homunculus_utils/Cargo.toml
@@ -16,6 +16,7 @@ serde_json = { workspace = true }
 thiserror = { workspace = true }
 anyhow = { workspace = true }
 toml = { workspace = true }
+url = { workspace = true }
 utoipa = { workspace = true, optional = true }
 
 [features]

--- a/engine/crates/homunculus_utils/src/runtime.rs
+++ b/engine/crates/homunculus_utils/src/runtime.rs
@@ -87,8 +87,10 @@ impl RuntimeResolver {
 
     /// Build a [`Command`] for `node --import tsx <args...>`.
     ///
-    /// In bundled mode, tsx is referenced by absolute path so that
-    /// `--import` resolves without `node_modules/` lookup.
+    /// In bundled mode, tsx is referenced by an absolute `file://` URL so that
+    /// Node's ESM loader accepts it on Windows (a bare `C:\...` path triggers
+    /// `ERR_UNSUPPORTED_ESM_URL_SCHEME` because the drive letter is parsed as
+    /// a URL scheme).
     /// In fallback mode, uses the bare specifier `tsx` (resolved from
     /// `node_modules/` in the mods directory).
     pub fn node_command_with_tsx(&self) -> Command {
@@ -96,7 +98,7 @@ impl RuntimeResolver {
         cmd.arg("--import");
         match &self.bundled_runtime_dir {
             Some(dir) => {
-                cmd.arg(tsx_import_path(dir));
+                cmd.arg(tsx_import_arg(dir));
             }
             None => {
                 cmd.arg("tsx");
@@ -236,6 +238,17 @@ fn tsx_import_path(runtime_dir: &Path) -> PathBuf {
         .join("dist")
         .join("esm")
         .join("index.mjs")
+}
+
+/// Argument passed to `node --import`. Node 22 on Windows rejects bare
+/// absolute paths containing a drive letter (`c:`) as unsupported URL
+/// schemes, so bundled-mode arguments are converted to `file://` URLs.
+fn tsx_import_arg(runtime_dir: &Path) -> std::ffi::OsString {
+    let path = tsx_import_path(runtime_dir);
+    match url::Url::from_file_path(&path) {
+        Ok(url) => std::ffi::OsString::from(url.to_string()),
+        Err(_) => path.into_os_string(),
+    }
 }
 
 /// Returns the correct program name for pnpm on the current platform.

--- a/engine/credits/licenses/RUST_THIRD_PARTY.md
+++ b/engine/credits/licenses/RUST_THIRD_PARTY.md
@@ -3698,10 +3698,10 @@ Used by:
 
 Used by:
 - assert_type_match 0.1.1 (https://github.com/MrGVSV/assert_type_match)
-- bevy_cef 0.6.0 (https://github.com/not-elm/bevy_cef)
+- bevy_cef 0.8.1 (https://github.com/not-elm/bevy_cef)
 - bevy_flurx 0.14.1 (https://github.com/not-elm/bevy_flurx)
 - bevy_tray_icon 0.3.1 (https://github.com/not-elm/bevy_tray_icon)
-- bevy_vrm1 0.7.0 (https://github.com/not-elm/bevy_vrm1)
+- bevy_vrm1 0.7.1 (https://github.com/not-elm/bevy_vrm1)
 - codespan-reporting 0.12.0 (https://github.com/brendanzab/codespan)
 - cpal 0.15.3 (https://github.com/rustaudio/cpal)
 - self_cell 1.2.2 (https://github.com/Voultapher/self_cell)
@@ -14221,7 +14221,7 @@ Used by:
 - bevy_asset_macros 0.18.1 (https://github.com/bevyengine/bevy)
 - bevy_audio 0.18.1 (https://github.com/bevyengine/bevy)
 - bevy_camera 0.18.1 (https://github.com/bevyengine/bevy)
-- bevy_cef_core 0.6.0 (https://github.com/not-elm/bevy_cef)
+- bevy_cef_core 0.8.1 (https://github.com/not-elm/bevy_cef)
 - bevy_color 0.18.1 (https://github.com/bevyengine/bevy)
 - bevy_core_pipeline 0.18.1 (https://github.com/bevyengine/bevy)
 - bevy_derive 0.18.1 (https://github.com/bevyengine/bevy)

--- a/engine/scripts/setup.py
+++ b/engine/scripts/setup.py
@@ -24,7 +24,7 @@ def setup() -> None:
             "bevy_cef_bundle_app@0.8.1",
         ])
     elif plat == Platform.WINDOWS:
-        cargo_packages.append("bevy_cef_render_process@0.4.1")
+        cargo_packages.append("bevy_cef_render_process@0.8.1")
 
     run(["cargo", "install"] + cargo_packages)
 

--- a/engine/scripts/setup_ci.py
+++ b/engine/scripts/setup_ci.py
@@ -15,9 +15,9 @@ def setup_ci() -> None:
     plat = current_platform()
     if plat == Platform.MACOS:
         packages.extend([
-            "bevy_cef_debug_render_process@0.4.1",
-            "bevy_cef_render_process@0.4.1",
-            "bevy_cef_bundle_app@0.4.1",
+            "bevy_cef_debug_render_process@0.8.1",
+            "bevy_cef_render_process@0.8.1",
+            "bevy_cef_bundle_app@0.8.1",
         ])
     elif plat == Platform.WINDOWS:
         packages.append("bevy_cef_render_process@0.4.1")

--- a/engine/scripts/setup_ci.py
+++ b/engine/scripts/setup_ci.py
@@ -20,7 +20,7 @@ def setup_ci() -> None:
             "bevy_cef_bundle_app@0.8.1",
         ])
     elif plat == Platform.WINDOWS:
-        packages.append("bevy_cef_render_process@0.4.1")
+        packages.append("bevy_cef_render_process@0.8.1")
 
     run(["cargo", "binstall", "--no-confirm", "--force"] + packages)
 

--- a/engine/scripts/stage_runtime.py
+++ b/engine/scripts/stage_runtime.py
@@ -87,7 +87,7 @@ def download_file(url: str, dest: Path) -> None:
     dest.parent.mkdir(parents=True, exist_ok=True)
     dest.write_bytes(data)
     size_mb = len(data) / (1024 * 1024)
-    log(f"  Downloaded {size_mb:.1f} MB → {dest}")
+    log(f"  Downloaded {size_mb:.1f} MB -> {dest}")
 
 
 def cached_download(url: str, filename: str) -> Path:
@@ -134,7 +134,7 @@ def stage_node(version: str, node_os: str, node_arch: str) -> None:
                 dest.write_bytes(src.read())
             dest.chmod(0o755)
 
-    log(f"Staged Node.js v{version} → {node_dir}")
+    log(f"Staged Node.js v{version} -> {node_dir}")
 
 
 def stage_pnpm(version: str) -> None:
@@ -175,7 +175,7 @@ def stage_pnpm(version: str) -> None:
                         with tf.extractfile(member) as src:
                             dest.write_bytes(src.read())
 
-    log(f"Staged pnpm v{version} → {pnpm_dir}")
+    log(f"Staged pnpm v{version} -> {pnpm_dir}")
 
 
 def stage_tsx(version: str) -> None:
@@ -209,7 +209,7 @@ def stage_tsx(version: str) -> None:
     if not esm_entry.exists():
         error(f"tsx ESM entry point not found: {esm_entry}")
 
-    log(f"Staged tsx v{version} → {tsx_dir}")
+    log(f"Staged tsx v{version} -> {tsx_dir}")
 
 
 def main() -> None:

--- a/engine/scripts/stage_runtime.py
+++ b/engine/scripts/stage_runtime.py
@@ -34,6 +34,10 @@ VERSIONS_FILE = ENGINE_DIR / "runtime-versions.toml"
 STAGING_DIR = ENGINE_DIR / "target" / "bundle" / "runtime"
 CACHE_DIR = ENGINE_DIR / "target" / "bundle" / "runtime-cache"
 
+# On Windows, npm is a .cmd shim; subprocess.run requires the full filename
+# because CreateProcess only resolves .exe by default.
+NPM = "npm.cmd" if platform.system() == "Windows" else "npm"
+
 
 def load_versions() -> dict[str, str]:
     """Parse runtime-versions.toml (minimal TOML parser for [runtime] section)."""
@@ -147,7 +151,7 @@ def stage_pnpm(version: str) -> None:
         tmp_path = Path(tmp)
         log(f"Packing pnpm@{version}")
         result = subprocess.run(
-            ["npm", "pack", f"pnpm@{version}", "--pack-destination", str(tmp_path)],
+            [NPM, "pack", f"pnpm@{version}", "--pack-destination", str(tmp_path)],
             capture_output=True,
             text=True,
         )
@@ -192,7 +196,7 @@ def stage_tsx(version: str) -> None:
 
     log(f"Installing tsx@{version}")
     result = subprocess.run(
-        ["npm", "install", "--no-audit", "--no-fund", f"tsx@{version}"],
+        [NPM, "install", "--no-audit", "--no-fund", f"tsx@{version}"],
         cwd=tsx_dir,
         capture_output=True,
         text=True,

--- a/packages/sdk/src/host.ts
+++ b/packages/sdk/src/host.ts
@@ -86,7 +86,11 @@ export class HomunculusStreamError extends Error {
 }
 
 export namespace host {
-  let _baseUrl = 'http://localhost:3100';
+  // Use 127.0.0.1 explicitly: on Windows 11, `localhost` resolves to `::1`
+  // first, and Node 22's undici 6 has no IPv4 fallback, causing every
+  // bundled-runtime mod service fetch to ECONNREFUSED against the engine's
+  // IPv4-only bind.
+  let _baseUrl = 'http://127.0.0.1:3100';
 
   /**
    * Configures the SDK's base URL for the Desktop Homunculus HTTP server.


### PR DESCRIPTION
## Problem

The `Check Build` workflow was failing on both macOS and Windows runners (e.g. [run 24815362987](https://github.com/not-elm/desktop-homunculus/actions/runs/24815362987)), and the workflow was also producing the wrong installer format:

- **macOS (`build-engine-macos`)**: `Bundle .app and create DMG` step fails with `ERROR: CLI_SOURCE not set` (make exit code 2). `check-build.yml` invoked `make bundle-macos-app` with only `BIN_SOURCE`, but `engine/Makefile` requires `CLI_SOURCE` for the `hmcs` binary. The engine build step also did not compile `homunculus_cli`.
- **Windows (`build-engine-windows`)**: `Build MSI installer` crashes with `UnicodeEncodeError: 'charmap' codec can't encode character '→'`. The `→` arrow in `stage_runtime.py` log messages cannot be encoded by the Windows runner's default `cp1252` stdout encoding.
- **Stale packaging format**: `check-build.yml` still produced a DMG even though the project migrated to PKG in #135 (2026-04-12). The PKG installer is the real distribution artifact — it runs a `postinstall` script that installs official MODs and symlinks `hmcs` to `/usr/local/bin`. A DMG check-build artifact could not reproduce that behavior, so it was not validating the real shipping format.

## Solution

Two commits:

**1. `fix(ci): fix macOS bundle and Windows runtime staging in check-build`**
- `check-build.yml`: add `cargo build -p homunculus_cli`, pass `CLI_SOURCE` and `TARGET_ARCH=arm64` to `make bundle-macos-app`.
- `stage_runtime.py`: replace U+2192 (`→`) with ASCII `->` in 4 log messages so `print()` works under Windows' `cp1252` console encoding.

**2. `refactor(ci): unify macOS bundle on PKG, remove DMG support`**
- `check-build.yml`: switch to `make package-macos-pkg`, remove the `Rename DMG with arch suffix` step (PKG is already named correctly by `build_pkg.sh`), upload `*.pkg` artifacts, add `Cache runtime downloads` step mirroring `release.yml`.
- `engine/Makefile`: delete the `package-macos-dmg` target, `DMG_FILE` variable, and `.PHONY` entry. No more `hdiutil` or `dmg-staging` anywhere in the repo.
- `.github/ISSUE_TEMPLATE/bug_report.md`: replace `DMG` with `PKG installer` in the build method list.
- `CLAUDE.md`: update the `make release-macos` description from `→ DMG` to `→ PKG` in two locations.

Affected area: CI only (`.github/workflows/`, `engine/scripts/`, `engine/Makefile`, issue template, docs). No runtime, API, or application code changes.

## Documentation

- [ ] Included in this PR
- [ ] Will be added in a follow-up PR
- [x] Not needed

---

- [ ] If HTTP endpoints changed: I ran \`make gen-open-api\` and \`pnpm build\`
- [ ] This PR includes breaking changes