### PR TITLE
bump up version to  v0.1.0-alpha.6

### DIFF
--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -33,15 +33,19 @@ jobs:
         run: |
           SDK_VERSION="$(node -e 'const p=require("./packages/sdk/package.json"); process.stdout.write(p.version)')"
           UI_VERSION="$(node -e 'const p=require("./packages/ui/package.json"); process.stdout.write(p.version)')"
+          OPENCLAW_PLUGIN_VERSION="$(node -e 'const p=require("./packages/openclaw-plugin/package.json"); process.stdout.write(p.version)')"
 
           SDK_TAG="$(.github/scripts/compute-tag.sh "$SDK_VERSION")"
           UI_TAG="$(.github/scripts/compute-tag.sh "$UI_VERSION")"
+          OPENCLAW_PLUGIN_TAG="$(.github/scripts/compute-tag.sh "$OPENCLAW_PLUGIN_VERSION")"
 
           {
             echo "sdk_version=$SDK_VERSION"
             echo "sdk_tag=$SDK_TAG"
             echo "ui_version=$UI_VERSION"
             echo "ui_tag=$UI_TAG"
+            echo "openclaw_plugin_version=$OPENCLAW_PLUGIN_VERSION"
+            echo "openclaw_plugin_tag=$OPENCLAW_PLUGIN_TAG"
           } >> "$GITHUB_OUTPUT"
 
       # --- Publish @hmcs/sdk ---
@@ -58,6 +62,14 @@ jobs:
           package-name: "@hmcs/ui"
           version: ${{ steps.versions.outputs.ui_version }}
           tag: ${{ steps.versions.outputs.ui_tag }}
+          npm-token: ${{ secrets.NPM_TOKEN }}
+
+      # --- Publish @hmcs/openclaw-plugin (bundles @hmcs/sdk; build after SDK is built) ---
+      - uses: ./.github/actions/publish-npm-package
+        with:
+          package-name: "@hmcs/openclaw-plugin"
+          version: ${{ steps.versions.outputs.openclaw_plugin_version }}
+          tag: ${{ steps.versions.outputs.openclaw_plugin_tag }}
           npm-token: ${{ secrets.NPM_TOKEN }}
 
       # --- Publish official MOD packages ---

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,6 +21,8 @@ jobs:
       sdk_tag: ${{ steps.check.outputs.sdk_tag }}
       ui_version: ${{ steps.check.outputs.ui_version }}
       ui_tag: ${{ steps.check.outputs.ui_tag }}
+      openclaw_plugin_version: ${{ steps.check.outputs.openclaw_plugin_version }}
+      openclaw_plugin_tag: ${{ steps.check.outputs.openclaw_plugin_tag }}
     steps:
       - uses: actions/checkout@v4
 
@@ -45,6 +47,7 @@ jobs:
           # Read package versions from package.json (using sed to avoid Node.js dependency)
           SDK_VERSION=$(sed -n 's/.*"version": *"\(.*\)".*/\1/p' packages/sdk/package.json | head -1)
           UI_VERSION=$(sed -n 's/.*"version": *"\(.*\)".*/\1/p' packages/ui/package.json | head -1)
+          OPENCLAW_PLUGIN_VERSION=$(sed -n 's/.*"version": *"\(.*\)".*/\1/p' packages/openclaw-plugin/package.json | head -1)
 
           # Prerelease detection
           if echo "$VERSION" | grep -qE -- '-(alpha|beta|rc)'; then
@@ -56,6 +59,7 @@ jobs:
           # Per-package dist-tag computation
           SDK_TAG="$(.github/scripts/compute-tag.sh "$SDK_VERSION")"
           UI_TAG="$(.github/scripts/compute-tag.sh "$UI_VERSION")"
+          OPENCLAW_PLUGIN_TAG="$(.github/scripts/compute-tag.sh "$OPENCLAW_PLUGIN_VERSION")"
 
           {
             echo "version=$VERSION"
@@ -64,6 +68,8 @@ jobs:
             echo "sdk_tag=$SDK_TAG"
             echo "ui_version=$UI_VERSION"
             echo "ui_tag=$UI_TAG"
+            echo "openclaw_plugin_version=$OPENCLAW_PLUGIN_VERSION"
+            echo "openclaw_plugin_tag=$OPENCLAW_PLUGIN_TAG"
           } >> "$GITHUB_OUTPUT"
 
   build-engine:
@@ -201,6 +207,14 @@ jobs:
           package-name: "@hmcs/ui"
           version: ${{ needs.validate.outputs.ui_version }}
           tag: ${{ needs.validate.outputs.ui_tag }}
