### PR TITLE
style(menu): utility-first migration

### DIFF
--- a/mods/menu/ui/src/App.tsx
+++ b/mods/menu/ui/src/App.tsx
@@ -17,7 +17,7 @@ export function App() {
       <DropdownMenuTrigger className="sr-only" />
       <DropdownMenuContent
         ref={contentRef}
-        className="menu-hud holo-refract-border holo-noise shadow-none"
+        className="holo-refract-border holo-noise shadow-none relative w-[calc(100vw-20px)] max-w-[340px] overflow-x-hidden p-[var(--hud-space-sm)] [scrollbar-gutter:stable] animate-orbital-float [animation-delay:0.8s] data-[state=open]:animate-orbital-hud-open data-[state=closed]:animate-orbital-hud-closed after:content-[''] after:absolute after:left-[-6px] after:top-1/4 after:bottom-1/4 after:w-px after:rounded-[1px] after:pointer-events-none after:z-10 after:bg-[linear-gradient(180deg,transparent,oklch(0.72_0.14_var(--menu-accent-hue)/0.2)_25%,oklch(0.72_0.14_var(--menu-accent-hue)/0.35)_50%,oklch(0.72_0.14_var(--menu-accent-hue)/0.2)_75%,transparent)] motion-reduce:animate-none motion-reduce:data-[state=open]:animate-none motion-reduce:data-[state=closed]:animate-none motion-reduce:data-[state=open]:opacity-100"
         onEscapeKeyDown={handleClose}
         onPointerDownOutside={handleClose}
         sideOffset={0}
@@ -34,10 +34,12 @@ export function App() {
         {/* Character status bar */}
         {characterName && (
           <>
-            <div className="menu-status-bar">
-              <span className="menu-status-name">{characterName}</span>
+            <div className="flex items-center justify-between px-[var(--hud-space-md)] pt-[var(--hud-space-xs)] pb-[var(--hud-space-sm)] relative z-[7]">
+              <span className="text-[var(--hud-font-size-sm)] font-semibold tracking-[0.02em] text-[oklch(0.93_0.03_var(--menu-accent-hue))] overflow-hidden text-ellipsis whitespace-nowrap max-w-[200px]">
+                {characterName}
+              </span>
             </div>
-            <div className="menu-separator" />
+            <div className="h-px mx-[var(--hud-space-sm)] mt-0.5 mb-[var(--hud-space-xs)] relative z-[7] bg-[linear-gradient(90deg,transparent,oklch(0.72_0.14_var(--menu-accent-hue)/0.2)_20%,oklch(0.65_0.18_285/0.15)_50%,oklch(0.7_0.16_350/0.2)_80%,transparent)]" />
           </>
         )}
 

--- a/mods/menu/ui/src/App.tsx
+++ b/mods/menu/ui/src/App.tsx
@@ -1,5 +1,7 @@
 import { DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuTrigger } from '@hmcs/ui';
 import { useRef } from 'react';
+import { HudCorner } from './components/HudCorner';
+import { HudHighlight } from './components/HudHighlight';
 import { useMenuActions } from './hooks/useMenuActions';
 import { useMenuData } from './hooks/useMenuData';
 
@@ -24,12 +26,12 @@ export function App() {
         align="start"
       >
         {/* Decorative layers */}
-        <div className="menu-hud-highlight" />
-        <div className="menu-hud-bottom-line" />
-        <span className="menu-hud-corner menu-hud-corner--tl" />
-        <span className="menu-hud-corner menu-hud-corner--tr" />
-        <span className="menu-hud-corner menu-hud-corner--bl" />
-        <span className="menu-hud-corner menu-hud-corner--br" />
+        <HudHighlight />
+        <div className="absolute bottom-0 left-[10%] right-[10%] h-px pointer-events-none z-10 bg-[linear-gradient(90deg,transparent,oklch(0.7_0.16_350/0.15)_30%,oklch(0.65_0.18_285/0.1)_50%,oklch(0.72_0.14_192/0.15)_70%,transparent)]" />
+        <HudCorner position="tl" />
+        <HudCorner position="tr" />
+        <HudCorner position="bl" />
+        <HudCorner position="br" />
 
         {/* Character status bar */}
         {characterName && (

--- a/mods/menu/ui/src/App.tsx
+++ b/mods/menu/ui/src/App.tsx
@@ -44,15 +44,21 @@ export function App() {
         )}
 
         {/* Action card grid */}
-        <div className={useGrid ? 'menu-card-grid' : 'menu-card-grid menu-card-grid--list'}>
+        <div
+          className={`grid gap-[5px] p-0.5 relative z-[7] ${useGrid ? 'grid-cols-2' : 'grid-cols-1'}`}
+        >
           {items.map((item, i) => (
             <DropdownMenuItem
               key={item.id}
-              className="menu-card menu-card-stagger"
+              className={`relative flex items-center rounded-md border cursor-pointer transition-all duration-150 ease-[cubic-bezier(0.4,0,0.2,1)] border-[oklch(1_0_0/0.14)] bg-[oklch(0.13_0.015_var(--menu-accent-hue)/0.45)] text-[oklch(0.9_0.01_230)] hover:border-[oklch(0.72_0.14_var(--menu-accent-hue)/0.5)] hover:bg-[linear-gradient(135deg,oklch(0.72_0.14_var(--menu-accent-hue)/0.18)_0%,oklch(0.65_0.18_285/0.08)_100%)] hover:-translate-y-px hover:text-[oklch(0.92_0.03_var(--menu-accent-hue))] focus:border-[oklch(0.72_0.14_var(--menu-accent-hue)/0.5)] focus:bg-[linear-gradient(135deg,oklch(0.72_0.14_var(--menu-accent-hue)/0.18)_0%,oklch(0.65_0.18_285/0.08)_100%)] focus:-translate-y-px focus:text-[oklch(0.92_0.03_var(--menu-accent-hue))] active:border-[oklch(0.65_0.18_285/0.4)] active:bg-[oklch(0.65_0.18_285/0.12)] active:scale-[0.97] active:text-[oklch(0.88_0.04_285)] data-[variant=destructive]:hover:border-[oklch(0.6_0.22_25/0.35)] data-[variant=destructive]:hover:bg-[oklch(0.6_0.22_25/0.1)] data-[variant=destructive]:hover:text-[oklch(0.78_0.16_25)] opacity-0 animate-orbital-card-in [animation-delay:calc(60ms+var(--i,0)*30ms)] motion-reduce:opacity-100 motion-reduce:animate-none ${useGrid ? 'min-h-[52px] justify-center px-2.5 py-[var(--hud-space-md)]' : 'min-h-[40px] justify-start px-[var(--hud-space-lg)] py-[var(--hud-space-sm)]'}`}
               style={{ '--i': i } as React.CSSProperties}
               onSelect={() => handleSelect(item)}
             >
-              <span className="menu-card-label">{item.text}</span>
+              <span
+                className={`text-[12.5px] font-medium tracking-[0.01em] leading-[1.3] pointer-events-none ${useGrid ? 'text-center' : 'text-left'}`}
+              >
+                {item.text}
+              </span>
             </DropdownMenuItem>
           ))}
         </div>

--- a/mods/menu/ui/src/App.tsx
+++ b/mods/menu/ui/src/App.tsx
@@ -1,4 +1,10 @@
-import { cn, DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuTrigger } from '@hmcs/ui';
+import {
+  cn,
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from '@hmcs/ui';
 import { useRef } from 'react';
 import { HudCorner } from './components/HudCorner';
 import { HudHighlight } from './components/HudHighlight';

--- a/mods/menu/ui/src/App.tsx
+++ b/mods/menu/ui/src/App.tsx
@@ -1,4 +1,4 @@
-import { DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuTrigger } from '@hmcs/ui';
+import { cn, DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuTrigger } from '@hmcs/ui';
 import { useRef } from 'react';
 import { HudCorner } from './components/HudCorner';
 import { HudHighlight } from './components/HudHighlight';
@@ -47,17 +47,42 @@ export function App() {
 
         {/* Action card grid */}
         <div
-          className={`grid gap-[5px] p-0.5 relative z-[7] ${useGrid ? 'grid-cols-2' : 'grid-cols-1'}`}
+          className={cn(
+            'grid gap-[5px] p-0.5 relative z-[7]',
+            useGrid ? 'grid-cols-2' : 'grid-cols-1',
+          )}
         >
           {items.map((item, i) => (
             <DropdownMenuItem
               key={item.id}
-              className={`relative flex items-center rounded-md border cursor-pointer transition-all duration-150 ease-[cubic-bezier(0.4,0,0.2,1)] border-[oklch(1_0_0/0.14)] bg-[oklch(0.13_0.015_var(--menu-accent-hue)/0.45)] text-[oklch(0.9_0.01_230)] hover:border-[oklch(0.72_0.14_var(--menu-accent-hue)/0.5)] hover:bg-[linear-gradient(135deg,oklch(0.72_0.14_var(--menu-accent-hue)/0.18)_0%,oklch(0.65_0.18_285/0.08)_100%)] hover:-translate-y-px hover:text-[oklch(0.92_0.03_var(--menu-accent-hue))] focus:border-[oklch(0.72_0.14_var(--menu-accent-hue)/0.5)] focus:bg-[linear-gradient(135deg,oklch(0.72_0.14_var(--menu-accent-hue)/0.18)_0%,oklch(0.65_0.18_285/0.08)_100%)] focus:-translate-y-px focus:text-[oklch(0.92_0.03_var(--menu-accent-hue))] active:border-[oklch(0.65_0.18_285/0.4)] active:bg-[oklch(0.65_0.18_285/0.12)] active:scale-[0.97] active:text-[oklch(0.88_0.04_285)] data-[variant=destructive]:hover:border-[oklch(0.6_0.22_25/0.35)] data-[variant=destructive]:hover:bg-[oklch(0.6_0.22_25/0.1)] data-[variant=destructive]:hover:text-[oklch(0.78_0.16_25)] opacity-0 animate-orbital-card-in [animation-delay:calc(60ms+var(--i,0)*30ms)] motion-reduce:opacity-100 motion-reduce:animate-none ${useGrid ? 'min-h-[52px] justify-center px-2.5 py-[var(--hud-space-md)]' : 'min-h-[40px] justify-start px-[var(--hud-space-lg)] py-[var(--hud-space-sm)]'}`}
+              className={cn(
+                // Base
+                'relative flex items-center rounded-md border cursor-pointer transition-all duration-150 ease-[cubic-bezier(0.4,0,0.2,1)] border-[oklch(1_0_0/0.14)] bg-[oklch(0.13_0.015_var(--menu-accent-hue)/0.45)] text-[oklch(0.9_0.01_230)]',
+                // Hover
+                'hover:border-[oklch(0.72_0.14_var(--menu-accent-hue)/0.5)] hover:bg-[linear-gradient(135deg,oklch(0.72_0.14_var(--menu-accent-hue)/0.18)_0%,oklch(0.65_0.18_285/0.08)_100%)] hover:-translate-y-px hover:text-[oklch(0.92_0.03_var(--menu-accent-hue))]',
+                // Focus (keyboard) — mirror hover for parity with the original :hover, :focus rule
+                'focus-visible:border-[oklch(0.72_0.14_var(--menu-accent-hue)/0.5)] focus-visible:bg-[linear-gradient(135deg,oklch(0.72_0.14_var(--menu-accent-hue)/0.18)_0%,oklch(0.65_0.18_285/0.08)_100%)] focus-visible:-translate-y-px focus-visible:text-[oklch(0.92_0.03_var(--menu-accent-hue))]',
+                // Active
+                'active:border-[oklch(0.65_0.18_285/0.4)] active:bg-[oklch(0.65_0.18_285/0.12)] active:scale-[0.97] active:text-[oklch(0.88_0.04_285)]',
+                // Destructive — hover
+                'data-[variant=destructive]:hover:border-[oklch(0.6_0.22_25/0.35)] data-[variant=destructive]:hover:bg-[oklch(0.6_0.22_25/0.1)] data-[variant=destructive]:hover:text-[oklch(0.78_0.16_25)]',
+                // Destructive — focus (keyboard) parity with original CSS
+                'data-[variant=destructive]:focus-visible:border-[oklch(0.6_0.22_25/0.35)] data-[variant=destructive]:focus-visible:bg-[oklch(0.6_0.22_25/0.1)] data-[variant=destructive]:focus-visible:text-[oklch(0.78_0.16_25)]',
+                // Motion / stagger
+                'opacity-0 animate-orbital-card-in [animation-delay:calc(60ms+var(--i,0)*30ms)] motion-reduce:opacity-100 motion-reduce:animate-none',
+                // Layout (grid vs list)
+                useGrid
+                  ? 'min-h-[52px] justify-center px-2.5 py-[var(--hud-space-md)]'
+                  : 'min-h-[40px] justify-start px-[var(--hud-space-lg)] py-[var(--hud-space-sm)]',
+              )}
               style={{ '--i': i } as React.CSSProperties}
               onSelect={() => handleSelect(item)}
             >
               <span
-                className={`text-[12.5px] font-medium tracking-[0.01em] leading-[1.3] pointer-events-none ${useGrid ? 'text-center' : 'text-left'}`}
+                className={cn(
+                  'text-[12.5px] font-medium tracking-[0.01em] leading-[1.3] pointer-events-none',
+                  useGrid ? 'text-center' : 'text-left',
+                )}
               >
                 {item.text}
               </span>

--- a/mods/menu/ui/src/components/HudCorner.tsx
+++ b/mods/menu/ui/src/components/HudCorner.tsx
@@ -1,3 +1,5 @@
+import { cn } from '@hmcs/ui';
+
 /**
  * Decorative L-shaped corner accent rendered at one of the four corners of the
  * menu HUD. Each corner has its own color and animation stagger to create a
@@ -15,7 +17,11 @@ const positionClasses: Record<Position, string> = {
 export function HudCorner({ position }: { position: Position }) {
   return (
     <span
-      className={`absolute w-2.5 h-2.5 pointer-events-none z-10 animate-holo-corner-pulse motion-reduce:animate-none motion-reduce:opacity-60 ${positionClasses[position]}`}
+      aria-hidden
+      className={cn(
+        'absolute w-2.5 h-2.5 pointer-events-none z-10 animate-holo-corner-pulse motion-reduce:animate-none motion-reduce:opacity-60',
+        positionClasses[position],
+      )}
     />
   );
 }

--- a/mods/menu/ui/src/components/HudCorner.tsx
+++ b/mods/menu/ui/src/components/HudCorner.tsx
@@ -1,0 +1,21 @@
+/**
+ * Decorative L-shaped corner accent rendered at one of the four corners of the
+ * menu HUD. Each corner has its own color and animation stagger to create a
+ * subtle rotating-pulse rhythm around the panel.
+ */
+type Position = 'tl' | 'tr' | 'bl' | 'br';
+
+const positionClasses: Record<Position, string> = {
+  tl: '-top-px -left-px border-t-[1.5px] border-l-[1.5px] border-t-[oklch(0.72_0.14_192/0.6)] border-l-[oklch(0.72_0.14_192/0.6)]',
+  tr: '-top-px -right-px border-t-[1.5px] border-r-[1.5px] border-t-[oklch(0.65_0.18_285/0.4)] border-r-[oklch(0.65_0.18_285/0.4)] [animation-delay:0.75s]',
+  bl: '-bottom-px -left-px border-b-[1.5px] border-l-[1.5px] border-b-[oklch(0.65_0.18_285/0.4)] border-l-[oklch(0.65_0.18_285/0.4)] [animation-delay:1.5s]',
+  br: '-bottom-px -right-px border-b-[1.5px] border-r-[1.5px] border-b-[oklch(0.7_0.16_350/0.4)] border-r-[oklch(0.7_0.16_350/0.4)] [animation-delay:2.25s]',
+};
+
+export function HudCorner({ position }: { position: Position }) {
+  return (
+    <span
+      className={`absolute w-2.5 h-2.5 pointer-events-none z-10 animate-holo-corner-pulse motion-reduce:animate-none motion-reduce:opacity-60 ${positionClasses[position]}`}
+    />
+  );
+}

--- a/mods/menu/ui/src/components/HudHighlight.tsx
+++ b/mods/menu/ui/src/components/HudHighlight.tsx
@@ -5,6 +5,9 @@
  */
 export function HudHighlight() {
   return (
-    <div className="absolute top-0 left-0 right-0 h-px pointer-events-none z-10 rounded-[inherit] bg-[linear-gradient(90deg,transparent_5%,oklch(0.72_0.14_192/0.35)_20%,oklch(0.65_0.18_285/0.25)_50%,oklch(0.7_0.16_350/0.35)_80%,transparent_95%)] after:content-[''] after:absolute after:inset-0 after:bg-[linear-gradient(90deg,transparent_0%,oklch(1_0_0/0.15)_45%,oklch(1_0_0/0.25)_50%,oklch(1_0_0/0.15)_55%,transparent_100%)] after:bg-[length:200%_100%] after:animate-holo-highlight-sweep after:[animation-delay:1s] motion-reduce:after:animate-none" />
+    <div
+      aria-hidden
+      className="absolute top-0 left-0 right-0 h-px pointer-events-none z-10 rounded-[inherit] bg-[linear-gradient(90deg,transparent_5%,oklch(0.72_0.14_192/0.35)_20%,oklch(0.65_0.18_285/0.25)_50%,oklch(0.7_0.16_350/0.35)_80%,transparent_95%)] after:content-[''] after:absolute after:inset-0 after:bg-[linear-gradient(90deg,transparent_0%,oklch(1_0_0/0.15)_45%,oklch(1_0_0/0.25)_50%,oklch(1_0_0/0.15)_55%,transparent_100%)] after:bg-[length:200%_100%] after:animate-holo-highlight-sweep after:[animation-delay:1s] motion-reduce:after:animate-none"
+    />
   );
 }

--- a/mods/menu/ui/src/components/HudHighlight.tsx
+++ b/mods/menu/ui/src/components/HudHighlight.tsx
@@ -1,0 +1,10 @@
+/**
+ * Top-edge highlight for the menu HUD. Renders a subtle multi-stop holographic
+ * gradient line, with an animated white-noise shimmer sweeping across it via a
+ * pseudo-element overlay.
+ */
+export function HudHighlight() {
+  return (
+    <div className="absolute top-0 left-0 right-0 h-px pointer-events-none z-10 rounded-[inherit] bg-[linear-gradient(90deg,transparent_5%,oklch(0.72_0.14_192/0.35)_20%,oklch(0.65_0.18_285/0.25)_50%,oklch(0.7_0.16_350/0.35)_80%,transparent_95%)] after:content-[''] after:absolute after:inset-0 after:bg-[linear-gradient(90deg,transparent_0%,oklch(1_0_0/0.15)_45%,oklch(1_0_0/0.25)_50%,oklch(1_0_0/0.15)_55%,transparent_100%)] after:bg-[length:200%_100%] after:animate-holo-highlight-sweep after:[animation-delay:1s] motion-reduce:after:animate-none" />
+  );
+}

--- a/mods/menu/ui/src/index.css
+++ b/mods/menu/ui/src/index.css
@@ -24,11 +24,11 @@ body {
 /* ━━ Animation tokens (so `animate-orbital-*` and `animate-holo-*` utilities work) ━━ */
 
 @theme inline {
-  --animate-orbital-hud-open: orbital-hud-in var(--hud-duration-content)
-      cubic-bezier(0.16, 1, 0.3, 1) both,
+  --animate-orbital-hud-open:
+    orbital-hud-in var(--hud-duration-content) cubic-bezier(0.16, 1, 0.3, 1) both,
     orbital-float 4s ease-in-out infinite 0.8s;
-  --animate-orbital-hud-closed: orbital-hud-out var(--hud-duration-micro)
-    cubic-bezier(0.4, 0, 1, 1) forwards;
+  --animate-orbital-hud-closed: orbital-hud-out var(--hud-duration-micro) cubic-bezier(0.4, 0, 1, 1)
+    forwards;
   --animate-orbital-float: orbital-float 4s ease-in-out infinite;
   --animate-orbital-card-in: orbital-card-in 220ms cubic-bezier(0.16, 1, 0.3, 1) both;
   --animate-holo-highlight-sweep: holo-highlight-sweep 3s ease-in-out infinite;
@@ -100,118 +100,5 @@ body {
   }
   50% {
     opacity: 0.8;
-  }
-}
-
-/* ━━ Corner Accents ━━ */
-
-.menu-hud-corner {
-  position: absolute;
-  width: 10px;
-  height: 10px;
-  pointer-events: none;
-  z-index: 10;
-  animation: holo-corner-pulse 3s ease-in-out infinite;
-}
-
-.menu-hud-corner--tl {
-  top: -1px;
-  left: -1px;
-  border-top: 1.5px solid oklch(0.72 0.14 192 / 0.6);
-  border-left: 1.5px solid oklch(0.72 0.14 192 / 0.6);
-}
-
-.menu-hud-corner--tr {
-  top: -1px;
-  right: -1px;
-  border-top: 1.5px solid oklch(0.65 0.18 285 / 0.4);
-  border-right: 1.5px solid oklch(0.65 0.18 285 / 0.4);
-  animation-delay: 0.75s;
-}
-
-.menu-hud-corner--bl {
-  bottom: -1px;
-  left: -1px;
-  border-bottom: 1.5px solid oklch(0.65 0.18 285 / 0.4);
-  border-left: 1.5px solid oklch(0.65 0.18 285 / 0.4);
-  animation-delay: 1.5s;
-}
-
-.menu-hud-corner--br {
-  bottom: -1px;
-  right: -1px;
-  border-bottom: 1.5px solid oklch(0.7 0.16 350 / 0.4);
-  border-right: 1.5px solid oklch(0.7 0.16 350 / 0.4);
-  animation-delay: 2.25s;
-}
-
-/* ━━ Top Edge Highlight ━━ */
-
-.menu-hud-highlight {
-  position: absolute;
-  top: 0;
-  left: 0;
-  right: 0;
-  height: 1px;
-  background: linear-gradient(
-    90deg,
-    transparent 5%,
-    oklch(0.72 0.14 192 / 0.35) 20%,
-    oklch(0.65 0.18 285 / 0.25) 50%,
-    oklch(0.7 0.16 350 / 0.35) 80%,
-    transparent 95%
-  );
-  pointer-events: none;
-  z-index: 10;
-  border-radius: inherit;
-}
-
-.menu-hud-highlight::after {
-  content: "";
-  position: absolute;
-  inset: 0;
-  background: linear-gradient(
-    90deg,
-    transparent 0%,
-    oklch(1 0 0 / 0.15) 45%,
-    oklch(1 0 0 / 0.25) 50%,
-    oklch(1 0 0 / 0.15) 55%,
-    transparent 100%
-  );
-  background-size: 200% 100%;
-  animation: holo-highlight-sweep 3s ease-in-out infinite;
-  animation-delay: 1s;
-}
-
-/* ━━ Bottom Edge Line ━━ */
-
-.menu-hud-bottom-line {
-  position: absolute;
-  bottom: 0;
-  left: 10%;
-  right: 10%;
-  height: 1px;
-  background: linear-gradient(
-    90deg,
-    transparent,
-    oklch(0.7 0.16 350 / 0.15) 30%,
-    oklch(0.65 0.18 285 / 0.1) 50%,
-    oklch(0.72 0.14 192 / 0.15) 70%,
-    transparent
-  );
-  pointer-events: none;
-  z-index: 10;
-}
-
-/* ━━ Reduced Motion ━━ */
-
-@media (prefers-reduced-motion: reduce) {
-  .menu-hud-highlight::after {
-    animation: none;
-  }
-
-  .menu-hud-corner {
-    animation: none;
-    opacity: 0.6;
   }
 }

--- a/mods/menu/ui/src/index.css
+++ b/mods/menu/ui/src/index.css
@@ -103,109 +103,6 @@ body {
   }
 }
 
-/* ━━ Card Grid ━━ */
-
-.menu-card-grid {
-  display: grid;
-  grid-template-columns: repeat(2, 1fr);
-  gap: 5px;
-  padding: 2px;
-  position: relative;
-  z-index: 7;
-}
-
-.menu-card-grid--list {
-  grid-template-columns: 1fr;
-}
-
-/* ━━ Card Item ━━ */
-
-.menu-card {
-  position: relative;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  min-height: 52px;
-  padding: var(--hud-space-md) 10px;
-  border-radius: 6px;
-  border: 1px solid oklch(1 0 0 / 0.14);
-  background: oklch(0.13 0.015 var(--menu-accent-hue) / 0.45);
-  cursor: pointer;
-  transition:
-    border-color var(--hud-duration-micro) cubic-bezier(0.4, 0, 0.2, 1),
-    background var(--hud-duration-micro) cubic-bezier(0.4, 0, 0.2, 1),
-    transform 100ms cubic-bezier(0.4, 0, 0.2, 1),
-    color var(--hud-duration-micro) cubic-bezier(0.4, 0, 0.2, 1);
-}
-
-.menu-card-label {
-  font-size: 12.5px;
-  font-weight: 500;
-  letter-spacing: 0.01em;
-  text-align: center;
-  line-height: 1.3;
-  color: oklch(0.9 0.01 230);
-  pointer-events: none;
-}
-
-/* Hover / Focus */
-.menu-card:hover,
-.menu-card:focus {
-  border-color: oklch(0.72 0.14 var(--menu-accent-hue) / 0.5);
-  background: linear-gradient(
-    135deg,
-    oklch(0.72 0.14 var(--menu-accent-hue) / 0.18) 0%,
-    oklch(0.65 0.18 285 / 0.08) 100%
-  );
-  transform: translateY(-1px);
-}
-
-.menu-card:hover .menu-card-label,
-.menu-card:focus .menu-card-label {
-  color: oklch(0.92 0.03 var(--menu-accent-hue));
-}
-
-/* Active / Press */
-.menu-card:active {
-  border-color: oklch(0.65 0.18 285 / 0.4);
-  background: oklch(0.65 0.18 285 / 0.12);
-  transform: scale(0.97);
-}
-
-.menu-card:active .menu-card-label {
-  color: oklch(0.88 0.04 285);
-}
-
-/* Destructive variant */
-.menu-card[data-variant="destructive"]:hover,
-.menu-card[data-variant="destructive"]:focus {
-  border-color: oklch(0.6 0.22 25 / 0.35);
-  background: oklch(0.6 0.22 25 / 0.1);
-}
-
-.menu-card[data-variant="destructive"]:hover .menu-card-label {
-  color: oklch(0.78 0.16 25);
-}
-
-/* Single-column card in list mode — wider, left-aligned */
-.menu-card-grid--list .menu-card {
-  min-height: 40px;
-  justify-content: flex-start;
-  padding: var(--hud-space-sm) var(--hud-space-lg);
-}
-
-.menu-card-grid--list .menu-card-label {
-  text-align: left;
-}
-
-/* ━━ Card Stagger Animation ━━ */
-
-.menu-card-stagger {
-  opacity: 0;
-  animation: orbital-card-in 220ms cubic-bezier(0.16, 1, 0.3, 1) both;
-  animation-delay: calc(60ms + var(--i, 0) * 30ms);
-}
-
 /* ━━ Corner Accents ━━ */
 
 .menu-hud-corner {
@@ -309,11 +206,6 @@ body {
 /* ━━ Reduced Motion ━━ */
 
 @media (prefers-reduced-motion: reduce) {
-  .menu-card-stagger {
-    opacity: 1;
-    animation: none;
-  }
-
   .menu-hud-highlight::after {
     animation: none;
   }

--- a/mods/menu/ui/src/index.css
+++ b/mods/menu/ui/src/index.css
@@ -21,6 +21,20 @@ body {
   --menu-accent-hue: 192;
 }
 
+/* ━━ Animation tokens (so `animate-orbital-*` and `animate-holo-*` utilities work) ━━ */
+
+@theme inline {
+  --animate-orbital-hud-open: orbital-hud-in var(--hud-duration-content)
+      cubic-bezier(0.16, 1, 0.3, 1) both,
+    orbital-float 4s ease-in-out infinite 0.8s;
+  --animate-orbital-hud-closed: orbital-hud-out var(--hud-duration-micro)
+    cubic-bezier(0.4, 0, 1, 1) forwards;
+  --animate-orbital-float: orbital-float 4s ease-in-out infinite;
+  --animate-orbital-card-in: orbital-card-in 220ms cubic-bezier(0.16, 1, 0.3, 1) both;
+  --animate-holo-highlight-sweep: holo-highlight-sweep 3s ease-in-out infinite;
+  --animate-holo-corner-pulse: holo-corner-pulse 3s ease-in-out infinite;
+}
+
 /* ━━ Keyframes ━━ */
 
 @keyframes orbital-hud-in {
@@ -87,93 +101,6 @@ body {
   50% {
     opacity: 0.8;
   }
-}
-
-/* ━━ Menu HUD Container ━━ */
-
-.menu-hud {
-  --menu-w: calc(100vw - 20px);
-  position: relative;
-  overflow-x: hidden;
-  scrollbar-gutter: stable;
-  width: var(--menu-w);
-  max-width: 340px;
-  padding: var(--hud-space-sm) var(--hud-space-sm) var(--hud-space-sm) var(--hud-space-sm);
-  box-shadow: none;
-  animation: orbital-float 4s ease-in-out infinite;
-  animation-delay: 0.8s;
-}
-
-.menu-hud[data-state="open"] {
-  animation:
-    orbital-hud-in var(--hud-duration-content) cubic-bezier(0.16, 1, 0.3, 1) both,
-    orbital-float 4s ease-in-out infinite 0.8s;
-}
-
-.menu-hud[data-state="closed"] {
-  animation: orbital-hud-out var(--hud-duration-micro) cubic-bezier(0.4, 0, 1, 1) forwards;
-}
-
-/* Noise texture — handled by shared .holo-noise class */
-
-/* Connection line — subtle cyan thread toward the character */
-.menu-hud::after {
-  content: "";
-  position: absolute;
-  left: -6px;
-  top: 25%;
-  bottom: 25%;
-  width: 1px;
-  background: linear-gradient(
-    180deg,
-    transparent,
-    oklch(0.72 0.14 var(--menu-accent-hue) / 0.2) 25%,
-    oklch(0.72 0.14 var(--menu-accent-hue) / 0.35) 50%,
-    oklch(0.72 0.14 var(--menu-accent-hue) / 0.2) 75%,
-    transparent
-  );
-  pointer-events: none;
-  z-index: 10;
-  border-radius: 1px;
-}
-
-/* ━━ Status Bar ━━ */
-
-.menu-status-bar {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  padding: var(--hud-space-xs) var(--hud-space-md) var(--hud-space-sm);
-  position: relative;
-  z-index: 7;
-}
-
-.menu-status-name {
-  font-size: var(--hud-font-size-sm);
-  font-weight: 600;
-  letter-spacing: 0.02em;
-  color: oklch(0.93 0.03 var(--menu-accent-hue));
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-  max-width: 200px;
-}
-
-/* ━━ Separator ━━ */
-
-.menu-separator {
-  height: 1px;
-  margin: 2px var(--hud-space-sm) var(--hud-space-xs);
-  background: linear-gradient(
-    90deg,
-    transparent,
-    oklch(0.72 0.14 var(--menu-accent-hue) / 0.2) 20%,
-    oklch(0.65 0.18 285 / 0.15) 50%,
-    oklch(0.7 0.16 350 / 0.2) 80%,
-    transparent
-  );
-  position: relative;
-  z-index: 7;
 }
 
 /* ━━ Card Grid ━━ */
@@ -384,19 +311,6 @@ body {
 @media (prefers-reduced-motion: reduce) {
   .menu-card-stagger {
     opacity: 1;
-    animation: none;
-  }
-
-  .menu-hud {
-    animation: none;
-  }
-
-  .menu-hud[data-state="open"] {
-    animation: none;
-    opacity: 1;
-  }
-
-  .menu-hud[data-state="closed"] {
     animation: none;
   }
 

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -41,5 +41,6 @@ export * from './components/ui/toolbar';
 export * from './components/ui/tooltip';
 export { useClickOutside } from './hooks/use-click-outside';
 export { type UseNavigationStateResult, useNavigationState } from './hooks/use-navigation-state';
+export { cn, type SomeRequired } from './lib/utils';
 import './index.css';
 import './animation.css';


### PR DESCRIPTION
## Summary

PR #2 of the Tailwind utility-first migration (depends on #163). Migrates `mods/menu/ui/src/index.css` from semantic `.menu-*` component classes (411 lines) to Tailwind utility classes on JSX (104 lines, theme tokens + keyframes only).

## What's in this PR

- **CSS reduced 411 → 104 lines.** All `.menu-*` rules removed; only `@import`, `body`/`#root`/`:root`, `@theme inline` (animation tokens), and 6 `@keyframes` blocks remain.
- **2 React components extracted** for pseudo-element decorations: `<HudCorner>` (4 positional variants with staggered animation), `<HudHighlight>` (top-edge gradient + animated shimmer overlay).
- **`@media (prefers-reduced-motion)` translated to `motion-reduce:` variants** on JSX (cleaner per Tailwind v4 idioms).
- **Restored `:focus`/`focus-visible:` variants** for the `data-[variant=destructive]` card state that were dropped in initial migration (keyboard focus now matches hover for destructive items).
- **`aria-hidden`** added to decorative components per the spec's pseudo-element extraction example.
- **`cn()` from `@hmcs/ui`** used throughout instead of template-literal class concatenation. Card className split by state group (Base / Hover / Focus / Active / Destructive / Motion / Layout) for readability.

## Small carve-out

This PR adds 1 line to `packages/ui/src/index.ts` exporting `cn` and `SomeRequired` from `@hmcs/ui`. The doc rule mandates `cn()` from `@hmcs/ui` but it wasn't actually re-exported. Strictly speaking this belongs in #163, but it's a +1-line change tightly coupled to using `cn()` in this PR.

## Per-PR checklist

- [x] CSS file shrunk to only allowed sections
- [x] All references to deleted classes removed from JSX
- [x] No new `@apply` directives
- [x] No new static inline `style={{}}` (the `style={{ '--i': i }}` for stagger index is a legitimate dynamic CSS variable setter)
- [x] No new `.css` files
- [x] `pnpm build`, `pnpm check-types` pass
- [ ] CI passes (depends on #163 merging or rebase)
- [ ] Visual smoke-test: `make debug` → right-click for menu → verify HUD corners pulse, separator gradient renders, card hover/focus shows red tint for destructive items

## Notes for reviewer

- 4 commits, each builds green: 3 staged migration commits + 1 fix commit addressing code review.
- `pnpm lint:styling` enforcement (Layer 2) ships in #163; this PR cannot run that check until #163 merges. After #163 merges and this PR rebases, the diff-scoped check should pass cleanly.