### PR TITLE
style(persona/ui): utility-first migration

### DIFF
--- a/mods/persona/ui/src/App.tsx
+++ b/mods/persona/ui/src/App.tsx
@@ -5,6 +5,7 @@ import { usePersonaDetail } from '@persona/shared/hooks/usePersonaDetail';
 import { useThumbnailImport } from '@persona/shared/hooks/useThumbnailImport';
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import { AppearanceTab } from './components/AppearanceTab';
+import { Decorations } from './components/Decorations';
 import { useScale } from './hooks/useScale';
 
 type Tab = 'persona' | 'appearance';
@@ -117,13 +118,7 @@ function SettingsContent({ personaId }: { personaId: string }) {
 
   return (
     <div className={cn(panelClasses, 'holo-refract-border holo-noise')}>
-      <div className="settings-highlight" />
-      <div className="settings-bottom-line" />
-      <div className="settings-scanline" />
-      <span className="settings-corner settings-corner--tl" />
-      <span className="settings-corner settings-corner--tr" />
-      <span className="settings-corner settings-corner--bl" />
-      <span className="settings-corner settings-corner--br" />
+      <Decorations />
 
       <div className="relative z-[7] flex flex-row items-center justify-between">
         <h1 className="m-0 text-sm font-semibold uppercase tracking-[0.15em] text-[oklch(0.72_0.14_192/0.9)]">

--- a/mods/persona/ui/src/App.tsx
+++ b/mods/persona/ui/src/App.tsx
@@ -1,4 +1,5 @@
 import { audio, Persona, Webview } from '@hmcs/sdk';
+import { cn } from '@hmcs/ui';
 import { PersonaDetailBody } from '@persona/shared/components/PersonaDetailBody';
 import { usePersonaDetail } from '@persona/shared/hooks/usePersonaDetail';
 import { useThumbnailImport } from '@persona/shared/hooks/useThumbnailImport';
@@ -10,6 +11,27 @@ type Tab = 'persona' | 'appearance';
 
 const NOOP = () => {};
 const DETAIL_CALLBACKS = { onDirtyChange: NOOP, onSaved: NOOP };
+
+const panelClasses =
+  'relative box-border flex h-screen max-h-screen max-w-[100vw] flex-col gap-4 overflow-hidden rounded-xl bg-[oklch(0.15_0.01_250/0.92)] p-5 animate-settings-in motion-reduce:animate-none motion-reduce:opacity-100';
+
+const loadingTextClasses =
+  'text-xs uppercase tracking-[0.12em] text-[oklch(0.72_0.14_192/0.5)] animate-holo-corner-pulse-fast motion-reduce:animate-none motion-reduce:opacity-50';
+
+const tabClasses =
+  'border-none border-b-2 border-transparent bg-transparent px-4 py-2 font-[inherit] text-xs uppercase tracking-[0.08em] text-[oklch(0.75_0.02_250/0.6)] cursor-pointer transition-[color,border-color,text-shadow] duration-[var(--hud-duration-content)] ease-linear hover:text-[oklch(0.85_0.06_192/0.8)]';
+
+const tabActiveClasses =
+  'text-[oklch(0.72_0.14_192)] border-b-[oklch(0.72_0.14_192/0.8)] [text-shadow:0_0_12px_oklch(0.72_0.14_192/0.3)]';
+
+const closeButtonClasses =
+  'rounded-md border border-[oklch(0.4_0.02_250/0.25)] bg-transparent px-6 py-2 font-[inherit] text-xs uppercase tracking-[0.08em] text-[oklch(0.75_0.04_250/0.75)] cursor-pointer transition-[color,border-color,text-shadow] duration-[var(--hud-duration-content)] ease-linear hover:text-[oklch(0.88_0.08_250/0.9)] hover:border-[oklch(0.55_0.04_250/0.35)] hover:[text-shadow:0_0_10px_oklch(0.72_0.14_192/0.2)] active:scale-[0.97]';
+
+const saveButtonClasses =
+  'rounded-md border border-[oklch(0.72_0.14_192/0.3)] bg-[oklch(0.72_0.14_192/0.15)] px-6 py-2 font-[inherit] text-xs uppercase tracking-[0.08em] text-[oklch(0.72_0.14_192)] cursor-pointer transition-[background,border-color,box-shadow,color] duration-[var(--hud-duration-content)] ease-linear hover:bg-[oklch(0.72_0.14_192/0.25)] hover:border-[oklch(0.72_0.14_192/0.5)] hover:[box-shadow:0_0_12px_oklch(0.72_0.14_192/0.2)] active:scale-[0.97] disabled:opacity-50 disabled:cursor-not-allowed';
+
+const saveButtonSuccessClasses =
+  'bg-[oklch(0.65_0.18_145/0.15)] border-[oklch(0.65_0.18_145/0.4)] text-[oklch(0.65_0.18_145)] [box-shadow:0_0_12px_oklch(0.65_0.18_145/0.15)] hover:bg-[oklch(0.65_0.18_145/0.2)] hover:border-[oklch(0.65_0.18_145/0.5)] hover:[box-shadow:0_0_16px_oklch(0.65_0.18_145/0.25)]';
 
 export function App() {
   const [personaId, setPersonaId] = useState<string | null>(null);
@@ -29,14 +51,18 @@ export function App() {
   }, []);
 
   if (!personaId) {
-    return (
-      <div className="settings-panel settings-loading">
-        <div className="settings-loading-text">Loading...</div>
-      </div>
-    );
+    return <LoadingPanel />;
   }
 
   return <SettingsContent personaId={personaId} />;
+}
+
+function LoadingPanel() {
+  return (
+    <div className={cn(panelClasses, 'items-center justify-center min-h-[200px]')}>
+      <div className={loadingTextClasses}>Loading...</div>
+    </div>
+  );
 }
 
 function SettingsContent({ personaId }: { personaId: string }) {
@@ -78,11 +104,7 @@ function SettingsContent({ personaId }: { personaId: string }) {
   }, [personaId, importThumbnail, detail]);
 
   if (!detail.snapshot || !detail.formValues || scaleState.loading) {
-    return (
-      <div className="settings-panel settings-loading">
-        <div className="settings-loading-text">Loading...</div>
-      </div>
-    );
+    return <LoadingPanel />;
   }
 
   const autoSpawn = detail.snapshot.metadata?.['auto-spawn'] === true;
@@ -94,8 +116,7 @@ function SettingsContent({ personaId }: { personaId: string }) {
   ];
 
   return (
-    <div className="settings-panel holo-refract-border holo-noise">
-      {/* Decorative layers */}
+    <div className={cn(panelClasses, 'holo-refract-border holo-noise')}>
       <div className="settings-highlight" />
       <div className="settings-bottom-line" />
       <div className="settings-scanline" />
@@ -104,19 +125,19 @@ function SettingsContent({ personaId }: { personaId: string }) {
       <span className="settings-corner settings-corner--bl" />
       <span className="settings-corner settings-corner--br" />
 
-      {/* Header */}
-      <div className="settings-header">
-        <h1 className="settings-title">Settings</h1>
-        <span className="settings-entity-name">{name}</span>
+      <div className="relative z-[7] flex flex-row items-center justify-between">
+        <h1 className="m-0 text-sm font-semibold uppercase tracking-[0.15em] text-[oklch(0.72_0.14_192/0.9)]">
+          Settings
+        </h1>
+        <span className="font-mono text-xs text-[oklch(0.72_0.14_192/0.5)]">{name}</span>
       </div>
 
-      {/* Tabs */}
-      <div className="settings-tabs">
+      <div className="relative z-[7] flex flex-row gap-1 border-b border-[oklch(0.72_0.14_192/0.1)] pb-0">
         {tabs.map((t) => (
           <button
             type="button"
             key={t.id}
-            className={`settings-tab ${tab === t.id ? 'settings-tab--active' : ''}`}
+            className={cn(tabClasses, tab === t.id && tabActiveClasses)}
             onClick={() => setTab(t.id)}
           >
             {t.label}
@@ -124,8 +145,7 @@ function SettingsContent({ personaId }: { personaId: string }) {
         ))}
       </div>
 
-      {/* Content */}
-      <div className="settings-content">
+      <div className="no-scrollbar relative z-[7] min-h-0 flex-1 overflow-y-auto">
         {tab === 'persona' && (
           <PersonaDetailBody
             personaId={personaId}
@@ -151,14 +171,13 @@ function SettingsContent({ personaId }: { personaId: string }) {
         )}
       </div>
 
-      {/* Footer */}
-      <div className="settings-footer">
-        <button type="button" className="settings-close" onClick={handleClose}>
+      <div className="relative z-[7] flex justify-end gap-2 pt-2">
+        <button type="button" className={closeButtonClasses} onClick={handleClose}>
           Close
         </button>
         <button
           type="button"
-          className={`settings-save ${saved ? 'settings-save--success' : ''}`}
+          className={cn(saveButtonClasses, saved && saveButtonSuccessClasses)}
           onClick={handleSave}
           disabled={saving}
         >

--- a/mods/persona/ui/src/components/AppearanceTab.tsx
+++ b/mods/persona/ui/src/components/AppearanceTab.tsx
@@ -21,7 +21,7 @@ export function AppearanceTab({
   return (
     <>
       <ScaleSection scale={scale} onScaleChange={onScaleChange} />
-      <div className="settings-separator" />
+      <div className="my-4 h-px bg-gradient-to-r from-transparent via-[oklch(0.35_0.02_250/0.25)] to-transparent" />
       <BehaviorSection
         process={behaviorProcess}
         animations={behaviorAnimations}
@@ -43,7 +43,7 @@ function ScaleSection({
     <div className="settings-section">
       <label className="settings-label">
         Scale
-        <div className="settings-slider-row">
+        <div className="flex flex-row items-center gap-3">
           <input
             type="range"
             className="settings-slider"
@@ -53,7 +53,9 @@ function ScaleSection({
             value={scale}
             onChange={(e) => onScaleChange(parseFloat(e.target.value))}
           />
-          <span className="settings-slider-value">{scale.toFixed(2)}</span>
+          <span className="min-w-[3.5em] text-right font-mono text-xs text-[oklch(0.72_0.14_192)]">
+            {scale.toFixed(2)}
+          </span>
         </div>
       </label>
     </div>

--- a/mods/persona/ui/src/components/Decorations.tsx
+++ b/mods/persona/ui/src/components/Decorations.tsx
@@ -1,0 +1,45 @@
+import { cn } from '@hmcs/ui';
+
+type CornerPosition = 'tl' | 'tr' | 'bl' | 'br';
+
+const cornerPositionClass: Record<CornerPosition, string> = {
+  tl: 'hud-corner--tl',
+  tr: 'hud-corner--tr',
+  bl: 'hud-corner--bl',
+  br: 'hud-corner--br',
+};
+
+function HudCorner({ position }: { position: CornerPosition }) {
+  return (
+    <span
+      aria-hidden="true"
+      className={cn('hud-corner pointer-events-none', cornerPositionClass[position])}
+    />
+  );
+}
+
+function HudHighlight() {
+  return <div aria-hidden="true" className="hud-highlight pointer-events-none" />;
+}
+
+function HudBottomLine() {
+  return <div aria-hidden="true" className="hud-bottom-line pointer-events-none" />;
+}
+
+function HudScanline() {
+  return <div aria-hidden="true" className="hud-scanline pointer-events-none" />;
+}
+
+export function Decorations() {
+  return (
+    <>
+      <HudHighlight />
+      <HudBottomLine />
+      <HudScanline />
+      <HudCorner position="tl" />
+      <HudCorner position="tr" />
+      <HudCorner position="bl" />
+      <HudCorner position="br" />
+    </>
+  );
+}

--- a/mods/persona/ui/src/index.css
+++ b/mods/persona/ui/src/index.css
@@ -12,8 +12,16 @@ body {
 }
 
 /* ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-   Settings Panel — Holographic HUD Theme
+   Persona Settings Panel — Holographic HUD Theme
    ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ */
+
+@theme inline {
+  --animate-settings-in: settings-in 400ms cubic-bezier(0.16, 1, 0.3, 1) both;
+  --animate-holo-corner-pulse: holo-corner-pulse 3s ease-in-out infinite;
+  --animate-holo-corner-pulse-fast: holo-corner-pulse 2s ease-in-out infinite;
+  --animate-holo-highlight-sweep: holo-highlight-sweep 3s ease-in-out infinite;
+  --animate-holo-scanline: holo-scanline 4s linear infinite;
+}
 
 /* ━━ Keyframes ━━ */
 
@@ -61,37 +69,6 @@ body {
   100% {
     background-position: 200% 0;
   }
-}
-
-/* ━━ Settings Panel Container ━━ */
-
-.settings-panel {
-  position: relative;
-  overflow: hidden;
-  background: oklch(0.15 0.01 250 / 0.92);
-  border-radius: 12px;
-  padding: 20px;
-  height: 100vh;
-  max-width: 100vw;
-  max-height: 100vh;
-  display: flex;
-  flex-direction: column;
-  gap: var(--hud-space-xl);
-  animation: settings-in 400ms cubic-bezier(0.16, 1, 0.3, 1) both;
-  box-sizing: border-box;
-}
-
-/* Noise texture overlay (scoped to settings panel) */
-.settings-panel.holo-noise::before {
-  content: "";
-  position: absolute;
-  inset: 0;
-  background-image: url("data:image/svg+xml,%3Csvg viewBox='0 0 256 256' xmlns='http://www.w3.org/2000/svg'%3E%3Cfilter id='n'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.9' numOctaves='4' stitchTiles='stitch'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23n)' opacity='0.03'/%3E%3C/svg%3E");
-  background-size: 128px 128px;
-  pointer-events: none;
-  z-index: 5;
-  border-radius: inherit;
-  mix-blend-mode: overlay;
 }
 
 /* ━━ Holographic Decorations ━━ */
@@ -224,95 +201,36 @@ body {
   animation: holo-scanline 4s linear infinite;
 }
 
-/* ━━ Header ━━ */
+/* ━━ Shared classes referenced from @persona/shared components ━━ */
 
-.settings-header {
-  display: flex;
-  flex-direction: row;
-  justify-content: space-between;
-  align-items: center;
-  position: relative;
-  z-index: 7;
-}
-
-.settings-title {
-  font-size: var(--hud-font-size-base);
-  letter-spacing: 0.15em;
-  text-transform: uppercase;
-  color: oklch(0.72 0.14 192 / 0.9);
-  font-weight: 600;
-  margin: 0;
-}
-
-.settings-entity-name {
-  font-size: var(--hud-font-size-sm);
-  color: oklch(0.72 0.14 192 / 0.5);
-  font-family: monospace;
-}
-
-/* ━━ Tab Bar ━━ */
-
-.settings-tabs {
-  display: flex;
-  flex-direction: row;
-  gap: var(--hud-space-xs);
-  position: relative;
-  z-index: 7;
-  border-bottom: 1px solid oklch(0.72 0.14 192 / 0.1);
-  padding-bottom: 0;
-}
-
-.settings-tab {
-  background: transparent;
-  border: none;
-  border-bottom: 2px solid transparent;
-  color: oklch(0.75 0.02 250 / 0.6);
-  font-size: var(--hud-font-size-sm);
-  letter-spacing: 0.08em;
-  text-transform: uppercase;
-  padding: var(--hud-space-md) var(--hud-space-xl);
-  cursor: pointer;
-  transition:
-    color var(--hud-duration-content) ease,
-    border-color var(--hud-duration-content) ease,
-    text-shadow var(--hud-duration-content) ease;
-  font-family: inherit;
-}
-
-.settings-tab:hover {
-  color: oklch(0.85 0.06 192 / 0.8);
-}
-
-.settings-tab--active {
-  color: oklch(0.72 0.14 192);
-  border-bottom-color: oklch(0.72 0.14 192 / 0.8);
-  text-shadow: 0 0 12px oklch(0.72 0.14 192 / 0.3);
-}
-
-/* ━━ Content Area ━━ */
-
-.settings-content {
-  flex: 1;
-  overflow-y: auto;
-  position: relative;
-  z-index: 7;
-  min-height: 0;
-  scrollbar-width: none;
-}
-
-.settings-content::-webkit-scrollbar {
-  display: none;
-}
-
-.settings-section {
+@utility settings-section {
   display: flex;
   flex-direction: column;
   gap: var(--hud-space-xl);
 }
 
-/* ━━ Form Elements ━━ */
+@utility settings-section-heading {
+  font-size: var(--hud-font-size-xs);
+  font-weight: 600;
+  letter-spacing: 0.15em;
+  text-transform: uppercase;
+  color: var(--hud-text);
+  margin-bottom: var(--hud-space-lg);
+  display: flex;
+  align-items: center;
+  gap: var(--hud-space-sm);
 
-.settings-label {
+  &::before {
+    content: "";
+    display: inline-block;
+    width: 3px;
+    height: 12px;
+    background: oklch(0.72 0.14 192 / 0.9);
+    border-radius: 1px;
+  }
+}
+
+@utility settings-label {
   display: flex;
   flex-direction: column;
   gap: var(--hud-space-sm);
@@ -322,7 +240,7 @@ body {
   color: oklch(0.72 0.14 192 / 0.7);
 }
 
-.settings-input {
+@utility settings-input {
   background: oklch(0.12 0.01 250 / 0.8);
   border: 1px solid oklch(0.72 0.14 192 / 0.2);
   border-radius: 6px;
@@ -334,16 +252,20 @@ body {
   transition:
     border-color var(--hud-duration-content) ease,
     box-shadow var(--hud-duration-content) ease;
+
+  &:focus {
+    border-color: oklch(0.72 0.14 192 / 0.5);
+    box-shadow:
+      0 0 8px oklch(0.72 0.14 192 / 0.15),
+      inset 0 0 4px oklch(0.72 0.14 192 / 0.05);
+  }
+
+  &::placeholder {
+    color: oklch(0.55 0.02 250 / 0.5);
+  }
 }
 
-.settings-input:focus {
-  border-color: oklch(0.72 0.14 192 / 0.5);
-  box-shadow:
-    0 0 8px oklch(0.72 0.14 192 / 0.15),
-    inset 0 0 4px oklch(0.72 0.14 192 / 0.05);
-}
-
-.settings-textarea {
+@utility settings-textarea {
   background: oklch(0.12 0.01 250 / 0.8);
   border: 1px solid oklch(0.72 0.14 192 / 0.2);
   border-radius: 6px;
@@ -357,29 +279,67 @@ body {
   transition:
     border-color var(--hud-duration-content) ease,
     box-shadow var(--hud-duration-content) ease;
+
+  &:focus {
+    border-color: oklch(0.72 0.14 192 / 0.5);
+    box-shadow:
+      0 0 8px oklch(0.72 0.14 192 / 0.15),
+      inset 0 0 4px oklch(0.72 0.14 192 / 0.05);
+  }
+
+  &::placeholder {
+    color: oklch(0.55 0.02 250 / 0.5);
+  }
 }
 
-.settings-textarea:focus {
-  border-color: oklch(0.72 0.14 192 / 0.5);
-  box-shadow:
-    0 0 8px oklch(0.72 0.14 192 / 0.15),
-    inset 0 0 4px oklch(0.72 0.14 192 / 0.05);
+@utility settings-vrma-fields {
+  display: flex;
+  flex-direction: column;
+  padding-left: var(--hud-space-xl);
+  border-left: 1px solid oklch(0.72 0.14 192 / 0.12);
+  margin-top: var(--hud-space-lg);
+  gap: var(--hud-space-md);
 }
 
-.settings-textarea::placeholder,
-.settings-input::placeholder {
+@utility settings-behavior-hint {
+  margin-top: var(--hud-space-lg);
+  padding: var(--hud-space-md) var(--hud-space-xl);
+  border-left: 1px solid oklch(0.72 0.14 192 / 0.12);
   color: oklch(0.55 0.02 250 / 0.5);
+  font-size: var(--hud-font-size-xs);
+  letter-spacing: 0.05em;
 }
 
-/* ━━ Age Field — Segmented Control + Value Area ━━ */
+@utility settings-state-dot {
+  display: inline-block;
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  margin-right: 6px;
+  vertical-align: middle;
+}
 
-.settings-age-field {
+@utility settings-state-dot--idle {
+  background: oklch(0.72 0.14 192);
+}
+
+@utility settings-state-dot--drag {
+  background: oklch(0.7 0.16 350);
+}
+
+@utility settings-state-dot--sitting {
+  background: oklch(0.65 0.18 285);
+}
+
+/* ━━ Age Field — Segmented Control + Value Area (Radix data-attributes + nested vendor pseudo-elements) ━━ */
+
+@utility settings-age-field {
   display: flex;
   flex-direction: column;
   gap: var(--hud-space-sm);
 }
 
-.settings-age-legend {
+@utility settings-age-legend {
   position: absolute;
   width: 1px;
   height: 1px;
@@ -391,7 +351,7 @@ body {
   border: 0;
 }
 
-.settings-age-segments {
+@utility settings-age-segments {
   display: flex;
   gap: 2px;
   background: oklch(0.12 0.01 250 / 0.8);
@@ -399,13 +359,13 @@ body {
   border-radius: 6px;
   overflow: hidden;
   height: 32px;
+
+  &[data-mode="unknown"] {
+    border-color: oklch(0.65 0.18 285 / 0.2);
+  }
 }
 
-.settings-age-segments[data-mode="unknown"] {
-  border-color: oklch(0.65 0.18 285 / 0.2);
-}
-
-.settings-age-segment {
+@utility settings-age-segment {
   flex: 1;
   display: flex;
   align-items: center;
@@ -427,36 +387,36 @@ body {
   border-bottom: 2px solid transparent;
   font-family: inherit;
   outline: none;
+
+  &:hover {
+    color: oklch(0.78 0.1 192);
+  }
+
+  &[data-mode="unknown"]:hover {
+    color: oklch(0.72 0.14 285);
+  }
+
+  &[data-state="checked"][data-mode="specify"] {
+    color: oklch(0.72 0.14 192);
+    border-bottom-color: oklch(0.72 0.14 192 / 0.8);
+    text-shadow: 0 0 12px oklch(0.72 0.14 192 / 0.3);
+    background: oklch(0.18 0.02 250 / 0.5);
+  }
+
+  &[data-state="checked"][data-mode="unknown"] {
+    color: oklch(0.65 0.18 285);
+    border-bottom-color: oklch(0.65 0.18 285 / 0.8);
+    text-shadow: 0 0 12px oklch(0.65 0.18 285 / 0.3);
+    background: oklch(0.18 0.02 250 / 0.5);
+  }
+
+  &:focus-visible {
+    outline: var(--hud-focus-ring-width) solid oklch(0.72 0.14 192);
+    outline-offset: var(--hud-focus-offset);
+  }
 }
 
-.settings-age-segment:hover {
-  color: oklch(0.78 0.1 192);
-}
-
-.settings-age-segment[data-mode="unknown"]:hover {
-  color: oklch(0.72 0.14 285);
-}
-
-.settings-age-segment[data-state="checked"][data-mode="specify"] {
-  color: oklch(0.72 0.14 192);
-  border-bottom-color: oklch(0.72 0.14 192 / 0.8);
-  text-shadow: 0 0 12px oklch(0.72 0.14 192 / 0.3);
-  background: oklch(0.18 0.02 250 / 0.5);
-}
-
-.settings-age-segment[data-state="checked"][data-mode="unknown"] {
-  color: oklch(0.65 0.18 285);
-  border-bottom-color: oklch(0.65 0.18 285 / 0.8);
-  text-shadow: 0 0 12px oklch(0.65 0.18 285 / 0.3);
-  background: oklch(0.18 0.02 250 / 0.5);
-}
-
-.settings-age-segment:focus-visible {
-  outline: var(--hud-focus-ring-width) solid oklch(0.72 0.14 192);
-  outline-offset: var(--hud-focus-offset);
-}
-
-.settings-age-value-area {
+@utility settings-age-value-area {
   display: flex;
   align-items: center;
   justify-content: center;
@@ -469,13 +429,27 @@ body {
   transition:
     border-color var(--hud-duration-content) ease-out,
     box-shadow var(--hud-duration-content) ease-out;
+
+  &[data-mode="unknown"] {
+    border-color: oklch(0.65 0.18 285 / 0.2);
+  }
+
+  &:focus-within {
+    border-color: oklch(0.72 0.14 192 / 0.5);
+    box-shadow:
+      0 0 8px oklch(0.72 0.14 192 / 0.15),
+      inset 0 0 4px oklch(0.72 0.14 192 / 0.05);
+  }
+
+  &[data-mode="unknown"]:focus-within {
+    border-color: oklch(0.65 0.18 285 / 0.5);
+    box-shadow:
+      0 0 8px oklch(0.65 0.18 285 / 0.15),
+      inset 0 0 4px oklch(0.65 0.18 285 / 0.05);
+  }
 }
 
-.settings-age-value-area[data-mode="unknown"] {
-  border-color: oklch(0.65 0.18 285 / 0.2);
-}
-
-.settings-age-input {
+@utility settings-age-input {
   width: 100%;
   background: transparent;
   border: none;
@@ -487,46 +461,32 @@ body {
   text-align: center;
   font-variant-numeric: tabular-nums;
   padding: 0;
+
+  &::placeholder {
+    color: oklch(0.55 0.02 250 / 0.5);
+  }
+
+  &::-webkit-inner-spin-button,
+  &::-webkit-outer-spin-button {
+    -webkit-appearance: none;
+    margin: 0;
+  }
 }
 
-.settings-age-input::placeholder {
-  color: oklch(0.55 0.02 250 / 0.5);
-}
-
-.settings-age-input::-webkit-inner-spin-button,
-.settings-age-input::-webkit-outer-spin-button {
-  -webkit-appearance: none;
-  margin: 0;
-}
-
-.settings-age-suffix {
+@utility settings-age-suffix {
   font-size: var(--hud-font-size-sm);
   color: oklch(0.72 0.14 192 / 0.5);
   margin-left: 2px;
   font-family: monospace;
 }
 
-.settings-age-unknown-readout {
+@utility settings-age-unknown-readout {
   font-family: monospace;
   font-size: 0.95rem;
   font-weight: 400;
   text-align: center;
   color: oklch(0.65 0.18 285);
   font-variant-numeric: tabular-nums;
-}
-
-.settings-age-value-area:focus-within {
-  border-color: oklch(0.72 0.14 192 / 0.5);
-  box-shadow:
-    0 0 8px oklch(0.72 0.14 192 / 0.15),
-    inset 0 0 4px oklch(0.72 0.14 192 / 0.05);
-}
-
-.settings-age-value-area[data-mode="unknown"]:focus-within {
-  border-color: oklch(0.65 0.18 285 / 0.5);
-  box-shadow:
-    0 0 8px oklch(0.65 0.18 285 / 0.15),
-    inset 0 0 4px oklch(0.65 0.18 285 / 0.05);
 }
 
 @media (forced-colors: active) {
@@ -549,16 +509,9 @@ body {
   }
 }
 
-/* ━━ Slider ━━ */
+/* ━━ Slider thumb/track (vendor pseudo-elements Tailwind cannot express) ━━ */
 
-.settings-slider-row {
-  display: flex;
-  flex-direction: row;
-  align-items: center;
-  gap: var(--hud-space-lg);
-}
-
-.settings-slider {
+@utility settings-slider {
   flex: 1;
   -webkit-appearance: none;
   appearance: none;
@@ -568,238 +521,54 @@ body {
   outline: none;
   cursor: pointer;
   padding: 0;
-}
 
-.settings-slider::-webkit-slider-thumb {
-  -webkit-appearance: none;
-  appearance: none;
-  width: 14px;
-  height: 14px;
-  margin-top: -5px;
-  border-radius: 50%;
-  background: oklch(0.72 0.14 192);
-  border: 2px solid oklch(0.72 0.14 192 / 0.5);
-  box-shadow: 0 0 8px oklch(0.72 0.14 192 / 0.4);
-  cursor: pointer;
-  transition:
-    box-shadow var(--hud-duration-content) ease,
-    transform var(--hud-duration-micro) ease;
-}
+  &::-webkit-slider-thumb {
+    -webkit-appearance: none;
+    appearance: none;
+    width: 14px;
+    height: 14px;
+    margin-top: -5px;
+    border-radius: 50%;
+    background: oklch(0.72 0.14 192);
+    border: 2px solid oklch(0.72 0.14 192 / 0.5);
+    box-shadow: 0 0 8px oklch(0.72 0.14 192 / 0.4);
+    cursor: pointer;
+    transition:
+      box-shadow var(--hud-duration-content) ease,
+      transform var(--hud-duration-micro) ease;
+  }
 
-.settings-slider::-webkit-slider-thumb:hover {
-  box-shadow: 0 0 14px oklch(0.72 0.14 192 / 0.6);
-  transform: scale(1.1);
-}
+  &::-webkit-slider-thumb:hover {
+    box-shadow: 0 0 14px oklch(0.72 0.14 192 / 0.6);
+    transform: scale(1.1);
+  }
 
-.settings-slider::-moz-range-thumb {
-  width: 14px;
-  height: 14px;
-  border-radius: 50%;
-  background: oklch(0.72 0.14 192);
-  border: 2px solid oklch(0.72 0.14 192 / 0.5);
-  box-shadow: 0 0 8px oklch(0.72 0.14 192 / 0.4);
-  cursor: pointer;
-}
+  &::-moz-range-thumb {
+    width: 14px;
+    height: 14px;
+    border-radius: 50%;
+    background: oklch(0.72 0.14 192);
+    border: 2px solid oklch(0.72 0.14 192 / 0.5);
+    box-shadow: 0 0 8px oklch(0.72 0.14 192 / 0.4);
+    cursor: pointer;
+  }
 
-.settings-slider::-webkit-slider-runnable-track {
-  height: 4px;
-  border-radius: 2px;
-  background: linear-gradient(90deg, oklch(0.72 0.14 192 / 0.3), oklch(0.65 0.18 285 / 0.2));
-}
+  &::-webkit-slider-runnable-track {
+    height: 4px;
+    border-radius: 2px;
+    background: linear-gradient(90deg, oklch(0.72 0.14 192 / 0.3), oklch(0.65 0.18 285 / 0.2));
+  }
 
-.settings-slider::-moz-range-track {
-  height: 4px;
-  border-radius: 2px;
-  background: linear-gradient(90deg, oklch(0.72 0.14 192 / 0.3), oklch(0.65 0.18 285 / 0.2));
-}
-
-.settings-slider-value {
-  font-family: monospace;
-  font-size: var(--hud-font-size-sm);
-  color: oklch(0.72 0.14 192);
-  min-width: 3.5em;
-  text-align: right;
-}
-
-/* ━━ Footer ━━ */
-
-.settings-footer {
-  display: flex;
-  justify-content: flex-end;
-  gap: var(--hud-space-md);
-  padding-top: var(--hud-space-md);
-  position: relative;
-  z-index: 7;
-}
-
-/* ━━ Close Button ━━ */
-
-.settings-close {
-  background: transparent;
-  border: 1px solid oklch(0.4 0.02 250 / 0.25);
-  border-radius: 6px;
-  padding: var(--hud-space-md) var(--hud-space-2xl);
-  color: oklch(0.75 0.04 250 / 0.75);
-  font-size: var(--hud-font-size-sm);
-  font-family: inherit;
-  letter-spacing: 0.08em;
-  text-transform: uppercase;
-  cursor: pointer;
-  transition:
-    color var(--hud-duration-content) ease,
-    border-color var(--hud-duration-content) ease,
-    text-shadow var(--hud-duration-content) ease;
-}
-
-.settings-close:hover {
-  color: oklch(0.88 0.08 250 / 0.9);
-  border-color: oklch(0.55 0.04 250 / 0.35);
-  text-shadow: 0 0 10px oklch(0.72 0.14 192 / 0.2);
-}
-
-.settings-close:active {
-  transform: scale(0.97);
-}
-
-/* ━━ Save Button ━━ */
-
-.settings-save {
-  background: oklch(0.72 0.14 192 / 0.15);
-  border: 1px solid oklch(0.72 0.14 192 / 0.3);
-  border-radius: 6px;
-  padding: var(--hud-space-md) var(--hud-space-2xl);
-  color: oklch(0.72 0.14 192);
-  font-size: var(--hud-font-size-sm);
-  font-family: inherit;
-  letter-spacing: 0.08em;
-  text-transform: uppercase;
-  cursor: pointer;
-  transition:
-    background var(--hud-duration-content) ease,
-    border-color var(--hud-duration-content) ease,
-    box-shadow var(--hud-duration-content) ease,
-    color var(--hud-duration-content) ease;
-}
-
-.settings-save:hover {
-  background: oklch(0.72 0.14 192 / 0.25);
-  border-color: oklch(0.72 0.14 192 / 0.5);
-  box-shadow: 0 0 12px oklch(0.72 0.14 192 / 0.2);
-}
-
-.settings-save:active {
-  transform: scale(0.97);
-}
-
-.settings-save:disabled {
-  opacity: 0.5;
-  cursor: not-allowed;
-}
-
-.settings-save--success {
-  background: oklch(0.65 0.18 145 / 0.15);
-  border-color: oklch(0.65 0.18 145 / 0.4);
-  color: oklch(0.65 0.18 145);
-  box-shadow: 0 0 12px oklch(0.65 0.18 145 / 0.15);
-}
-
-.settings-save--success:hover {
-  background: oklch(0.65 0.18 145 / 0.2);
-  border-color: oklch(0.65 0.18 145 / 0.5);
-  box-shadow: 0 0 16px oklch(0.65 0.18 145 / 0.25);
-}
-
-/* ━━ Loading State ━━ */
-
-.settings-loading {
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  min-height: 200px;
-}
-
-.settings-loading-text {
-  font-size: var(--hud-font-size-sm);
-  letter-spacing: 0.12em;
-  text-transform: uppercase;
-  color: oklch(0.72 0.14 192 / 0.5);
-  animation: holo-corner-pulse 2s ease-in-out infinite;
-}
-
-/* --- Behavior section --- */
-
-.settings-section-heading {
-  font-size: var(--hud-font-size-xs);
-  font-weight: 600;
-  letter-spacing: 0.15em;
-  text-transform: uppercase;
-  color: var(--hud-text);
-  margin-bottom: var(--hud-space-lg);
-  display: flex;
-  align-items: center;
-  gap: var(--hud-space-sm);
-}
-
-.settings-section-heading::before {
-  content: "";
-  display: inline-block;
-  width: 3px;
-  height: 12px;
-  background: oklch(0.72 0.14 192 / 0.9);
-  border-radius: 1px;
-}
-
-.settings-separator {
-  height: 1px;
-  background: linear-gradient(90deg, transparent, oklch(0.35 0.02 250 / 0.25), transparent);
-  margin: var(--hud-space-xl) 0;
-}
-
-.settings-vrma-fields {
-  display: flex;
-  flex-direction: column;
-  padding-left: var(--hud-space-xl);
-  border-left: 1px solid oklch(0.72 0.14 192 / 0.12);
-  margin-top: var(--hud-space-lg);
-  gap: var(--hud-space-md);
-}
-
-.settings-state-dot {
-  display: inline-block;
-  width: 6px;
-  height: 6px;
-  border-radius: 50%;
-  margin-right: 6px;
-  vertical-align: middle;
-}
-
-.settings-state-dot--idle {
-  background: oklch(0.72 0.14 192);
-}
-.settings-state-dot--drag {
-  background: oklch(0.7 0.16 350);
-}
-.settings-state-dot--sitting {
-  background: oklch(0.65 0.18 285);
-}
-
-.settings-behavior-hint {
-  margin-top: var(--hud-space-lg);
-  padding: var(--hud-space-md) var(--hud-space-xl);
-  border-left: 1px solid oklch(0.72 0.14 192 / 0.12);
-  color: oklch(0.55 0.02 250 / 0.5);
-  font-size: var(--hud-font-size-xs);
-  letter-spacing: 0.05em;
+  &::-moz-range-track {
+    height: 4px;
+    border-radius: 2px;
+    background: linear-gradient(90deg, oklch(0.72 0.14 192 / 0.3), oklch(0.65 0.18 285 / 0.2));
+  }
 }
 
 /* ━━ Reduced Motion ━━ */
 
 @media (prefers-reduced-motion: reduce) {
-  .settings-panel {
-    animation: none;
-    opacity: 1;
-  }
-
   .settings-scanline::after {
     animation: none;
   }
@@ -811,11 +580,6 @@ body {
   .settings-corner {
     animation: none;
     opacity: 0.6;
-  }
-
-  .settings-loading-text {
-    animation: none;
-    opacity: 0.5;
   }
 
   .settings-age-segment,

--- a/mods/persona/ui/src/index.css
+++ b/mods/persona/ui/src/index.css
@@ -71,10 +71,9 @@ body {
   }
 }
 
-/* ━━ Holographic Decorations ━━ */
+/* ━━ Holographic Decorations (linear-gradients + filters Tailwind can't ergonomically express) ━━ */
 
-/* Corner accent pieces */
-.settings-corner {
+@utility hud-corner {
   position: absolute;
   width: 12px;
   height: 12px;
@@ -83,7 +82,7 @@ body {
   animation: holo-corner-pulse 3s ease-in-out infinite;
 }
 
-.settings-corner--tl {
+@utility hud-corner--tl {
   top: -1px;
   left: -1px;
   border-top: 1.5px solid oklch(0.72 0.14 192 / 0.6);
@@ -91,7 +90,7 @@ body {
   filter: drop-shadow(0 0 3px oklch(0.72 0.14 192 / 0.3));
 }
 
-.settings-corner--tr {
+@utility hud-corner--tr {
   top: -1px;
   right: -1px;
   border-top: 1.5px solid oklch(0.65 0.18 285 / 0.4);
@@ -100,7 +99,7 @@ body {
   animation-delay: 0.75s;
 }
 
-.settings-corner--bl {
+@utility hud-corner--bl {
   bottom: -1px;
   left: -1px;
   border-bottom: 1.5px solid oklch(0.65 0.18 285 / 0.4);
@@ -109,7 +108,7 @@ body {
   animation-delay: 1.5s;
 }
 
-.settings-corner--br {
+@utility hud-corner--br {
   bottom: -1px;
   right: -1px;
   border-bottom: 1.5px solid oklch(0.7 0.16 350 / 0.4);
@@ -118,8 +117,7 @@ body {
   animation-delay: 2.25s;
 }
 
-/* Top edge highlight with sweep animation */
-.settings-highlight {
+@utility hud-highlight {
   position: absolute;
   top: 0;
   left: 0;
@@ -136,27 +134,26 @@ body {
   pointer-events: none;
   z-index: 10;
   border-radius: inherit;
+
+  &::after {
+    content: "";
+    position: absolute;
+    inset: 0;
+    background: linear-gradient(
+      90deg,
+      transparent 0%,
+      oklch(1 0 0 / 0.15) 45%,
+      oklch(1 0 0 / 0.25) 50%,
+      oklch(1 0 0 / 0.15) 55%,
+      transparent 100%
+    );
+    background-size: 200% 100%;
+    animation: holo-highlight-sweep 3s ease-in-out infinite;
+    animation-delay: 1s;
+  }
 }
 
-.settings-highlight::after {
-  content: "";
-  position: absolute;
-  inset: 0;
-  background: linear-gradient(
-    90deg,
-    transparent 0%,
-    oklch(1 0 0 / 0.15) 45%,
-    oklch(1 0 0 / 0.25) 50%,
-    oklch(1 0 0 / 0.15) 55%,
-    transparent 100%
-  );
-  background-size: 200% 100%;
-  animation: holo-highlight-sweep 3s ease-in-out infinite;
-  animation-delay: 1s;
-}
-
-/* Bottom edge subtle line */
-.settings-bottom-line {
+@utility hud-bottom-line {
   position: absolute;
   bottom: 0;
   left: 10%;
@@ -174,31 +171,30 @@ body {
   z-index: 10;
 }
 
-/* Slow scanline sweep */
-.settings-scanline {
+@utility hud-scanline {
   position: absolute;
   inset: 0;
   overflow: hidden;
   pointer-events: none;
   z-index: 6;
   border-radius: inherit;
-}
 
-.settings-scanline::after {
-  content: "";
-  position: absolute;
-  left: 0;
-  right: 0;
-  height: 40px;
-  background: linear-gradient(
-    180deg,
-    transparent,
-    oklch(0.72 0.14 192 / 0.03) 40%,
-    oklch(0.72 0.14 192 / 0.05) 50%,
-    oklch(0.72 0.14 192 / 0.03) 60%,
-    transparent
-  );
-  animation: holo-scanline 4s linear infinite;
+  &::after {
+    content: "";
+    position: absolute;
+    left: 0;
+    right: 0;
+    height: 40px;
+    background: linear-gradient(
+      180deg,
+      transparent,
+      oklch(0.72 0.14 192 / 0.03) 40%,
+      oklch(0.72 0.14 192 / 0.05) 50%,
+      oklch(0.72 0.14 192 / 0.03) 60%,
+      transparent
+    );
+    animation: holo-scanline 4s linear infinite;
+  }
 }
 
 /* ━━ Shared classes referenced from @persona/shared components ━━ */
@@ -569,15 +565,15 @@ body {
 /* ━━ Reduced Motion ━━ */
 
 @media (prefers-reduced-motion: reduce) {
-  .settings-scanline::after {
+  .hud-scanline::after {
     animation: none;
   }
 
-  .settings-highlight::after {
+  .hud-highlight::after {
     animation: none;
   }
 
-  .settings-corner {
+  .hud-corner {
     animation: none;
     opacity: 0.6;
   }

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -41,5 +41,6 @@ export * from './components/ui/toolbar';
 export * from './components/ui/tooltip';
 export { useClickOutside } from './hooks/use-click-outside';
 export { type UseNavigationStateResult, useNavigationState } from './hooks/use-navigation-state';
+export { cn, type SomeRequired } from './lib/utils';
 import './index.css';
 import './animation.css';


### PR DESCRIPTION
## Summary

PR #8 of the Tailwind utility-first migration. Migrates `mods/persona/ui/src/index.css` (825 lines, 78 semantic classes) to Tailwind `@utility` directives + utility chains. Depends on #169 (persona/shared) for full cleanup of unused `@utility` blocks.

## What's in this PR

- **CSS reduced 825 → 585 lines** (29% — less aggressive than other phases because many `@utility` blocks are retained as a defensive backward-compat layer for `@persona/shared` components on main).
- **28 `@utility` blocks** retained: 8 `hud-*` (decorations consumed by `<Decorations>`), 19 `settings-*` (still referenced by `@persona/shared` components on main), 1 `settings-slider` (vendor pseudo-elements). After #169 merges, the `settings-*` `@utility` blocks consumed by `@persona/shared` become dead code (cleanable in follow-up).
- **`<Decorations>` component** extracted with internal `<HudCorner>`, `<HudHighlight>`, `<HudBottomLine>`, `<HudScanline>`. All decoratives have `aria-hidden` + `pointer-events-none`.
- **Age-field tri-state segmented control** kept as `@utility` blocks because `[data-mode]` × `[data-state=checked]` × `:focus-within` × `:focus-visible` × vendor pseudo-elements (`::-webkit-inner-spin-button`) was cleaner as utilities than inline.
- **Module-level class constants** in `App.tsx` reduce JSX clutter and stabilize re-renders.
- **`cn` re-exported** from `packages/ui/src/index.ts` (idempotent across PR #2-#8).

## Per-PR checklist

- [x] No top-level `.classname` selectors remain in CSS (only `@utility` + `@media` + `@theme inline` + `@keyframes` + `@import`)
- [x] All references to deleted classes removed from JSX in `mods/persona/ui/src/`
- [x] No new `@apply` directives
- [x] No new static inline `style={{}}`
- [x] No new `.css` files
- [x] `pnpm --filter @hmcs/persona build` passes (726.61 kB)
- [x] `biome check` clean (141 files)
- [ ] Visual smoke-test: `make debug` → open Persona settings → verify panel + tabs + age field tri-state + sliders + buttons + state dots all render correctly

## Notes for reviewer

- 3 commits (consolidated from suggested 6-7 — the App.tsx structural classes are tightly coupled and splitting would force half-rendered intermediate states).
- After #169 merges, the `settings-section`, `settings-label`, `settings-input`, `settings-textarea`, `settings-vrma-fields`, `settings-behavior-hint` `@utility` blocks become unused (because PR #7 migrates `@persona/shared` to inline utilities). These can be cleaned up in a follow-up PR.
- `@import "@persona/shared/detail-body.css"` is preserved on this branch; PR #169 removes it. After PR #169 merges + this rebases, the import auto-resolves.
- The `@media (forced-colors: active)` block for the age field is retained — Tailwind variants don't fully cover this accessibility scenario.