+          npm-token: ${{ secrets.NPM_TOKEN }}
+
+      # --- Publish @hmcs/openclaw-plugin (bundles @hmcs/sdk; build after SDK is built) ---
+      - uses: ./.github/actions/publish-npm-package
+        with:
+          package-name: "@hmcs/openclaw-plugin"
+          version: ${{ needs.validate.outputs.openclaw_plugin_version }}
+          tag: ${{ needs.validate.outputs.openclaw_plugin_tag }}
           npm-token: ${{ secrets.NPM_TOKEN }}
 
       # --- Publish official MOD packages ---

--- a/engine/Cargo.lock
+++ b/engine/Cargo.lock
@@ -3209,7 +3209,7 @@ dependencies = [
 
 [[package]]
 name = "desktop_homunculus"
-version = "0.1.0-alpha.6-dev"
+version = "0.1.0-alpha.6"
 dependencies = [
  "async-channel",
  "base64",
@@ -4539,7 +4539,7 @@ dependencies = [
 
 [[package]]
 name = "homunculus_api"
-version = "0.1.0-alpha.6-dev"
+version = "0.1.0-alpha.6"
 dependencies = [
  "async-broadcast",
  "async-channel",
@@ -4572,7 +4572,7 @@ dependencies = [
 
 [[package]]
 name = "homunculus_audio"
-version = "0.1.0-alpha.6-dev"
+version = "0.1.0-alpha.6"
 dependencies = [
  "bevy",
  "bevy_kira_audio",
@@ -4583,7 +4583,7 @@ dependencies = [
 
 [[package]]
 name = "homunculus_cli"
-version = "0.1.0-alpha.6-dev"
+version = "0.1.0-alpha.6"
 dependencies = [
  "anyhow",
  "clap",
@@ -4597,7 +4597,7 @@ dependencies = [
 
 [[package]]
 name = "homunculus_core"
-version = "0.1.0-alpha.6-dev"
+version = "0.1.0-alpha.6"
 dependencies = [
  "anyhow",
  "async-broadcast",
@@ -4611,7 +4611,7 @@ dependencies = [
 
 [[package]]
 name = "homunculus_drag"
-version = "0.1.0-alpha.6-dev"
+version = "0.1.0-alpha.6"
 dependencies = [
  "bevy",
  "bevy_cef",
@@ -4623,7 +4623,7 @@ dependencies = [
 
 [[package]]
 name = "homunculus_effects"
-version = "0.1.0-alpha.6-dev"
+version = "0.1.0-alpha.6"
 dependencies = [
  "bevy",
  "bevy_vrm1",
@@ -4635,7 +4635,7 @@ dependencies = [
 
 [[package]]
 name = "homunculus_hit_test"
-version = "0.1.0-alpha.6-dev"
+version = "0.1.0-alpha.6"
 dependencies = [
  "bevy",
  "bevy_cef",
@@ -4647,7 +4647,7 @@ dependencies = [
 
 [[package]]
 name = "homunculus_http_server"
-version = "0.1.0-alpha.6-dev"
+version = "0.1.0-alpha.6"
 dependencies = [
  "async-broadcast",
  "async-channel",
@@ -4683,7 +4683,7 @@ dependencies = [
 
 [[package]]
 name = "homunculus_mcp"
-version = "0.1.0-alpha.6-dev"
+version = "0.1.0-alpha.6"
 dependencies = [
  "bevy",
  "bevy_vrm1",
@@ -4699,7 +4699,7 @@ dependencies = [
 
 [[package]]
 name = "homunculus_microphone"
-version = "0.1.0-alpha.6-dev"
+version = "0.1.0-alpha.6"
 dependencies = [
  "block2 0.6.2",
  "cpal",
@@ -4723,7 +4723,7 @@ dependencies = [
 
 [[package]]
 name = "homunculus_mod"
-version = "0.1.0-alpha.6-dev"
+version = "0.1.0-alpha.6"
 dependencies = [
  "bevy",
  "chrono",
@@ -4737,7 +4737,7 @@ dependencies = [
 
 [[package]]
 name = "homunculus_power_saver"
-version = "0.1.0-alpha.6-dev"
+version = "0.1.0-alpha.6"
 dependencies = [
  "bevy",
  "bevy_framepace",
@@ -4748,7 +4748,7 @@ dependencies = [
 
 [[package]]
 name = "homunculus_prefs"
-version = "0.1.0-alpha.6-dev"
+version = "0.1.0-alpha.6"
 dependencies = [
  "bevy",
  "bevy_vrm1",
@@ -4761,7 +4761,7 @@ dependencies = [
 
 [[package]]
 name = "homunculus_screen"
-version = "0.1.0-alpha.6-dev"
+version = "0.1.0-alpha.6"
 dependencies = [
  "apple-sys",
  "bevy",
@@ -4782,7 +4782,7 @@ dependencies = [
 
 [[package]]
 name = "homunculus_shadow_panel"
-version = "0.1.0-alpha.6-dev"
+version = "0.1.0-alpha.6"
 dependencies = [
  "bevy",
  "bevy_vrm1",
@@ -4791,7 +4791,7 @@ dependencies = [
 
 [[package]]
 name = "homunculus_sitting"
-version = "0.1.0-alpha.6-dev"
+version = "0.1.0-alpha.6"
 dependencies = [
  "bevy",
  "homunculus_core",
@@ -4800,7 +4800,7 @@ dependencies = [
 
 [[package]]
 name = "homunculus_speech"
-version = "0.1.0-alpha.6-dev"
+version = "0.1.0-alpha.6"
 dependencies = [
  "async-channel",
  "bevy",
@@ -4811,7 +4811,7 @@ dependencies = [
 
 [[package]]
 name = "homunculus_tray"
-version = "0.1.0-alpha.6-dev"
+version = "0.1.0-alpha.6"
 dependencies = [
  "bevy",
  "bevy_tray_icon",
@@ -4822,7 +4822,7 @@ dependencies = [
 
 [[package]]
 name = "homunculus_utils"
-version = "0.1.0-alpha.6-dev"
+version = "0.1.0-alpha.6"
 dependencies = [
  "anyhow",
  "bevy",
@@ -4839,7 +4839,7 @@ dependencies = [
 
 [[package]]
 name = "homunculus_windows"
-version = "0.1.0-alpha.6-dev"
+version = "0.1.0-alpha.6"
 dependencies = [
  "bevy",
  "homunculus_core",

--- a/engine/Cargo.toml
+++ b/engine/Cargo.toml
@@ -11,7 +11,7 @@ edition.workspace = true
 publish.workspace = true
 
 [workspace.package]
-version = "0.1.0-alpha.6-dev"
+version = "0.1.0-alpha.6"
 edition = "2024"
 authors = ["notelm <elmprograminfo@gmail.com>"]
 repository = "https://github.com/not-elm/desktop_homunculus"

--- a/mods/app-exit/package.json
+++ b/mods/app-exit/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hmcs/app-exit",
-  "version": "0.1.0-alpha.6-dev",
+  "version": "0.1.0-alpha.6",
   "description": "Provide tray menu that exits the desktop-homunculus",
   "license": "MIT",
   "type": "module",

--- a/mods/assets/package.json
+++ b/mods/assets/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hmcs/assets",
-  "version": "0.1.0-alpha.6-dev",
+  "version": "0.1.0-alpha.6",
   "description": "Official built-in assets for Desktop Homunculus — includes the default VRM character, VRMA animations, and UI sound effects",
   "license": "MIT AND CC-BY-4.0",
   "author": "notelm",

--- a/mods/menu/package.json
+++ b/mods/menu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hmcs/menu",
-  "version": "0.1.0-alpha.6-dev",
+  "version": "0.1.0-alpha.6",
   "description": "Right-click context menu mod that provides a WebView-based HUD overlay for quick in-app actions",
   "license": "MIT",
   "type": "module",

--- a/mods/openclaw/package.json
+++ b/mods/openclaw/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hmcs/openclaw",
-  "version": "0.1.0-alpha.0",
+  "version": "0.1.0-alpha.6",
   "description": "OpenClaw integration settings UI for Desktop Homunculus",
   "license": "MIT",
   "type": "module",

--- a/mods/persona/package.json
+++ b/mods/persona/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hmcs/persona",
-  "version": "0.1.0-alpha.6-dev",
+  "version": "0.1.0-alpha.6",
   "description": "Persona management mod — spawns personas at startup, manages animations, and provides settings and management UIs",
   "license": "MIT",
   "type": "module",

--- a/mods/settings/package.json
+++ b/mods/settings/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hmcs/settings",
-  "version": "0.1.0-alpha.6-dev",
+  "version": "0.1.0-alpha.6",
   "description": "Application settings mod — provides a tray menu to open the settings panel",
   "license": "MIT",
   "type": "module",

--- a/mods/stt/package.json
+++ b/mods/stt/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hmcs/stt",
-  "version": "0.1.0-alpha.6-dev",
+  "version": "0.1.0-alpha.6",
   "description": "Speech-to-Text control panel — provides a tray menu to manage STT models and sessions",
   "license": "MIT",
   "type": "module",

--- a/mods/voicevox/package.json
+++ b/mods/voicevox/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hmcs/voicevox",
-  "version": "0.1.0-alpha.6-dev",
+  "version": "0.1.0-alpha.6",
   "author": "notelm",
   "license": "MIT",
   "description": "VoiceVox TTS integration for Desktop Homunculus",

--- a/packages/openclaw-plugin/README.md
+++ b/packages/openclaw-plugin/README.md
@@ -1,0 +1,31 @@
+# @hmcs/openclaw-plugin
+
+OpenClaw plugin that bridges agent output to [Desktop Homunculus](https://github.com/not-elm/desktop-homunculus) characters. Renders agent replies as speech on VRM mascots and keeps persona state synchronized with OpenClaw sessions.
+
+## Installation
+
+Install into your OpenClaw runtime:
+
+```bash
+openclaw plugins install @hmcs/openclaw-plugin
+```
+
+Desktop Homunculus must be running locally (default `http://127.0.0.1:3100`) for the plugin to dispatch replies.
+
+## Configuration
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| `hmcsBaseUrl` | `string` | `http://127.0.0.1:3100` | Base URL of the Desktop Homunculus HTTP server. |
+| `soulMaxChars` | `integer` | `10000` | Maximum character length carried per persona's soul/context buffer. |
+
+Set via the OpenClaw plugin configuration UI or `openclaw.plugin.json`.
+
+## Related
+
+- [Desktop Homunculus](https://github.com/not-elm/desktop-homunculus) — the host application
+- [OpenClaw](https://docs.openclaw.ai) — the agent runtime this plugin extends
+
+## License
+
+MIT

--- a/packages/openclaw-plugin/package.json
+++ b/packages/openclaw-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hmcs/openclaw-plugin",
-  "version": "0.1.0-alpha.0",
+  "version": "0.1.0-alpha.6",
   "type": "module",
   "main": "./dist/entry.js",
   "license": "MIT",

--- a/packages/openclaw-plugin/package.json
+++ b/packages/openclaw-plugin/package.json
@@ -6,6 +6,14 @@
   "license": "MIT",
   "author": "notelm",
   "description": "OpenClaw plugin bridging agent output to Desktop Homunculus characters.",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/not-elm/desktop-homunculus.git",
+    "directory": "packages/openclaw-plugin"
+  },
+  "publishConfig": {
+    "access": "public"
+  },
   "files": [
     "dist",
     "openclaw.plugin.json"

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hmcs/sdk",
-  "version": "0.1.0-alpha.6-dev",
+  "version": "0.1.0-alpha.6",
   "description": "TypeScript SDK for building mods and extensions for Desktop Homunculus",
   "author": "notelm",
   "license": "MIT",

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hmcs/ui",
-  "version": "0.1.0-alpha.6-dev",
+  "version": "0.1.0-alpha.6",
   "license": "MIT",
   "files": [
     "dist"

--- a/version.toml
+++ b/version.toml
@@ -1,4 +1,4 @@
-version = "0.1.0-alpha.6-dev"
+version = "0.1.0-alpha.6"
 
 targets = [
     "engine/Cargo.toml",


### PR DESCRIPTION
## Problem

Two concerns bundled in this branch:

1. **Release prep** — dropped the `-dev` suffix from the workspace version (`0.1.0-alpha.6-dev` → `0.1.0-alpha.6`) via `make bump-version`.
2. **CI gap** — `@hmcs/openclaw-plugin` was never being published to NPM. Documentation tells users to install it via `openclaw plugins install @hmcs/openclaw-plugin`, but the registry returned 404 because both `publish-npm.yml` and `release.yml` only explicitly publish `@hmcs/sdk` and `@hmcs/ui` under `packages/`, then scan `mods/` for the rest — `packages/openclaw-plugin/` fell through both paths.

## Solution

**Version bump** — regenerated via `make bump-version`:

- `version.toml` (source of truth)
- `engine/Cargo.toml` (workspace package) + `engine/Cargo.lock`
- `packages/{sdk,ui,openclaw-plugin}/package.json`
- `mods/{app-exit,assets,menu,openclaw,persona,settings,stt,voicevox}/package.json`

**openclaw-plugin publish pipeline** — added an explicit publish step in both workflows (after `@hmcs/ui`, before `publish-npm-mods`), mirroring the existing pattern for SDK and UI:

- `.github/workflows/publish-npm.yml` — add `openclaw_plugin_version` / `openclaw_plugin_tag` to the versions step and invoke the `publish-npm-package` action.
- `.github/workflows/release.yml` — same, with the version extracted via sed in the `validate` job.

Also hardened `packages/openclaw-plugin/package.json` with `publishConfig` and `repository` metadata (required for npm provenance attestation), and added a `README.md` so the NPM page has usable content on first publish.

Verified locally: `pnpm pack --dry-run` in `packages/openclaw-plugin/` produces a tarball containing `dist/entry.js`, `openclaw.plugin.json`, `package.json`, `README.md`.

## Documentation

- [ ] Included in this PR
- [ ] Will be added in a follow-up PR
- [x] Not needed

---

- [ ] If HTTP endpoints changed: I ran \`make gen-open-api\` and \`pnpm build\`
- [ ] This PR includes breaking changes