### PR TITLE
style: migrate @hmcs/ui to utility-first + enforcement

### DIFF
--- a/.biome-plugins/no-inline-style.grit
+++ b/.biome-plugins/no-inline-style.grit
@@ -1,0 +1,45 @@
+// Layer 3 of the Tailwind utility-first enforcement (see .claude/rules/tailwind-style.md).
+//
+// Layer 1: documented rules in .claude/rules/tailwind-style.md (source of truth).
+// Layer 2: scripts/check-styling.sh — bash heuristic invoked via `pnpm lint:styling`.
+// Layer 3: this Grit plugin — AST-aware safety net for inline JSX `style={...}` patterns.
+//
+// Two patterns are matched:
+//
+//   1. Static `style={{ ... }}` whose object literal contains no template expressions,
+//      no function calls, no member-access values, and no spreads. These are 100%
+//      static and can always be expressed as Tailwind utility classes.
+//
+//   2. `style={someIdentifier}` — passing a pre-built style object hides the contents
+//      from reviewers and bypasses the literal-object check above. Inline the literal
+//      (so the dynamic parts are visible) or convert to Tailwind classes.
+//
+// Intentionally NOT flagged:
+//   - `style={{ width: `${w}%` }}` — template literal value (dynamic).
+//   - `style={{ ...base, width: '100%' }}` — spread (caller composition).
+//   - `style={{ width: getValue() }}` — function call value (dynamic).
+//   - `style={{ background: item.color }}` — member-access value (dynamic data).
+//   - `style={{ ... } as React.CSSProperties}` — TS cast around an object literal,
+//     which appears in shadcn/ui chart components and is dynamic in practice.
+
+language js(jsx);
+
+or {
+  `style={{$props}}` where {
+    $props <: not contains JsTemplateExpression(),
+    $props <: not contains `$f($args)`,
+    $props <: not contains `...$x`,
+    $props <: not contains `$o.$p`,
+    register_diagnostic(
+      span = $props,
+      message = "Static inline `style={{...}}`: use Tailwind utility classes instead. See .claude/rules/tailwind-style.md."
+    )
+  },
+  `style={$id}` where {
+    $id <: JsIdentifierExpression(),
+    register_diagnostic(
+      span = $id,
+      message = "Avoid `style={identifier}` — inline the literal object so reviewers can see exactly what is dynamic, or convert to Tailwind utility classes. See .claude/rules/tailwind-style.md."
+    )
+  }
+}

--- a/.claude/rules/tailwind-style.md
+++ b/.claude/rules/tailwind-style.md
@@ -1,0 +1,126 @@
+# Tailwind CSS Style
+
+Mod UIs (`mods/*/ui/`) and `@hmcs/ui` use **Tailwind CSS v4**. All styling MUST follow Tailwind's utility-first methodology. Do not invent semantic class names, do not write parallel custom CSS, do not reach for `@apply` as a default.
+
+## The Core Rule: Utility-First, Always
+
+Style elements by composing utility classes directly in the markup. Do not author semantic classes like `.btn`, `.card`, `.modal-header`, `.glass-panel`, etc. and then style them in a CSS file.
+
+```tsx
+// ✅ Utility-first — styles live with the markup
+<button className="rounded-md bg-primary/30 px-4 py-2 text-white backdrop-blur-sm hover:bg-primary/40">
+  Save
+</button>
+
+// ❌ Semantic class + custom CSS
+<button className="btn btn-primary">Save</button>
+/* button.css */
+.btn-primary { background: ...; padding: ...; }
+```
+
+**Why utility-first:**
+- Adding/removing a utility only affects that one element — semantic classes create cross-page coupling and silent regressions.
+- The CSS bundle stops growing linearly with features.
+- Markup is portable: copy/paste a component to another mod and it brings its styles with it.
+- No naming bikeshedding, no jumping between `.tsx` and `.css` files.
+
+## Forbidden Patterns
+
+- **Do NOT write component-scoped CSS files** (`Button.css`, `Settings.module.css`, etc.) for styling concerns Tailwind already covers. Delete them when found and migrate to utility classes.
+- **Do NOT author semantic class names** as a styling layer (`.card`, `.btn-primary`, `.glass-panel`, `.section-header`). Class names that exist *only* to attach CSS rules are forbidden.
+- **Do NOT use `@apply` to recreate semantic classes.** `@apply` is not a workaround that makes the previous two rules acceptable. Reuse comes from React components, not CSS classes (see *Handling Repetition* below).
+- **Do NOT use inline `style={{ ... }}`** for static values. Inline styles cannot express hover/focus/responsive/dark variants and bypass the design system. They are acceptable *only* for dynamic values that come from runtime data (API responses, user-picked colors, computed positions).
+- **Do NOT use native HTML elements (`<button>`, `<select>`, `<input>`) directly** in mod WebView UIs when a `@hmcs/ui` equivalent exists — see `ts-style.md`. Then style the `@hmcs/ui` component with utilities via `className`.
+
+## Handling Repetition
+
+When the same class list appears multiple times, **do not extract a CSS class**. Instead, in order of preference:
+
+1. **Render in a loop.** If the duplication is "this list of N items all look the same", the class list is written once in the loop body — there is no duplication to solve.
+2. **Extract a React component.** If a chunk of styled markup needs to be reused across files, make it a component (`<VacationCard />`, `<SettingRow />`). The component encapsulates *both* structure and Tailwind classes in one place. This is the canonical reuse mechanism.
+3. **Multi-cursor edit.** For localized duplication within a single file, just edit all instances at once — extracting prematurely is worse than a few duplicated class lists.
+
+`@apply` is a last resort, not a step in this list.
+
+## Variants Are How You Express State and Context
+
+Use Tailwind variants — never write custom CSS or use JS to toggle classes for these:
+
+| Concern | Use |
+|---|---|
+| Hover / focus / active / disabled | `hover:`, `focus:`, `active:`, `disabled:` |
+| Responsive breakpoints | `sm:`, `md:`, `lg:`, `xl:` (mobile-first) |
+| Dark mode | `dark:` |
+| Group / peer state | `group-hover:`, `peer-checked:`, etc. |
+| Data attributes | `data-[state=open]:`, `aria-expanded:` |
+
+```tsx
+// ✅
+<button className="bg-primary/30 hover:bg-primary/40 disabled:opacity-50 sm:px-6">…</button>
+
+// ❌ — manual class toggling for what variants already do
+<button className={`bg-primary/30 ${isHovered ? 'bg-primary/40' : ''}`} onMouseEnter={…}>…</button>
+```
+
+Variants can stack: `dark:hover:bg-primary/40`, `sm:focus-visible:ring-2`.
+
+## Arbitrary Values: Bracket Syntax, Not Custom CSS
+
+When you need a one-off value not in the theme, use bracket syntax — do not drop down to a CSS file:
+
+```tsx
+<div className="bg-[#316ff6]" />
+<div className="grid-cols-[24rem_2.5rem_minmax(0,1fr)]" />
+<div className="max-h-[calc(100dvh-theme(spacing.6))]" />
+<div className="[--gutter:1rem] lg:[--gutter:2rem]" />
+```
+
+If the same arbitrary value appears in 3+ places, promote it to the theme (a CSS variable in the Tailwind config / `@theme` block) instead of repeating the brackets.
+
+## Project Design Language
+
+Mod WebView UIs follow the **glassmorphism** look documented in the root `CLAUDE.md`:
+- Semi-transparent backgrounds: `bg-primary/30`, `bg-white/10`
+- Backdrop blur: `backdrop-blur-sm`
+- Subtle borders: `border border-white/20`
+- White text on the transparent Bevy window: `text-white`
+
+Compose these with utilities. Do not create a `.glass` class.
+
+## Conditional Classes: Use `cn()`
+
+For conditional class composition, use the `cn()` helper exported from `@hmcs/ui` (clsx + tailwind-merge). It correctly resolves conflicts (e.g., `px-4` vs `px-6`).
+
+```tsx
+import { cn } from "@hmcs/ui";
+
+<div className={cn(
+  "rounded-md px-4 py-2",
+  isActive && "bg-primary/40",
+  variant === "ghost" && "bg-transparent",
+  className, // allow caller overrides
+)} />
+```
+
+Do not hand-roll string concatenation (`` `${a} ${b ? c : ''}` ``) when `cn()` is available.
+
+## When Custom CSS Is Acceptable
+
+Limited, narrow scenarios — not as an escape hatch from utility-first:
+
+1. **Dynamic values from runtime data** (theme picker, user-supplied color, computed pixel position): use inline `style={{ … }}` for the dynamic property *only*, and keep everything else as utility classes.
+2. **Genuinely global concerns** that cannot be expressed per-element: CSS resets, font-face declarations, scrollbar theming, base typography. These belong in the single global stylesheet, not per-component.
+3. **Animations/keyframes** that Tailwind does not provide out of the box: define `@keyframes` once globally, then reference via `animate-[name]` utilities.
+
+If you find yourself wanting custom CSS for anything else, the answer is almost always "extract a React component" instead.
+
+## Review Checklist
+
+Before submitting UI changes:
+- [ ] No new `.css` / `.module.css` files for component-level styling.
+- [ ] No new semantic class names (`.btn-*`, `.card-*`, `.glass-*`).
+- [ ] No `@apply` directives added.
+- [ ] No inline `style={{ … }}` for static values.
+- [ ] Hover/focus/responsive/dark are expressed as variants, not JS state or media-query CSS.
+- [ ] Repeated markup is reused via a React component, not a shared class.
+- [ ] `cn()` used for conditional classes.

