### PR TITLE
style(settings): utility-first migration

### DIFF
--- a/mods/settings/ui/src/App.tsx
+++ b/mods/settings/ui/src/App.tsx
@@ -1,20 +1,25 @@
-import { Toolbar } from '@hmcs/ui';
+import { cn, Toolbar } from '@hmcs/ui';
 import { GeneralTab } from './components/GeneralTab';
 import { useSettings } from './hooks/useSettings';
+
+const panelClasses =
+  'relative box-border flex h-screen max-h-screen max-w-screen flex-col overflow-hidden rounded-xl bg-[oklch(0.15_0.01_250/0.92)] animate-settings-in motion-reduce:animate-none motion-reduce:opacity-100';
 
 export function App() {
   const { loading, fps, setFps, alpha, setAlpha, handleClose } = useSettings();
 
   if (loading) {
     return (
-      <div className="settings-panel settings-loading">
-        <div className="settings-loading-text">Loading...</div>
+      <div className={cn(panelClasses, 'items-center justify-center')}>
+        <div className="text-xs uppercase tracking-[0.12em] text-[oklch(0.72_0.14_192/0.5)] animate-holo-corner-pulse-fast motion-reduce:animate-none motion-reduce:opacity-50">
+          Loading...
+        </div>
       </div>
     );
   }
 
   return (
-    <div className="settings-panel holo-refract-border holo-noise">
+    <div className={cn(panelClasses, 'holo-refract-border holo-noise')}>
       <div className="settings-highlight" />
       <div className="settings-bottom-line" />
       <div className="settings-scanline" />
@@ -25,7 +30,7 @@ export function App() {
 
       <Toolbar title="Settings" onClose={handleClose} />
 
-      <div className="settings-content">
+      <div className="no-scrollbar relative z-[7] flex min-h-0 flex-1 flex-col gap-4 overflow-y-auto p-5">
         <GeneralTab fps={fps} setFps={setFps} alpha={alpha} setAlpha={setAlpha} />
       </div>
     </div>

--- a/mods/settings/ui/src/App.tsx
+++ b/mods/settings/ui/src/App.tsx
@@ -1,4 +1,5 @@
 import { cn, Toolbar } from '@hmcs/ui';
+import { Decorations } from './components/Decorations';
 import { GeneralTab } from './components/GeneralTab';
 import { useSettings } from './hooks/useSettings';
 
@@ -20,13 +21,7 @@ export function App() {
 
   return (
     <div className={cn(panelClasses, 'holo-refract-border holo-noise')}>
-      <div className="settings-highlight" />
-      <div className="settings-bottom-line" />
-      <div className="settings-scanline" />
-      <span className="settings-corner settings-corner--tl" />
-      <span className="settings-corner settings-corner--tr" />
-      <span className="settings-corner settings-corner--bl" />
-      <span className="settings-corner settings-corner--br" />
+      <Decorations />
 
       <Toolbar title="Settings" onClose={handleClose} />
 

--- a/mods/settings/ui/src/components/Decorations.tsx
+++ b/mods/settings/ui/src/components/Decorations.tsx
@@ -1,0 +1,45 @@
+import { cn } from '@hmcs/ui';
+
+type CornerPosition = 'tl' | 'tr' | 'bl' | 'br';
+
+const cornerPositionClass: Record<CornerPosition, string> = {
+  tl: 'hud-corner--tl',
+  tr: 'hud-corner--tr',
+  bl: 'hud-corner--bl',
+  br: 'hud-corner--br',
+};
+
+function HudCorner({ position }: { position: CornerPosition }) {
+  return (
+    <span
+      aria-hidden="true"
+      className={cn('hud-corner pointer-events-none', cornerPositionClass[position])}
+    />
+  );
+}
+
+function HudHighlight() {
+  return <div aria-hidden="true" className="hud-highlight pointer-events-none" />;
+}
+
+function HudBottomLine() {
+  return <div aria-hidden="true" className="hud-bottom-line pointer-events-none" />;
+}
+
+function HudScanline() {
+  return <div aria-hidden="true" className="hud-scanline pointer-events-none" />;
+}
+
+export function Decorations() {
+  return (
+    <>
+      <HudHighlight />
+      <HudBottomLine />
+      <HudScanline />
+      <HudCorner position="tl" />
+      <HudCorner position="tr" />
+      <HudCorner position="bl" />
+      <HudCorner position="br" />
+    </>
+  );
+}

--- a/mods/settings/ui/src/components/GeneralTab.tsx
+++ b/mods/settings/ui/src/components/GeneralTab.tsx
@@ -5,10 +5,16 @@ interface GeneralTabProps {
   setAlpha: (v: number) => void;
 }
 
+const labelClasses =
+  'flex flex-col gap-1.5 text-xs uppercase tracking-[0.1em] text-[oklch(0.72_0.14_192/0.7)]';
+
+const descriptionClasses =
+  'text-[0.7rem] tracking-[0.04em] normal-case text-[oklch(0.55_0.02_250/0.6)] leading-[1.4]';
+
 export function GeneralTab({ fps, setFps, alpha, setAlpha }: GeneralTabProps) {
   return (
-    <div className="settings-section">
-      <label className="settings-label">
+    <div className="flex flex-col gap-4">
+      <label className={labelClasses}>
         Frame Rate
         <div className="settings-slider-row">
           <input
@@ -22,12 +28,12 @@ export function GeneralTab({ fps, setFps, alpha, setAlpha }: GeneralTabProps) {
           />
           <span className="settings-slider-value">{Math.round(fps)} fps</span>
         </div>
-        <span className="settings-description">
+        <span className={descriptionClasses}>
           Controls the rendering frame rate. Lower values reduce CPU/GPU usage.
         </span>
       </label>
 
-      <label className="settings-label">
+      <label className={labelClasses}>
         Shadow Opacity
         <div className="settings-slider-row">
           <input
@@ -41,7 +47,7 @@ export function GeneralTab({ fps, setFps, alpha, setAlpha }: GeneralTabProps) {
           />
           <span className="settings-slider-value">{Math.round(alpha * 100)}%</span>
         </div>
-        <span className="settings-description">
+        <span className={descriptionClasses}>
           Controls the transparency of the shadow panel overlay behind the character.
         </span>
       </label>

--- a/mods/settings/ui/src/components/GeneralTab.tsx
+++ b/mods/settings/ui/src/components/GeneralTab.tsx
@@ -11,12 +11,16 @@ const labelClasses =
 const descriptionClasses =
   'text-[0.7rem] tracking-[0.04em] normal-case text-[oklch(0.55_0.02_250/0.6)] leading-[1.4]';
 
+const sliderRowClasses = 'flex flex-row items-center gap-3';
+
+const sliderValueClasses = 'min-w-[3.5em] text-right font-mono text-xs text-[oklch(0.72_0.14_192)]';
+
 export function GeneralTab({ fps, setFps, alpha, setAlpha }: GeneralTabProps) {
   return (
     <div className="flex flex-col gap-4">
       <label className={labelClasses}>
         Frame Rate
-        <div className="settings-slider-row">
+        <div className={sliderRowClasses}>
           <input
             type="range"
             className="settings-slider"
@@ -26,7 +30,7 @@ export function GeneralTab({ fps, setFps, alpha, setAlpha }: GeneralTabProps) {
             value={fps}
             onChange={(e) => setFps(Number(e.target.value))}
           />
-          <span className="settings-slider-value">{Math.round(fps)} fps</span>
+          <span className={sliderValueClasses}>{Math.round(fps)} fps</span>
         </div>
         <span className={descriptionClasses}>
           Controls the rendering frame rate. Lower values reduce CPU/GPU usage.
@@ -35,7 +39,7 @@ export function GeneralTab({ fps, setFps, alpha, setAlpha }: GeneralTabProps) {
 
       <label className={labelClasses}>
         Shadow Opacity
-        <div className="settings-slider-row">
+        <div className={sliderRowClasses}>
           <input
             type="range"
             className="settings-slider"
@@ -45,7 +49,7 @@ export function GeneralTab({ fps, setFps, alpha, setAlpha }: GeneralTabProps) {
             value={alpha}
             onChange={(e) => setAlpha(Number(e.target.value))}
           />
-          <span className="settings-slider-value">{Math.round(alpha * 100)}%</span>
+          <span className={sliderValueClasses}>{Math.round(alpha * 100)}%</span>
         </div>
         <span className={descriptionClasses}>
           Controls the transparency of the shadow panel overlay behind the character.

--- a/mods/settings/ui/src/index.css
+++ b/mods/settings/ui/src/index.css
@@ -14,6 +14,14 @@ body {
    Settings Panel — Holographic HUD Theme
    ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ */
 
+@theme inline {
+  --animate-settings-in: settings-in 400ms cubic-bezier(0.16, 1, 0.3, 1) both;
+  --animate-holo-corner-pulse: holo-corner-pulse 3s ease-in-out infinite;
+  --animate-holo-corner-pulse-fast: holo-corner-pulse 2s ease-in-out infinite;
+  --animate-holo-highlight-sweep: holo-highlight-sweep 3s ease-in-out infinite;
+  --animate-holo-scanline: holo-scanline 4s linear infinite;
+}
+
 /* ━━ Keyframes ━━ */
 
 @keyframes settings-in {
@@ -60,35 +68,6 @@ body {
   100% {
     background-position: 200% 0;
   }
-}
-
-/* ━━ Settings Panel Container ━━ */
-
-.settings-panel {
-  position: relative;
-  overflow: hidden;
-  background: oklch(0.15 0.01 250 / 0.92);
-  border-radius: 12px;
-  height: 100vh;
-  max-width: 100vw;
-  max-height: 100vh;
-  display: flex;
-  flex-direction: column;
-  animation: settings-in 400ms cubic-bezier(0.16, 1, 0.3, 1) both;
-  box-sizing: border-box;
-}
-
-/* Noise texture overlay (scoped to settings panel) */
-.settings-panel.holo-noise::before {
-  content: "";
-  position: absolute;
-  inset: 0;
-  background-image: url("data:image/svg+xml,%3Csvg viewBox='0 0 256 256' xmlns='http://www.w3.org/2000/svg'%3E%3Cfilter id='n'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.9' numOctaves='4' stitchTiles='stitch'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23n)' opacity='0.03'/%3E%3C/svg%3E");
-  background-size: 128px 128px;
-  pointer-events: none;
-  z-index: 5;
-  border-radius: inherit;
-  mix-blend-mode: overlay;
 }
 
 /* ━━ Holographic Decorations ━━ */
@@ -221,43 +200,6 @@ body {
   animation: holo-scanline 4s linear infinite;
 }
 
-/* ━━ Content Area ━━ */
-
-.settings-content {
-  flex: 1;
-  overflow-y: auto;
-  position: relative;
-  z-index: 7;
-  min-height: 0;
-  scrollbar-width: none;
-  padding: 20px;
-  display: flex;
-  flex-direction: column;
-  gap: var(--hud-space-xl);
-}
-
-.settings-content::-webkit-scrollbar {
-  display: none;
-}
-
-.settings-section {
-  display: flex;
-  flex-direction: column;
-  gap: var(--hud-space-xl);
-}
-
-/* ━━ Form Elements ━━ */
-
-.settings-label {
-  display: flex;
-  flex-direction: column;
-  gap: var(--hud-space-sm);
-  font-size: var(--hud-font-size-sm);
-  letter-spacing: 0.1em;
-  text-transform: uppercase;
-  color: oklch(0.72 0.14 192 / 0.7);
-}
-
 /* ━━ Slider ━━ */
 
 .settings-slider-row {
@@ -330,41 +272,9 @@ body {
   text-align: right;
 }
 
-/* ━━ Description Text ━━ */
-
-.settings-description {
-  font-size: 0.7rem;
-  letter-spacing: 0.04em;
-  text-transform: none;
-  color: oklch(0.55 0.02 250 / 0.6);
-  line-height: 1.4;
-}
-
-/* ━━ Loading State ━━ */
-
-.settings-loading {
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  min-height: 200px;
-}
-
-.settings-loading-text {
-  font-size: var(--hud-font-size-sm);
-  letter-spacing: 0.12em;
-  text-transform: uppercase;
-  color: oklch(0.72 0.14 192 / 0.5);
-  animation: holo-corner-pulse 2s ease-in-out infinite;
-}
-
 /* ━━ Reduced Motion ━━ */
 
 @media (prefers-reduced-motion: reduce) {
-  .settings-panel {
-    animation: none;
-    opacity: 1;
-  }
-
   .settings-scanline::after {
     animation: none;
   }
@@ -376,10 +286,5 @@ body {
   .settings-corner {
     animation: none;
     opacity: 0.6;
-  }
-
-  .settings-loading-text {
-    animation: none;
-    opacity: 0.5;
   }
 }

--- a/mods/settings/ui/src/index.css
+++ b/mods/settings/ui/src/index.css
@@ -70,10 +70,9 @@ body {
   }
 }
 
-/* ━━ Holographic Decorations ━━ */
+/* ━━ Holographic Decorations (linear-gradients + filters Tailwind can't ergonomically express) ━━ */
 
-/* Corner accent pieces */
-.settings-corner {
+@utility hud-corner {
   position: absolute;
   width: 12px;
   height: 12px;
@@ -82,7 +81,7 @@ body {
   animation: holo-corner-pulse 3s ease-in-out infinite;
 }
 
-.settings-corner--tl {
+@utility hud-corner--tl {
   top: -1px;
   left: -1px;
   border-top: 1.5px solid oklch(0.72 0.14 192 / 0.6);
@@ -90,7 +89,7 @@ body {
   filter: drop-shadow(0 0 3px oklch(0.72 0.14 192 / 0.3));
 }
 
-.settings-corner--tr {
+@utility hud-corner--tr {
   top: -1px;
   right: -1px;
   border-top: 1.5px solid oklch(0.65 0.18 285 / 0.4);
@@ -99,7 +98,7 @@ body {
   animation-delay: 0.75s;
 }
 
-.settings-corner--bl {
+@utility hud-corner--bl {
   bottom: -1px;
   left: -1px;
   border-bottom: 1.5px solid oklch(0.65 0.18 285 / 0.4);
@@ -108,7 +107,7 @@ body {
   animation-delay: 1.5s;
 }
 
-.settings-corner--br {
+@utility hud-corner--br {
   bottom: -1px;
   right: -1px;
   border-bottom: 1.5px solid oklch(0.7 0.16 350 / 0.4);
@@ -117,8 +116,7 @@ body {
   animation-delay: 2.25s;
 }
 
-/* Top edge highlight with sweep animation */
-.settings-highlight {
+@utility hud-highlight {
   position: absolute;
   top: 0;
   left: 0;
@@ -135,27 +133,26 @@ body {
   pointer-events: none;
   z-index: 10;
   border-radius: inherit;
+
+  &::after {
+    content: "";
+    position: absolute;
+    inset: 0;
+    background: linear-gradient(
+      90deg,
+      transparent 0%,
+      oklch(1 0 0 / 0.15) 45%,
+      oklch(1 0 0 / 0.25) 50%,
+      oklch(1 0 0 / 0.15) 55%,
+      transparent 100%
+    );
+    background-size: 200% 100%;
+    animation: holo-highlight-sweep 3s ease-in-out infinite;
+    animation-delay: 1s;
+  }
 }
 
-.settings-highlight::after {
-  content: "";
-  position: absolute;
-  inset: 0;
-  background: linear-gradient(
-    90deg,
-    transparent 0%,
-    oklch(1 0 0 / 0.15) 45%,
-    oklch(1 0 0 / 0.25) 50%,
-    oklch(1 0 0 / 0.15) 55%,
-    transparent 100%
-  );
-  background-size: 200% 100%;
-  animation: holo-highlight-sweep 3s ease-in-out infinite;
-  animation-delay: 1s;
-}
-
-/* Bottom edge subtle line */
-.settings-bottom-line {
+@utility hud-bottom-line {
   position: absolute;
   bottom: 0;
   left: 10%;
@@ -173,31 +170,30 @@ body {
   z-index: 10;
 }
 
-/* Slow scanline sweep */
-.settings-scanline {
+@utility hud-scanline {
   position: absolute;
   inset: 0;
   overflow: hidden;
   pointer-events: none;
   z-index: 6;
   border-radius: inherit;
-}
 
-.settings-scanline::after {
-  content: "";
-  position: absolute;
-  left: 0;
-  right: 0;
-  height: 40px;
-  background: linear-gradient(
-    180deg,
-    transparent,
-    oklch(0.72 0.14 192 / 0.03) 40%,
-    oklch(0.72 0.14 192 / 0.05) 50%,
-    oklch(0.72 0.14 192 / 0.03) 60%,
-    transparent
-  );
-  animation: holo-scanline 4s linear infinite;
+  &::after {
+    content: "";
+    position: absolute;
+    left: 0;
+    right: 0;
+    height: 40px;
+    background: linear-gradient(
+      180deg,
+      transparent,
+      oklch(0.72 0.14 192 / 0.03) 40%,
+      oklch(0.72 0.14 192 / 0.05) 50%,
+      oklch(0.72 0.14 192 / 0.03) 60%,
+      transparent
+    );
+    animation: holo-scanline 4s linear infinite;
+  }
 }
 
 /* ━━ Slider thumb/track (vendor pseudo-elements Tailwind cannot express) ━━ */
@@ -260,15 +256,15 @@ body {
 /* ━━ Reduced Motion ━━ */
 
 @media (prefers-reduced-motion: reduce) {
-  .settings-scanline::after {
+  .hud-scanline::after {
     animation: none;
   }
 
-  .settings-highlight::after {
+  .hud-highlight::after {
     animation: none;
   }
 
-  .settings-corner {
+  .hud-corner {
     animation: none;
     opacity: 0.6;
   }

--- a/mods/settings/ui/src/index.css
+++ b/mods/settings/ui/src/index.css
@@ -200,16 +200,9 @@ body {
   animation: holo-scanline 4s linear infinite;
 }
 
-/* ━━ Slider ━━ */
+/* ━━ Slider thumb/track (vendor pseudo-elements Tailwind cannot express) ━━ */
 
-.settings-slider-row {
-  display: flex;
-  flex-direction: row;
-  align-items: center;
-  gap: var(--hud-space-lg);
-}
-
-.settings-slider {
+@utility settings-slider {
   flex: 1;
   -webkit-appearance: none;
   appearance: none;
@@ -219,57 +212,49 @@ body {
   outline: none;
   cursor: pointer;
   padding: 0;
-}
 
-.settings-slider::-webkit-slider-thumb {
-  -webkit-appearance: none;
-  appearance: none;
-  width: 14px;
-  height: 14px;
-  margin-top: -5px;
-  border-radius: 50%;
-  background: oklch(0.72 0.14 192);
-  border: 2px solid oklch(0.72 0.14 192 / 0.5);
-  box-shadow: 0 0 8px oklch(0.72 0.14 192 / 0.4);
-  cursor: pointer;
-  transition:
-    box-shadow var(--hud-duration-content) ease,
-    transform var(--hud-duration-micro) ease;
-}
+  &::-webkit-slider-thumb {
+    -webkit-appearance: none;
+    appearance: none;
+    width: 14px;
+    height: 14px;
+    margin-top: -5px;
+    border-radius: 50%;
+    background: oklch(0.72 0.14 192);
+    border: 2px solid oklch(0.72 0.14 192 / 0.5);
+    box-shadow: 0 0 8px oklch(0.72 0.14 192 / 0.4);
+    cursor: pointer;
+    transition:
+      box-shadow var(--hud-duration-content) ease,
+      transform var(--hud-duration-micro) ease;
+  }
 
-.settings-slider::-webkit-slider-thumb:hover {
-  box-shadow: 0 0 14px oklch(0.72 0.14 192 / 0.6);
-  transform: scale(1.1);
-}
+  &::-webkit-slider-thumb:hover {
+    box-shadow: 0 0 14px oklch(0.72 0.14 192 / 0.6);
+    transform: scale(1.1);
+  }
 
-.settings-slider::-moz-range-thumb {
-  width: 14px;
-  height: 14px;
-  border-radius: 50%;
-  background: oklch(0.72 0.14 192);
-  border: 2px solid oklch(0.72 0.14 192 / 0.5);
-  box-shadow: 0 0 8px oklch(0.72 0.14 192 / 0.4);
-  cursor: pointer;
-}
+  &::-moz-range-thumb {
+    width: 14px;
+    height: 14px;
+    border-radius: 50%;
+    background: oklch(0.72 0.14 192);
+    border: 2px solid oklch(0.72 0.14 192 / 0.5);
+    box-shadow: 0 0 8px oklch(0.72 0.14 192 / 0.4);
+    cursor: pointer;
+  }
 
-.settings-slider::-webkit-slider-runnable-track {
-  height: 4px;
-  border-radius: 2px;
-  background: linear-gradient(90deg, oklch(0.72 0.14 192 / 0.3), oklch(0.65 0.18 285 / 0.2));
-}
+  &::-webkit-slider-runnable-track {
+    height: 4px;
+    border-radius: 2px;
+    background: linear-gradient(90deg, oklch(0.72 0.14 192 / 0.3), oklch(0.65 0.18 285 / 0.2));
+  }
 
-.settings-slider::-moz-range-track {
-  height: 4px;
-  border-radius: 2px;
-  background: linear-gradient(90deg, oklch(0.72 0.14 192 / 0.3), oklch(0.65 0.18 285 / 0.2));
-}
-
-.settings-slider-value {
-  font-family: monospace;
-  font-size: var(--hud-font-size-sm);
-  color: oklch(0.72 0.14 192);
-  min-width: 3.5em;
-  text-align: right;
+  &::-moz-range-track {
+    height: 4px;
+    border-radius: 2px;
+    background: linear-gradient(90deg, oklch(0.72 0.14 192 / 0.3), oklch(0.65 0.18 285 / 0.2));
+  }
 }
 
 /* ━━ Reduced Motion ━━ */

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -41,5 +41,6 @@ export * from './components/ui/toolbar';
 export * from './components/ui/tooltip';
 export { useClickOutside } from './hooks/use-click-outside';
 export { type UseNavigationStateResult, useNavigationState } from './hooks/use-navigation-state';
+export { cn, type SomeRequired } from './lib/utils';
 import './index.css';
 import './animation.css';


### PR DESCRIPTION
## Summary

PR #4 of the Tailwind utility-first migration. Migrates `mods/settings/ui/src/index.css` from semantic component classes to Tailwind v4 `@utility` directives + utility chains.

## What's in this PR

- **CSS reduced 385 → 271 lines.** All `.settings-*` semantic class definitions removed. Remaining content: `@import`, base resets, `@theme inline`, 4 `@keyframes`, 9 `@utility` blocks, and a `@media (prefers-reduced-motion)` rule.
- **HUD decorations extracted** as `Decorations.tsx` — aggregates `<HudHighlight>`, `<HudBottomLine>`, `<HudScanline>`, and four `<HudCorner position="tl|tr|bl|br" />`. All decoratives have `aria-hidden` + `pointer-events-none`.
- **Range slider styling preserved as `@utility settings-slider`** — vendor pseudo-elements (`::-webkit-slider-thumb`, `::-moz-range-thumb`, etc.) cannot be expressed in plain Tailwind utilities; `@utility` is the v4-endorsed home for "CSS feature Tailwind doesn't include" ([docs](https://tailwindcss.com/docs/adding-custom-styles)).
- **HUD decoration styles also live as `@utility hud-*` blocks** consumed by the `Decorations.tsx` components. This is a slight pattern divergence from PR #2 (menu) and PR #3 (openclaw) which used inline utility chains for the same visuals — chosen here to centralize the `@media (prefers-reduced-motion)` overrides for `::after` animations.
- **`@media (prefers-reduced-motion)`** retained for `::after` animations inside `@utility` blocks; structural utilities use `motion-reduce:` JSX variants.
- **`cn` re-exported** from `packages/ui/src/index.ts` (idempotent across PR #2/#3/#4).

## Per-PR checklist

- [x] CSS contains no semantic class definitions
- [x] All references to deleted classes removed from JSX
- [x] No new `@apply` directives
- [x] No new static inline `style={{}}`
- [x] No new `.css` files
- [x] `pnpm --filter @hmcs/settings build` passes
- [x] `pnpm check-types` passes
- [x] `biome check` clean
- [ ] CI passes (depends on PR #163 enforcement landing)
- [ ] Visual smoke-test: `make debug` → open settings → verify panel + corners + highlight + scanline + slider all render correctly

## Notes for reviewer

- 4 commits: 1 chore (`cn` re-export) + 3 staged migrations.
- Pattern divergence vs PRs #164/#165: this PR keeps HUD decoration styling as `@utility hud-*` blocks; the others used inline utility chains. Both are Tailwind v4 idiomatic. Could be normalized post-merge if consistency matters.
- `.settings-panel.holo-noise::before` override (z-index: 5, mix-blend-mode: overlay) dropped in favor of `@hmcs/ui`'s default `holo-noise` styling. Visual delta likely subtle; restore via `[&.holo-noise]:before:mix-blend-overlay` if regression spotted.