### PR TITLE
chore: bump version to v0.1.0-alpha.7-dev

### DIFF
--- a/engine/Cargo.lock
+++ b/engine/Cargo.lock
@@ -3209,7 +3209,7 @@ dependencies = [
 
 [[package]]
 name = "desktop_homunculus"
-version = "0.1.0-alpha.6"
+version = "0.1.0-alpha.7-dev"
 dependencies = [
  "async-channel",
  "base64",
@@ -4539,7 +4539,7 @@ dependencies = [
 
 [[package]]
 name = "homunculus_api"
-version = "0.1.0-alpha.6"
+version = "0.1.0-alpha.7-dev"
 dependencies = [
  "async-broadcast",
  "async-channel",
@@ -4572,7 +4572,7 @@ dependencies = [
 
 [[package]]
 name = "homunculus_audio"
-version = "0.1.0-alpha.6"
+version = "0.1.0-alpha.7-dev"
 dependencies = [
  "bevy",
  "bevy_kira_audio",
@@ -4583,7 +4583,7 @@ dependencies = [
 
 [[package]]
 name = "homunculus_cli"
-version = "0.1.0-alpha.6"
+version = "0.1.0-alpha.7-dev"
 dependencies = [
  "anyhow",
  "clap",
@@ -4597,7 +4597,7 @@ dependencies = [
 
 [[package]]
 name = "homunculus_core"
-version = "0.1.0-alpha.6"
+version = "0.1.0-alpha.7-dev"
 dependencies = [
  "anyhow",
  "async-broadcast",
@@ -4611,7 +4611,7 @@ dependencies = [
 
 [[package]]
 name = "homunculus_drag"
-version = "0.1.0-alpha.6"
+version = "0.1.0-alpha.7-dev"
 dependencies = [
  "bevy",
  "bevy_cef",
@@ -4623,7 +4623,7 @@ dependencies = [
 
 [[package]]
 name = "homunculus_effects"
-version = "0.1.0-alpha.6"
+version = "0.1.0-alpha.7-dev"
 dependencies = [
  "bevy",
  "bevy_vrm1",
@@ -4635,7 +4635,7 @@ dependencies = [
 
 [[package]]
 name = "homunculus_hit_test"
-version = "0.1.0-alpha.6"
+version = "0.1.0-alpha.7-dev"
 dependencies = [
  "bevy",
  "bevy_cef",
@@ -4647,7 +4647,7 @@ dependencies = [
 
 [[package]]
 name = "homunculus_http_server"
-version = "0.1.0-alpha.6"
+version = "0.1.0-alpha.7-dev"
 dependencies = [
  "async-broadcast",
  "async-channel",
@@ -4683,7 +4683,7 @@ dependencies = [
 
 [[package]]
 name = "homunculus_mcp"
-version = "0.1.0-alpha.6"
+version = "0.1.0-alpha.7-dev"
 dependencies = [
  "bevy",
  "bevy_vrm1",
@@ -4699,7 +4699,7 @@ dependencies = [
 
 [[package]]
 name = "homunculus_microphone"
-version = "0.1.0-alpha.6"
+version = "0.1.0-alpha.7-dev"
 dependencies = [
  "block2 0.6.2",
  "cpal",
@@ -4723,7 +4723,7 @@ dependencies = [
 
 [[package]]
 name = "homunculus_mod"
-version = "0.1.0-alpha.6"
+version = "0.1.0-alpha.7-dev"
 dependencies = [
  "bevy",
  "chrono",
@@ -4737,7 +4737,7 @@ dependencies = [
 
 [[package]]
 name = "homunculus_power_saver"
-version = "0.1.0-alpha.6"
+version = "0.1.0-alpha.7-dev"
 dependencies = [
  "bevy",
  "bevy_framepace",
@@ -4748,7 +4748,7 @@ dependencies = [
 
 [[package]]
 name = "homunculus_prefs"
-version = "0.1.0-alpha.6"
+version = "0.1.0-alpha.7-dev"
 dependencies = [
  "bevy",
  "bevy_vrm1",
@@ -4761,7 +4761,7 @@ dependencies = [
 
 [[package]]
 name = "homunculus_screen"
-version = "0.1.0-alpha.6"
+version = "0.1.0-alpha.7-dev"
 dependencies = [
  "apple-sys",
  "bevy",
@@ -4782,7 +4782,7 @@ dependencies = [
 
 [[package]]
 name = "homunculus_shadow_panel"
-version = "0.1.0-alpha.6"
+version = "0.1.0-alpha.7-dev"
 dependencies = [
  "bevy",
  "bevy_vrm1",
@@ -4791,7 +4791,7 @@ dependencies = [
 
 [[package]]
 name = "homunculus_sitting"
-version = "0.1.0-alpha.6"
+version = "0.1.0-alpha.7-dev"
 dependencies = [
  "bevy",
  "homunculus_core",
@@ -4800,7 +4800,7 @@ dependencies = [
 
 [[package]]
 name = "homunculus_speech"
-version = "0.1.0-alpha.6"
+version = "0.1.0-alpha.7-dev"
 dependencies = [
  "async-channel",
  "bevy",
@@ -4811,7 +4811,7 @@ dependencies = [
 
 [[package]]
 name = "homunculus_tray"
-version = "0.1.0-alpha.6"
+version = "0.1.0-alpha.7-dev"
 dependencies = [
  "bevy",
  "bevy_tray_icon",
@@ -4822,7 +4822,7 @@ dependencies = [
 
 [[package]]
 name = "homunculus_utils"
-version = "0.1.0-alpha.6"
+version = "0.1.0-alpha.7-dev"
 dependencies = [
  "anyhow",
  "bevy",
@@ -4839,7 +4839,7 @@ dependencies = [
 
 [[package]]
 name = "homunculus_windows"
-version = "0.1.0-alpha.6"
+version = "0.1.0-alpha.7-dev"
 dependencies = [
  "bevy",
  "homunculus_core",

--- a/engine/Cargo.toml
+++ b/engine/Cargo.toml
@@ -11,7 +11,7 @@ edition.workspace = true
 publish.workspace = true
 
 [workspace.package]
-version = "0.1.0-alpha.6"
+version = "0.1.0-alpha.7-dev"
 edition = "2024"
 authors = ["notelm <elmprograminfo@gmail.com>"]
 repository = "https://github.com/not-elm/desktop_homunculus"

--- a/mods/app-exit/package.json
+++ b/mods/app-exit/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hmcs/app-exit",
-  "version": "0.1.0-alpha.6",
+  "version": "0.1.0-alpha.7-dev",
   "description": "Provide tray menu that exits the desktop-homunculus",
   "license": "MIT",
   "type": "module",

--- a/mods/assets/package.json
+++ b/mods/assets/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hmcs/assets",
-  "version": "0.1.0-alpha.6",
+  "version": "0.1.0-alpha.7-dev",
   "description": "Official built-in assets for Desktop Homunculus — includes the default VRM character, VRMA animations, and UI sound effects",
   "license": "MIT AND CC-BY-4.0",
   "author": "notelm",

--- a/mods/menu/package.json
+++ b/mods/menu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hmcs/menu",
-  "version": "0.1.0-alpha.6",
+  "version": "0.1.0-alpha.7-dev",
   "description": "Right-click context menu mod that provides a WebView-based HUD overlay for quick in-app actions",
   "license": "MIT",
   "type": "module",

--- a/mods/openclaw/package.json
+++ b/mods/openclaw/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hmcs/openclaw",
-  "version": "0.1.0-alpha.6",
+  "version": "0.1.0-alpha.7-dev",
   "description": "OpenClaw integration settings UI for Desktop Homunculus",
   "license": "MIT",
   "type": "module",

--- a/mods/persona/package.json
+++ b/mods/persona/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hmcs/persona",
-  "version": "0.1.0-alpha.6",
+  "version": "0.1.0-alpha.7-dev",
   "description": "Persona management mod — spawns personas at startup, manages animations, and provides settings and management UIs",
   "license": "MIT",
   "type": "module",

--- a/mods/settings/package.json
+++ b/mods/settings/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hmcs/settings",
-  "version": "0.1.0-alpha.6",
+  "version": "0.1.0-alpha.7-dev",
   "description": "Application settings mod — provides a tray menu to open the settings panel",
   "license": "MIT",
   "type": "module",

--- a/mods/stt/package.json
+++ b/mods/stt/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hmcs/stt",
-  "version": "0.1.0-alpha.6",
+  "version": "0.1.0-alpha.7-dev",
   "description": "Speech-to-Text control panel — provides a tray menu to manage STT models and sessions",
   "license": "MIT",
   "type": "module",

--- a/mods/voicevox/package.json
+++ b/mods/voicevox/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hmcs/voicevox",
-  "version": "0.1.0-alpha.6",
+  "version": "0.1.0-alpha.7-dev",
   "author": "notelm",
   "license": "MIT",
   "description": "VoiceVox TTS integration for Desktop Homunculus",

--- a/packages/openclaw-plugin/package.json
+++ b/packages/openclaw-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hmcs/openclaw-plugin",
-  "version": "0.1.0-alpha.6",
+  "version": "0.1.0-alpha.7-dev",
   "type": "module",
   "main": "./dist/entry.js",
   "license": "MIT",

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hmcs/sdk",
-  "version": "0.1.0-alpha.6",
+  "version": "0.1.0-alpha.7-dev",
   "description": "TypeScript SDK for building mods and extensions for Desktop Homunculus",
   "author": "notelm",
   "license": "MIT",

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hmcs/ui",
-  "version": "0.1.0-alpha.6",
+  "version": "0.1.0-alpha.7-dev",
   "license": "MIT",
   "files": [
     "dist"

--- a/version.toml
+++ b/version.toml
@@ -1,4 +1,4 @@
-version = "0.1.0-alpha.6"
+version = "0.1.0-alpha.7-dev"
 
 targets = [
     "engine/Cargo.toml",


### PR DESCRIPTION
## Problem

Open the development cycle for the next pre-release by bumping the workspace version from `v0.1.0-alpha.6` (the previously cut release) to `v0.1.0-alpha.7-dev`, so subsequent commits to `main` are clearly attributed to the in-progress alpha.7 line rather than the already-shipped alpha.6.

## Solution

Ran the standard version-bump workflow to update every target tracked in `version.toml`:

- `version.toml` — source of truth bumped to `0.1.0-alpha.7-dev`
- `engine/Cargo.toml` (`workspace.package.version`) and the resulting `engine/Cargo.lock` updates for all `homunculus_*` crates
- `packages/*/package.json` — `@hmcs/sdk`, `@hmcs/ui`, `@hmcs/openclaw-plugin`
- `mods/*/package.json` — `app-exit`, `assets`, `menu`, `openclaw`, `persona`, `settings`, `stt`, `voicevox`

No code changes; this is a coordinated metadata-only update.

## Documentation

- [ ] Included in this PR
- [ ] Will be added in a follow-up PR
- [x] Not needed

---

- [ ] If HTTP endpoints changed: I ran `make gen-open-api` and `pnpm build`
- [ ] This PR includes breaking changes