--- a/.claude/rules/ts-style.md
+++ b/.claude/rules/ts-style.md
@@ -3,6 +3,7 @@
 ## UI Components
 
 - Always use `@hmcs/ui` components (Select, Button, Label, etc.) instead of native HTML elements (`<select>`, `<button>`, etc.) in MOD WebView UIs. The `@hmcs/ui` library provides glassmorphism-styled components that render correctly in CEF WebViews. Native elements may not display properly in the transparent window context.
+- For all styling, follow the utility-first rules in `tailwind-style.md`. Do not author semantic CSS classes or component-scoped `.css` files.
 
 ## Comments
 

--- a/.github/workflows/ci-ts.yml
+++ b/.github/workflows/ci-ts.yml
@@ -24,6 +24,8 @@ jobs:
     timeout-minutes: 15
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
       - uses: pnpm/action-setup@v4
       - uses: actions/setup-node@v4
         with:
@@ -34,3 +36,6 @@ jobs:
       - run: pnpm check-types
       - run: pnpm test
       - run: pnpm lint:ci
+      - run: pnpm lint:styling -- --diff origin/${{ github.base_ref }}
+        if: github.event_name == 'pull_request'
+      - run: pnpm lint:styling:test

--- a/.github/workflows/ci-ts.yml
+++ b/.github/workflows/ci-ts.yml
@@ -36,6 +36,6 @@ jobs:
       - run: pnpm check-types
       - run: pnpm test
       - run: pnpm lint:ci
-      - run: pnpm lint:styling -- --diff origin/${{ github.base_ref }}
+      - run: pnpm lint:styling --diff origin/${{ github.base_ref }}
         if: github.event_name == 'pull_request'
       - run: pnpm lint:styling:test

--- a/.styling-exempt
+++ b/.styling-exempt
@@ -1,0 +1,15 @@
+# Files exempted from the Biome inline-style enforcement plugin.
+# Each line is a glob path, matched relative to repo root.
+# Add new entries with PR review justification.
+#
+# Note: this file is currently a future-extension placeholder. The
+# .biome-plugins/no-inline-style.grit plugin does not (yet) read this file —
+# Biome 2.4 GritQL plugins do not have a built-in glob-exemption mechanism.
+# When an exemption is genuinely required, options are:
+#   1. Add a `// biome-ignore lint/plugin: <reason>` comment above the line.
+#   2. Wire the file path into the Grit predicate via a project-level
+#      override block in biome.json (see .claude/rules/tailwind-style.md).
+#
+# Empty exemption list — add entries only when an identifier-based or
+# all-static inline style is truly necessary (e.g., third-party component
+# prop forwarding, generated chart wrappers).

--- a/biome.json
+++ b/biome.json
@@ -74,6 +74,7 @@
       }
     }
   },
+  "plugins": ["./.biome-plugins/no-inline-style.grit"],
   "assist": {
     "enabled": true,
     "actions": {

--- a/mods/persona/shared/components/PersonaDetailBody.tsx
+++ b/mods/persona/shared/components/PersonaDetailBody.tsx
@@ -104,10 +104,9 @@ function RightColumn({
         <div className="detail-field-label">ID</div>
         <input
           type="text"
-          className="settings-input"
+          className="settings-input w-full cursor-not-allowed opacity-50"
           value={personaId}
           readOnly
-          style={{ opacity: 0.5, cursor: 'not-allowed', width: '100%' }}
         />
       </div>
       <PersonaFields values={formValues} onChange={onFormChange} />

--- a/mods/stt/ui/src/components/SttPanel.tsx
+++ b/mods/stt/ui/src/components/SttPanel.tsx
@@ -85,7 +85,7 @@ function ModelCard({
               style={{ width: `${model.downloadProgress ?? 0}%` }}
             />
           </div>
-          <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
+          <div className="flex items-center justify-between">
             <span className="stt-model-card__size">{Math.round(model.downloadProgress ?? 0)}%</span>
             <button type="button" className="stt-model-card__cancel" onClick={onCancel}>
               ✕

--- a/package.json
+++ b/package.json
@@ -11,6 +11,9 @@
     "lint": "biome check .",
     "lint:fix": "biome check --write .",
     "lint:ci": "biome ci .",
+    "lint:styling": "bash scripts/check-styling.sh",
+    "lint:styling:full": "bash scripts/check-styling.sh --full",
+    "lint:styling:test": "bash scripts/test-check-styling.sh",
     "format": "biome format --write ."
   },
   "devDependencies": {

--- a/packages/ui/src/components/holo-frame.tsx
+++ b/packages/ui/src/components/holo-frame.tsx
@@ -1,0 +1,88 @@
+import type { HTMLAttributes, PropsWithChildren } from 'react';
+
+import { cn } from '@/lib/utils';
+
+/**
+ * Animated diagonal light-sweep overlay.
+ *
+ * Renders as an absolutely-positioned, aria-hidden child rather than a
+ * `::after` pseudo-element so it composes cleanly with other layered effects
+ * (per Tailwind v4 guidance: prefer real elements over pseudo-elements).
+ *
+ * Inherits border-radius from parent so it matches a rounded card frame.
+ *
+ * @example
+ * ```tsx
+ * <div className="relative overflow-hidden rounded-xl">
+ *   <HoloShimmer />
+ *   <p>Content above the shimmer</p>
+ * </div>
+ * ```
+ */
+export function HoloShimmer({ className }: { className?: string }) {
+  return (
+    <span
+      aria-hidden
+      className={cn(
+        'pointer-events-none absolute inset-0 overflow-hidden rounded-[inherit] holo-shimmer-bg',
+        className,
+      )}
+    />
+  );
+}
+
+/**
+ * Subtle SVG fractal-noise overlay.
+ *
+ * Renders as an absolutely-positioned, aria-hidden child rather than a
+ * `::before` pseudo-element. Opacity differs in light vs dark mode (handled
+ * by the underlying `holo-noise-bg` utility).
+ *
+ * @example
+ * ```tsx
+ * <div className="relative rounded-xl">
+ *   <HoloNoise />
+ *   <p>Content above the noise</p>
+ * </div>
+ * ```
+ */
+export function HoloNoise({ className }: { className?: string }) {
+  return (
+    <span
+      aria-hidden
+      className={cn(
+        'pointer-events-none absolute inset-0 z-[1] rounded-[inherit] holo-noise-bg',
+        className,
+      )}
+    />
+  );
+}
+
+export type HoloFrameProps = PropsWithChildren<HTMLAttributes<HTMLDivElement>>;
+
+/**
+ * Canonical "holo card" frame: animated refract-border + shimmer overlay +
+ * noise overlay. This 3-effect stack is the foundation of the project's
+ * glassmorphism design language — used together throughout `@hmcs/ui`
+ * (Card, Drawer, Dialog) and mod UI shells.
+ *
+ * Children render in front of both overlays. Pass `className` to set
+ * background, border-radius, padding, etc. on the wrapper.
+ *
+ * @example
+ * ```tsx
+ * <HoloFrame className="rounded-xl bg-card p-6 backdrop-blur-md">
+ *   <h2>Settings</h2>
+ *   <p>Content here</p>
+ * </HoloFrame>
+ * ```
+ */
+export function HoloFrame({ className, children, ...rest }: HoloFrameProps) {
+  return (
+    <div className={cn('relative overflow-hidden holo-refract-border', className)} {...rest}>
+      <HoloShimmer />
+      <HoloNoise />
+      {children}
+    </div>
+  );
+}

--- a/packages/ui/src/components/ui/alert-dialog.tsx
+++ b/packages/ui/src/components/ui/alert-dialog.tsx
@@ -43,9 +43,8 @@ function AlertDialogContent({
       {/* Tier 2-Overlay: holo-glass + border-gradient (not Tier 1 refract/shimmer like Dialog) */}
       <AlertDialogPrimitive.Content
         data-slot="alert-dialog-content"
-        style={{ position: 'fixed', top: '50%', left: '50%', transform: 'translate(-50%, -50%)' }}
         className={cn(
-          'holo-glass holo-border-gradient text-popover-foreground z-50 grid w-full max-w-[calc(100%-2rem)] gap-4 rounded-xl p-6 shadow-holo-lg sm:max-w-lg',
+          'fixed top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 holo-glass holo-border-gradient text-popover-foreground z-50 grid w-full max-w-[calc(100%-2rem)] gap-4 rounded-xl p-6 shadow-holo-lg sm:max-w-lg',
           'data-[state=open]:[animation:holo-dialog-in_300ms_ease-out] data-[state=closed]:[animation:holo-dialog-out_200ms_ease-in]',
           className,
         )}

--- a/packages/ui/src/components/ui/dialog.tsx
+++ b/packages/ui/src/components/ui/dialog.tsx
@@ -51,9 +51,8 @@ function DialogContent({
       <DialogOverlay />
       <DialogPrimitive.Content
         data-slot="dialog-content"
-        style={{ position: 'fixed', top: '50%', left: '50%', transform: 'translate(-50%, -50%)' }}
         className={cn(
-          'holo-shimmer holo-refract-border holo-noise [--holo-refract-fill:var(--popover)] bg-popover text-popover-foreground z-50 grid w-full max-w-[calc(100%-2rem)] gap-4 rounded-xl p-6 shadow-holo-lg backdrop-blur-xl sm:max-w-lg',
+          'fixed top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 holo-shimmer holo-refract-border holo-noise [--holo-refract-fill:var(--popover)] bg-popover text-popover-foreground z-50 grid w-full max-w-[calc(100%-2rem)] gap-4 rounded-xl p-6 shadow-holo-lg backdrop-blur-xl sm:max-w-lg',
           'data-[state=open]:[animation:holo-dialog-in_300ms_ease-out] data-[state=closed]:[animation:holo-dialog-out_200ms_ease-in]',
           className,
         )}

--- a/packages/ui/src/index.css
+++ b/packages/ui/src/index.css
@@ -420,6 +420,74 @@
 
 /* ━━ Holographic Utilities ━━ */
 
+@utility holo-glass {
+  backdrop-filter: blur(24px);
+  background: var(--card);
+  border: 1px solid oklch(1 0 0 / 0.1);
+}
+
+@utility holo-text-glow {
+  text-shadow: var(--fx-text-glow);
+}
+
+@utility holo-separator {
+  background: linear-gradient(
+    90deg,
+    transparent,
+    oklch(0.72 0.14 192 / 0.4) 20%,
+    oklch(0.72 0.14 192 / 0.25) 50%,
+    oklch(0.72 0.14 192 / 0.4) 80%,
+    transparent
+  );
+
+  &[data-orientation="vertical"] {
+    background: linear-gradient(
+      180deg,
+      transparent,
+      oklch(0.72 0.14 192 / 0.4) 20%,
+      oklch(0.72 0.14 192 / 0.25) 50%,
+      oklch(0.72 0.14 192 / 0.4) 80%,
+      transparent
+    );
+  }
+}
+
+@utility holo-border-gradient {
+  position: relative;
+  border: 1px solid transparent;
+  background-origin: border-box;
+  background-clip: padding-box, border-box;
+  background-image:
+    linear-gradient(var(--background), var(--background)),
+    linear-gradient(
+      135deg,
+      var(--holo-cyan),
+      oklch(from var(--holo-cyan) calc(l - 0.05) c h),
+      var(--holo-cyan)
+    );
+}
+
+/* Animated prismatic border via @property --holo-angle.
+   Uses background-clip trick — NO pseudo-elements, so it composes
+   cleanly with HoloShimmer/HoloNoise overlays. */
+@utility holo-refract-border {
+  --holo-refract-fill: var(--card);
+  position: relative;
+  border: 1px solid transparent;
+  background-color: transparent;
+  background-image:
+    linear-gradient(var(--holo-refract-fill), var(--holo-refract-fill)),
+    conic-gradient(
+      from var(--holo-angle),
+      var(--holo-cyan),
+      oklch(from var(--holo-cyan) l c h / 0.6),
+      var(--holo-cyan)
+    );
+  background-origin: border-box;
+  background-clip: padding-box, border-box;
+  animation: var(--animate-holo-refract);
+}
+
 @layer components {
   .holo-shimmer {
     position: relative;
@@ -442,74 +510,6 @@
     animation: var(--animate-holo-shimmer);
     pointer-events: none;
     border-radius: inherit;
-  }
-
-  .holo-separator {
-    background: linear-gradient(
-      90deg,
-      transparent,
-      oklch(0.72 0.14 192 / 0.4) 20%,
-      oklch(0.72 0.14 192 / 0.25) 50%,
-      oklch(0.72 0.14 192 / 0.4) 80%,
-      transparent
-    );
-  }
-
-  .holo-separator[data-orientation="vertical"] {
-    background: linear-gradient(
-      180deg,
-      transparent,
-      oklch(0.72 0.14 192 / 0.4) 20%,
-      oklch(0.72 0.14 192 / 0.25) 50%,
-      oklch(0.72 0.14 192 / 0.4) 80%,
-      transparent
-    );
-  }
-
-  .holo-border-gradient {
-    position: relative;
-    border: 1px solid transparent;
-    background-origin: border-box;
-    background-clip: padding-box, border-box;
-    background-image:
-      linear-gradient(var(--background), var(--background)),
-      linear-gradient(
-        135deg,
-        var(--holo-cyan),
-        oklch(from var(--holo-cyan) calc(l - 0.05) c h),
-        var(--holo-cyan)
-      );
-  }
-
-  /* Animated prismatic border via @property --holo-angle.
-   Uses background-clip trick — NO pseudo-elements, so it composes
-   cleanly with holo-shimmer (::after) and holo-noise (::before). */
-  .holo-refract-border {
-    --holo-refract-fill: var(--card);
-    position: relative;
-    border: 1px solid transparent;
-    background-color: transparent;
-    background-image:
-      linear-gradient(var(--holo-refract-fill), var(--holo-refract-fill)),
-      conic-gradient(
-        from var(--holo-angle),
-        var(--holo-cyan),
-        oklch(from var(--holo-cyan) l c h / 0.6),
-        var(--holo-cyan)
-      );
-    background-origin: border-box;
-    background-clip: padding-box, border-box;
-    animation: var(--animate-holo-refract);
-  }
-
-  .holo-glass {
-    backdrop-filter: blur(24px);
-    background: var(--card);
-    border: 1px solid oklch(1 0 0 / 0.1);
-  }
-
-  .holo-text-glow {
-    text-shadow: var(--fx-text-glow);
   }
 
   .holo-noise {

--- a/packages/ui/src/index.css
+++ b/packages/ui/src/index.css
@@ -467,6 +467,33 @@
     );
 }
 
+/* SVG fractal-noise background — same content as legacy .holo-noise::before.
+   Used by the <HoloNoise> React component (real DOM child, no pseudo-element). */
+@utility holo-noise-bg {
+  background-image: url("data:image/svg+xml,%3Csvg viewBox='0 0 256 256' xmlns='http://www.w3.org/2000/svg'%3E%3Cfilter id='n'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.9' numOctaves='4' stitchTiles='stitch'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23n)'/%3E%3C/svg%3E");
+  background-size: 128px 128px;
+  opacity: 0.02;
+
+  :where(.dark *) & {
+    opacity: 0.04;
+  }
+}
+
+/* Animated prismatic light sweep — same gradient/animation as legacy
+   .holo-shimmer::after. Used by the <HoloShimmer> React component. */
+@utility holo-shimmer-bg {
+  background: linear-gradient(
+    105deg,
+    transparent 40%,
+    oklch(1 0 0 / 0.03) 45%,
+    oklch(1 0 0 / 0.06) 50%,
+    oklch(1 0 0 / 0.03) 55%,
+    transparent 60%
+  );
+  background-size: 250% 100%;
+  animation: var(--animate-holo-shimmer);
+}
+
 /* Animated prismatic border via @property --holo-angle.
    Uses background-clip trick — NO pseudo-elements, so it composes
    cleanly with HoloShimmer/HoloNoise overlays. */

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -4,6 +4,12 @@ export {
   type AssetSelectItem,
   type AssetSelectProps,
 } from './components/asset-select';
+export {
+  HoloFrame,
+  type HoloFrameProps,
+  HoloNoise,
+  HoloShimmer,
+} from './components/holo-frame';
 export * from './components/sliders/NumericSlider';
 export * from './components/ui/accordion';
 export * from './components/ui/alert';

--- a/scripts/check-styling.sh
+++ b/scripts/check-styling.sh
@@ -122,40 +122,71 @@ for f in "${css_candidates[@]+"${css_candidates[@]}"}"; do
 done
 
 # Step 3: scan TSX/TS files for static inline style attributes.
-# Heuristic: match `style={{ ... }}` where every value is a string or number literal.
-# Multi-line objects are out of scope (false negatives ok).
+#
+# Heuristic: match `style={{ ... }}` on a single line where every value is a
+# string literal or numeric literal (no template literals, identifiers,
+# function calls, member access, spreads, etc.).
+#
+# Implemented in awk for portable, deterministic regex behavior across
+# bash 3.2 (macOS) and bash 5 (Linux CI). The earlier sed-pipeline version
+# diverged between BSD sed and GNU sed in subtle ways.
 #
 # Heuristic limitations (acceptable false negatives):
 # - Only the first style={{...}} per line is scanned
-# - JS comments inside style objects (/*...*/) may be misread as identifiers
-# - Commented-out @apply lines (e.g. /* @apply ... */) are still scanned
-# The .claude/rules/tailwind-style.md doc is the source of truth; this script
-# is a heuristic safety net that biases toward false negatives.
+# - Multi-line object literals are not analysed
+# - JS comments inside style objects may be misread
+# The .claude/rules/tailwind-style.md doc is the source of truth; this
+# script is a heuristic safety net that biases toward false negatives.
+classify_inline_style() {
+  # Reads stdin (the line). Prints "static" if the line contains a static
+  # inline style={{...}}, "dynamic" if it has a dynamic one, "none" otherwise.
+  awk '
+    {
+      line = $0
+      # Find style={{ marker
+      if (!match(line, /style=\{\{/)) { print "none"; exit }
+      rest = substr(line, RSTART + RLENGTH)
+      # Find closing }} (first occurrence)
+      if (!match(rest, /\}\}/)) { print "none"; exit }
+      content = substr(rest, 1, RSTART - 1)
+
+      # Dynamic indicators inside the object literal.
+      # Template-literal substitution or backtick.
+      if (content ~ /\$\{/ || content ~ /`/) { print "dynamic"; exit }
+      # Spread.
+      if (content ~ /\.\.\./) { print "dynamic"; exit }
+
+      # Strip string literals (single-quoted and double-quoted, non-greedy).
+      gsub(/'\''[^'\'']*'\''/, "", content)
+      gsub(/"[^"]*"/, "", content)
+      # Strip numeric literals (incl. negatives, decimals).
+      gsub(/-?[0-9]+(\.[0-9]+)?/, "", content)
+      # Strip property-name identifiers followed by colon
+      # (key may be plain identifier; quoted-key was already stripped above).
+      gsub(/[A-Za-z_$][A-Za-z0-9_$]*[[:space:]]*:/, "", content)
+      # Strip whitespace, commas, parentheses around the colon stripping.
+      gsub(/[[:space:],]/, "", content)
+
+      if (length(content) == 0) { print "static"; exit }
+      print "dynamic"
+    }
+  '
+}
+
 for f in "${tsx_candidates[@]+"${tsx_candidates[@]}"}"; do
   [ -z "$f" ] && continue
   if [ ! -f "$f" ]; then
     continue
   fi
   while IFS= read -r line; do
-    if ! echo "$line" | grep -qE 'style=\{\{'; then
-      continue
-    fi
-    after="$(echo "$line" | sed -E 's/^.*style=\{\{//')"
-    # Strip string literals so their contents don't count as identifiers.
-    stripped="$(echo "$after" | sed -E "s/'[^']*'//g; s/\"[^\"]*\"//g")"
-    # Template literal or substitution -> dynamic.
-    if echo "$stripped" | grep -qE '\$\{|\`'; then
-      continue
-    fi
-    # Take only the chunk inside the first style={{...}}.
-    inside="$(echo "$stripped" | sed -E 's/\}\}.*$//')"
-    # Strip property-name identifiers (followed by colon) and numeric literals.
-    cleaned="$(echo "$inside" | sed -E 's/[a-zA-Z_$][a-zA-Z0-9_$]*[[:space:]]*://g; s/-?[0-9]+(\.[0-9]+)?//g')"
-    # Any remaining identifier means a non-literal value (variable, fn call, spread, etc.).
-    if echo "$cleaned" | grep -qE '[a-zA-Z_$]'; then
-      continue
-    fi
-    errors+=("static inline style in $f: $line")
+    case "$line" in
+      *"style={{"*)
+        verdict="$(printf '%s\n' "$line" | classify_inline_style)"
+        if [ "$verdict" = "static" ]; then
+          errors+=("static inline style in $f: $line")
+        fi
+        ;;
+    esac
   done < "$f"
 done
 

--- a/scripts/check-styling.sh
+++ b/scripts/check-styling.sh
@@ -38,6 +38,7 @@ is_allowlisted_css() {
     packages/ui/src/animation.css) return 0 ;;
     packages/ui/.storybook/storybook.css) return 0 ;;
     mods/menu/ui/.storybook/storybook.css) return 0 ;;
+    mods/persona/management/src/index.css) return 0 ;;
   esac
   if [[ "$path" =~ ^mods/[^/]+/ui/src/index\.css$ ]]; then return 0; fi
   if [[ "$path" =~ ^mods/persona/shared/[^/]+\.css$ ]]; then return 0; fi

--- a/scripts/check-styling.sh
+++ b/scripts/check-styling.sh
@@ -1,0 +1,153 @@
+#!/usr/bin/env bash
+# Tailwind utility-first enforcement check.
+#
+# Usage:
+#   scripts/check-styling.sh                # diff scope vs origin/main
+#   scripts/check-styling.sh --diff <base>  # diff scope vs <base>
+#   scripts/check-styling.sh --full         # full-repo scope (local opt-in)
+#
+# Exits 0 if all checks pass, 1 if any fail.
+
+set -euo pipefail
+
+MODE="diff"
+BASE="${BASE:-origin/main}"
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --full) MODE="full"; shift ;;
+    --diff)
+      MODE="diff"
+      shift
+      if [ $# -gt 0 ] && [ "${1:0:2}" != "--" ]; then
+        BASE="$1"
+        shift
+      fi
+      ;;
+    *) echo "unknown arg: $1" >&2; exit 2 ;;
+  esac
+done
+
+# Allowlist of CSS paths permitted to exist. Globs match via case statement.
+is_allowlisted_css() {
+  local path="$1"
+  case "$path" in
+    packages/ui/src/index.css) return 0 ;;
+    packages/ui/src/animation.css) return 0 ;;
+    packages/ui/.storybook/storybook.css) return 0 ;;
+    mods/menu/ui/.storybook/storybook.css) return 0 ;;
+    mods/*/ui/src/index.css) return 0 ;;
+    mods/persona/shared/*.css) return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
+# Allowed @apply lines (substring match after trimming).
+is_exempt_apply() {
+  local line="$1"
+  case "$line" in
+    *"@apply border-border outline-ring/50"*) return 0 ;;
+    *"@apply bg-transparent text-foreground antialiased"*) return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
+errors=()
+
+# read_lines reads stdin into the named array variable, one element per line.
+# Compat shim for bash 3.2 which lacks `mapfile`.
+read_lines() {
+  local __arr_name="$1"
+  local __line
+  eval "$__arr_name=()"
+  while IFS= read -r __line; do
+    eval "$__arr_name+=(\"\$__line\")"
+  done
+}
+
+# Step 1: collect candidate files for the active scope.
+css_candidates=()
+tsx_candidates=()
+if [ "$MODE" = "full" ]; then
+  read_lines css_candidates < <(find packages mods -type f -name "*.css" 2>/dev/null | sort)
+  read_lines tsx_candidates < <(find packages mods -type f \( -name "*.tsx" -o -name "*.ts" \) 2>/dev/null | sort)
+else
+  if ! git rev-parse --verify "$BASE" >/dev/null 2>&1; then
+    echo "warn: base ref '$BASE' not found; skipping diff-scope checks" >&2
+  else
+    read_lines css_candidates < <(
+      git diff --name-only --diff-filter=AM "$BASE"...HEAD 2>/dev/null \
+        | grep -E '\.css$' \
+        | sort || true
+    )
+    read_lines tsx_candidates < <(
+      git diff --name-only --diff-filter=AM "$BASE"...HEAD 2>/dev/null \
+        | grep -E '\.(tsx|ts)$' \
+        | sort || true
+    )
+  fi
+fi
+
+# Step 2: check each CSS file is allowlisted; if so, scan @apply usage.
+for f in "${css_candidates[@]+"${css_candidates[@]}"}"; do
+  [ -z "$f" ] && continue
+  if ! is_allowlisted_css "$f"; then
+    errors+=("disallowed CSS file: $f")
+    continue
+  fi
+  if [ ! -f "$f" ]; then
+    continue
+  fi
+  while IFS= read -r line; do
+    case "$line" in
+      *"@apply"*)
+        if ! is_exempt_apply "$line"; then
+          errors+=("non-exempt @apply in $f: $(echo "$line" | sed 's/^[[:space:]]*//')")
+        fi
+        ;;
+    esac
+  done < "$f"
+done
+
+# Step 3: scan TSX/TS files for static inline style attributes.
+# Heuristic: match `style={{ ... }}` where every value is a string or number literal.
+# Multi-line objects are out of scope (false negatives ok).
+for f in "${tsx_candidates[@]+"${tsx_candidates[@]}"}"; do
+  [ -z "$f" ] && continue
+  if [ ! -f "$f" ]; then
+    continue
+  fi
+  while IFS= read -r line; do
+    if ! echo "$line" | grep -qE 'style=\{\{'; then
+      continue
+    fi
+    after="$(echo "$line" | sed -E 's/^.*style=\{\{//')"
+    # Strip string literals so their contents don't count as identifiers.
+    stripped="$(echo "$after" | sed -E "s/'[^']*'//g; s/\"[^\"]*\"//g")"
+    # Template literal or substitution -> dynamic.
+    if echo "$stripped" | grep -qE '\$\{|\`'; then
+      continue
+    fi
+    # Take only the chunk inside the first style={{...}}.
+    inside="$(echo "$stripped" | sed -E 's/\}\}.*$//')"
+    # Strip property-name identifiers (followed by colon) and numeric literals.
+    cleaned="$(echo "$inside" | sed -E 's/[a-zA-Z_$][a-zA-Z0-9_$]*[[:space:]]*://g; s/-?[0-9]+(\.[0-9]+)?//g')"
+    # Any remaining identifier means a non-literal value (variable, fn call, spread, etc.).
+    if echo "$cleaned" | grep -qE '[a-zA-Z_$]'; then
+      continue
+    fi
+    errors+=("static inline style in $f: $line")
+  done < "$f"
+done
+
+errors_count="${#errors[@]}"
+if [ "$errors_count" -gt 0 ]; then
+  echo "check-styling: $errors_count violation(s):"
+  for e in "${errors[@]+"${errors[@]}"}"; do
+    echo "  - $e"
+  done
+  exit 1
+fi
+
+echo "check-styling: OK ($MODE scope)"
+exit 0

--- a/scripts/check-styling.sh
+++ b/scripts/check-styling.sh
@@ -28,7 +28,9 @@ while [ $# -gt 0 ]; do
   esac
 done
 
-# Allowlist of CSS paths permitted to exist. Globs match via case statement.
+# Allowlist of CSS paths permitted to exist.
+# Exact paths use `case`; segment-bounded globs use `=~` regex with [^/]+
+# to ensure exactly one path segment (no nesting).
 is_allowlisted_css() {
   local path="$1"
   case "$path" in
@@ -36,10 +38,10 @@ is_allowlisted_css() {
     packages/ui/src/animation.css) return 0 ;;
     packages/ui/.storybook/storybook.css) return 0 ;;
     mods/menu/ui/.storybook/storybook.css) return 0 ;;
-    mods/*/ui/src/index.css) return 0 ;;
-    mods/persona/shared/*.css) return 0 ;;
-    *) return 1 ;;
   esac
+  if [[ "$path" =~ ^mods/[^/]+/ui/src/index\.css$ ]]; then return 0; fi
+  if [[ "$path" =~ ^mods/persona/shared/[^/]+\.css$ ]]; then return 0; fi
+  return 1
 }
 
 # Allowed @apply lines (substring match after trimming).
@@ -69,23 +71,32 @@ read_lines() {
 css_candidates=()
 tsx_candidates=()
 if [ "$MODE" = "full" ]; then
-  read_lines css_candidates < <(find packages mods -type f -name "*.css" 2>/dev/null | sort)
-  read_lines tsx_candidates < <(find packages mods -type f \( -name "*.tsx" -o -name "*.ts" \) 2>/dev/null | sort)
+  read_lines css_candidates < <(
+    find packages mods \
+      \( -name node_modules -o -name dist -o -name build -o -name .next -o -name .turbo \) -prune -o \
+      -type f -name "*.css" -print 2>/dev/null | sort
+  )
+  read_lines tsx_candidates < <(
+    find packages mods \
+      \( -name node_modules -o -name dist -o -name build -o -name .next -o -name .turbo \) -prune -o \
+      -type f \( -name "*.tsx" -o -name "*.ts" \) -print 2>/dev/null | sort
+  )
 else
   if ! git rev-parse --verify "$BASE" >/dev/null 2>&1; then
-    echo "warn: base ref '$BASE' not found; skipping diff-scope checks" >&2
-  else
-    read_lines css_candidates < <(
-      git diff --name-only --diff-filter=AM "$BASE"...HEAD 2>/dev/null \
-        | grep -E '\.css$' \
-        | sort || true
-    )
-    read_lines tsx_candidates < <(
-      git diff --name-only --diff-filter=AM "$BASE"...HEAD 2>/dev/null \
-        | grep -E '\.(tsx|ts)$' \
-        | sort || true
-    )
+    echo "error: base ref '$BASE' not found. Run 'git fetch' or pass --diff <existing-ref>." >&2
+    echo "error: refusing to silently skip enforcement." >&2
+    exit 2
   fi
+  read_lines css_candidates < <(
+    git diff --name-only --diff-filter=AM "$BASE"...HEAD 2>/dev/null \
+      | grep -E '\.css$' \
+      | sort || true
+  )
+  read_lines tsx_candidates < <(
+    git diff --name-only --diff-filter=AM "$BASE"...HEAD 2>/dev/null \
+      | grep -E '\.(tsx|ts)$' \
+      | sort || true
+  )
 fi
 
 # Step 2: check each CSS file is allowlisted; if so, scan @apply usage.
@@ -112,6 +123,13 @@ done
 # Step 3: scan TSX/TS files for static inline style attributes.
 # Heuristic: match `style={{ ... }}` where every value is a string or number literal.
 # Multi-line objects are out of scope (false negatives ok).
+#
+# Heuristic limitations (acceptable false negatives):
+# - Only the first style={{...}} per line is scanned
+# - JS comments inside style objects (/*...*/) may be misread as identifiers
+# - Commented-out @apply lines (e.g. /* @apply ... */) are still scanned
+# The .claude/rules/tailwind-style.md doc is the source of truth; this script
+# is a heuristic safety net that biases toward false negatives.
 for f in "${tsx_candidates[@]+"${tsx_candidates[@]}"}"; do
   [ -z "$f" ] && continue
   if [ ! -f "$f" ]; then

--- a/scripts/test-check-styling.sh
+++ b/scripts/test-check-styling.sh
@@ -196,6 +196,17 @@ DIR="$(setup_tmp_repo)"
 )
 rm -rf "$DIR"
 
+echo "=== test_allowlist_includes_persona_management_index ==="
+DIR="$(setup_tmp_repo)"
+(
+  cd "$DIR"
+  mkdir -p mods/persona/management/src
+  echo "@import 'tailwindcss';" > mods/persona/management/src/index.css
+  output="$(./scripts/check-styling.sh --full 2>&1)" && exit_code=0 || exit_code=$?
+  assert_exit 0 "$exit_code" "persona/management/src/index.css is allowlisted"
+)
+rm -rf "$DIR"
+
 echo "=== test_diff_scope_fails_when_base_missing ==="
 DIR="$(setup_tmp_repo)"
 (

--- a/scripts/test-check-styling.sh
+++ b/scripts/test-check-styling.sh
@@ -1,0 +1,179 @@
+#!/usr/bin/env bash
+# Tests for scripts/check-styling.sh.
+# Each test creates a tmp git repo, drops fixture files, runs check-styling.sh,
+# and asserts exit code + stdout contains expected substrings.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+CHECK="$SCRIPT_DIR/check-styling.sh"
+# Subshells cannot mutate parent variables, so persist counters via temp files.
+COUNTER_DIR="$(mktemp -d)"
+trap 'rm -rf "$COUNTER_DIR"' EXIT
+echo 0 > "$COUNTER_DIR/pass"
+echo 0 > "$COUNTER_DIR/fail"
+
+bump_pass() {
+  local n
+  n="$(cat "$COUNTER_DIR/pass")"
+  echo $((n + 1)) > "$COUNTER_DIR/pass"
+}
+
+bump_fail() {
+  local n
+  n="$(cat "$COUNTER_DIR/fail")"
+  echo $((n + 1)) > "$COUNTER_DIR/fail"
+}
+
+assert_exit() {
+  local expected="$1"
+  local actual="$2"
+  local name="$3"
+  if [ "$actual" -eq "$expected" ]; then
+    echo "  PASS: $name"
+    bump_pass
+  else
+    echo "  FAIL: $name (expected exit $expected, got $actual)"
+    bump_fail
+  fi
+}
+
+assert_contains() {
+  local needle="$1"
+  local haystack="$2"
+  local name="$3"
+  if echo "$haystack" | grep -qF "$needle"; then
+    echo "  PASS: $name"
+    bump_pass
+  else
+    echo "  FAIL: $name (output did not contain '$needle')"
+    echo "    Output: $haystack"
+    bump_fail
+  fi
+}
+
+setup_tmp_repo() {
+  local dir
+  dir="$(mktemp -d)"
+  (
+    cd "$dir"
+    git init -q -b main
+    git config user.email t@t
+    git config user.name t
+    mkdir -p packages/ui/src mods/menu/ui/src scripts
+    cp "$CHECK" scripts/
+    chmod +x scripts/check-styling.sh
+    git add -A
+    git commit -q -m initial
+  )
+  echo "$dir"
+}
+
+echo "=== test_full_scope_passes_with_only_allowlisted_files ==="
+DIR="$(setup_tmp_repo)"
+(
+  cd "$DIR"
+  echo "@import 'tailwindcss';" > packages/ui/src/index.css
+  echo "@keyframes a { 0% { opacity: 0 } }" > packages/ui/src/animation.css
+  output="$(./scripts/check-styling.sh --full 2>&1)" && exit_code=0 || exit_code=$?
+  assert_exit 0 "$exit_code" "exits 0 when only allowlisted CSS exists"
+)
+rm -rf "$DIR"
+
+echo "=== test_full_scope_fails_on_disallowed_css ==="
+DIR="$(setup_tmp_repo)"
+(
+  cd "$DIR"
+  echo ".btn { color: red }" > packages/ui/src/extra.css
+  output="$(./scripts/check-styling.sh --full 2>&1)" && exit_code=0 || exit_code=$?
+  assert_exit 1 "$exit_code" "exits 1 when a disallowed CSS file exists"
+  assert_contains "extra.css" "$output" "error message names the offending file"
+)
+rm -rf "$DIR"
+
+echo "=== test_diff_scope_only_checks_added_files ==="
+DIR="$(setup_tmp_repo)"
+(
+  cd "$DIR"
+  echo ".pre-existing { color: blue }" > packages/ui/src/legacy.css
+  git add -A && git commit -q -m "add legacy"
+  git checkout -q -b feature
+  echo ".new { color: green }" > packages/ui/src/new-bad.css
+  git add -A && git commit -q -m "add new bad"
+  output="$(./scripts/check-styling.sh --diff main 2>&1)" && exit_code=0 || exit_code=$?
+  assert_exit 1 "$exit_code" "diff scope flags newly added disallowed CSS"
+  assert_contains "new-bad.css" "$output" "diff error names the new file"
+  if echo "$output" | grep -qF "legacy.css"; then
+    echo "  FAIL: diff scope incorrectly flagged pre-existing file"
+    bump_fail
+  else
+    echo "  PASS: diff scope ignored pre-existing file"
+    bump_pass
+  fi
+)
+rm -rf "$DIR"
+
+echo "=== test_apply_outside_reset_block_fails ==="
+DIR="$(setup_tmp_repo)"
+(
+  cd "$DIR"
+  cat > packages/ui/src/index.css <<'CSS'
+@import 'tailwindcss';
+.foo {
+  @apply bg-primary;
+}
+CSS
+  output="$(./scripts/check-styling.sh --full 2>&1)" && exit_code=0 || exit_code=$?
+  assert_exit 1 "$exit_code" "non-reset @apply fails"
+  assert_contains "@apply" "$output" "error mentions @apply"
+)
+rm -rf "$DIR"
+
+echo "=== test_apply_in_known_reset_passes ==="
+DIR="$(setup_tmp_repo)"
+(
+  cd "$DIR"
+  cat > packages/ui/src/index.css <<'CSS'
+@import 'tailwindcss';
+* {
+  @apply border-border outline-ring/50;
+}
+body {
+  @apply bg-transparent text-foreground antialiased;
+}
+CSS
+  output="$(./scripts/check-styling.sh --full 2>&1)" && exit_code=0 || exit_code=$?
+  assert_exit 0 "$exit_code" "exempted @apply lines pass"
+)
+rm -rf "$DIR"
+
+echo "=== test_inline_style_object_literal_with_only_literals_fails ==="
+DIR="$(setup_tmp_repo)"
+(
+  cd "$DIR"
+  cat > mods/menu/ui/src/Bad.tsx <<'TSX'
+export const Bad = () => <div style={{ width: '100%', display: 'flex' }} />;
+TSX
+  output="$(./scripts/check-styling.sh --full 2>&1)" && exit_code=0 || exit_code=$?
+  assert_exit 1 "$exit_code" "static inline style object literal fails"
+  assert_contains "Bad.tsx" "$output" "error names the file"
+)
+rm -rf "$DIR"
+
+echo "=== test_inline_style_with_dynamic_value_passes ==="
+DIR="$(setup_tmp_repo)"
+(
+  cd "$DIR"
+  cat > mods/menu/ui/src/Good.tsx <<'TSX'
+export const Good = ({ w }: { w: number }) => <div style={{ width: `${w}%` }} />;
+TSX
+  output="$(./scripts/check-styling.sh --full 2>&1)" && exit_code=0 || exit_code=$?
+  assert_exit 0 "$exit_code" "dynamic inline style passes"
+)
+rm -rf "$DIR"
+
+PASS="$(cat "$COUNTER_DIR/pass")"
+FAIL="$(cat "$COUNTER_DIR/fail")"
+echo
+echo "=== Summary: $PASS passed, $FAIL failed ==="
+[ "$FAIL" -eq 0 ]

--- a/scripts/test-check-styling.sh
+++ b/scripts/test-check-styling.sh
@@ -172,6 +172,40 @@ TSX
 )
 rm -rf "$DIR"
 
+echo "=== test_allowlist_rejects_deeply_nested_css ==="
+DIR="$(setup_tmp_repo)"
+(
+  cd "$DIR"
+  mkdir -p mods/persona/shared/sub/dir
+  echo ".sneaky { color: red }" > mods/persona/shared/sub/dir/anything.css
+  output="$(./scripts/check-styling.sh --full 2>&1)" && exit_code=0 || exit_code=$?
+  assert_exit 1 "$exit_code" "deeply-nested CSS under allowlisted prefix is rejected"
+  assert_contains "mods/persona/shared/sub/dir/anything.css" "$output" "error names the deeply-nested file"
+)
+rm -rf "$DIR"
+
+echo "=== test_full_scope_ignores_dist_and_node_modules ==="
+DIR="$(setup_tmp_repo)"
+(
+  cd "$DIR"
+  mkdir -p packages/ui/dist packages/ui/node_modules/something
+  echo ".leak { color: red }" > packages/ui/dist/leak.css
+  echo ".vendor { color: blue }" > packages/ui/node_modules/something/foo.css
+  output="$(./scripts/check-styling.sh --full 2>&1)" && exit_code=0 || exit_code=$?
+  assert_exit 0 "$exit_code" "build artifacts under dist/ and node_modules/ are pruned"
+)
+rm -rf "$DIR"
+
+echo "=== test_diff_scope_fails_when_base_missing ==="
+DIR="$(setup_tmp_repo)"
+(
+  cd "$DIR"
+  output="$(./scripts/check-styling.sh --diff nonexistent-ref 2>&1)" && exit_code=0 || exit_code=$?
+  assert_exit 2 "$exit_code" "missing diff base ref exits 2"
+  assert_contains "nonexistent-ref" "$output" "error names the missing ref"
+)
+rm -rf "$DIR"
+
 PASS="$(cat "$COUNTER_DIR/pass")"
 FAIL="$(cat "$COUNTER_DIR/fail")"
 echo


### PR DESCRIPTION
## Summary

PR #1 of a 9-PR Tailwind utility-first migration. This PR ships the doc rule, both layers of enforcement, the `@hmcs/ui` CSS migration, and two static inline-style fixes.

## What's in this PR

1. **Doc rule** — `.claude/rules/tailwind-style.md` defines utility-first methodology and exemptions (theme tokens, keyframes, base resets, custom utilities like `.no-scrollbar`).
2. **Layer 2 enforcement** — `scripts/check-styling.sh` (diff + full scope, 18 test cases) catches disallowed `.css` files, non-exempt `@apply`, and static inline `style={{}}`.
3. **CI wiring** — `pnpm lint:styling` runs in diff mode on every PR; `pnpm lint:styling:test` always runs.
4. **Layer 3 enforcement** — Biome GritQL plugin (`.biome-plugins/no-inline-style.grit`) catches static inline styles AND identifier-based bypass patterns. More accurate than the bash heuristic (correctly spares dynamic member-access values).
5. **Dialog inline-style fixes** — `alert-dialog.tsx` and `dialog.tsx` static positioning replaced with utilities.
6. **`@hmcs/ui` CSS migration** — per Tailwind v4 idioms:
   - 5 effect classes → `@utility` directives (`holo-glass`, `holo-text-glow`, `holo-separator`, `holo-border-gradient`, `holo-refract-border`)
   - 3 React components (`<HoloShimmer>`, `<HoloNoise>`, `<HoloFrame>`) backed by supporting `@utility` directives
   - Legacy `.holo-shimmer` / `.holo-noise` classes preserved for mod backward compat; will be retired after all mods migrate

## Out of scope

The 7 remaining static inline-style violations (5 in `chart.tsx` are dynamic and intentionally kept; 2 in `PersonaDetailBody.tsx`/`SttPanel.tsx` are addressed in Phases 5 and 7).

## Test plan

- [x] `pnpm build` (all packages)
- [x] `pnpm check-types`
- [x] `pnpm lint:ci` — only the 2 known out-of-scope violations remain
- [x] `pnpm lint:styling --diff origin/main` passes
- [x] `pnpm lint:styling:test` — 18/18 assertions pass
- [ ] Visual smoke-test via \`make debug\`: open Card / Dialog / Drawer / Alert, verify the holographic effects (shimmer, refract-border, noise, glass) still render correctly

## Notes for reviewers

- The Biome plugin uses a GritQL pattern, which is Biome 2.x's plugin mechanism. `noRestrictedSyntax` doesn't exist in Biome 2.4, so GritQL is the path that works.
- The bash and Biome layers intentionally disagree on `chart.tsx:275` (`backgroundColor: item.color`). The Biome plugin's AST-aware exclusion of member-access values is correct; the bash heuristic over-flags. Layer 2 is heuristic, Layer 3 is precise — defense in depth.
- After all mods migrate (Phases 2-9), a follow-up will retire the legacy `.holo-shimmer` / `.holo-noise` CSS classes.